### PR TITLE
[JBRes-8664] Fix handling of database migration locks

### DIFF
--- a/orchestrator/src/idegym/orchestrator/database/database.py
+++ b/orchestrator/src/idegym/orchestrator/database/database.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import asynccontextmanager
 from typing import Any, List, NamedTuple, Optional, Set, cast
 from uuid import UUID
@@ -61,7 +62,43 @@ async def init_db(db_url: str, config: SQLAlchemyConfig, clean_database: bool = 
 
     # Run database migrations
     logger.info("Running database migrations...")
-    await migration_manager.run_migrations()
+    ran_migrations = await migration_manager.run_migrations()
+
+    # If another process is running migrations, wait for them to complete
+    if not ran_migrations:
+        logger.info("Waiting for migrations to complete...")
+        max_wait_time = 300  # 5 minutes timeout
+        poll_interval = 1  # Check every second
+        elapsed = 0
+
+        # Get the expected migration version from Alembic
+        expected_version = migration_manager.get_expected_version()
+
+        while elapsed < max_wait_time:
+            await asyncio.sleep(poll_interval)
+            elapsed += poll_interval
+
+            # Check if migrations are complete by verifying the alembic_version table
+            try:
+                async with migration_manager.engine.begin() as conn:
+                    result = await conn.execute(text("SELECT version_num FROM alembic_version"))
+                    current_version = result.scalar_one_or_none()
+
+                    if current_version == expected_version:
+                        logger.info(f"Migrations completed successfully at version {current_version}")
+                        break
+                    elif elapsed % 10 == 0:  # Log every 10 seconds
+                        logger.info(
+                            f"Still waiting for migrations... (current: {current_version}, expected: {expected_version}, {elapsed}s elapsed)"
+                        )
+            except Exception:
+                # Alembic version table doesn't exist yet or other error, migrations still running
+                if elapsed % 10 == 0:  # Log every 10 seconds
+                    logger.info(f"Still waiting for migrations... ({elapsed}s elapsed)")
+                continue
+        else:
+            raise TimeoutError(f"Migrations did not complete within {max_wait_time} seconds")
+
     logger.info("Database migrations completed")
 
     # Note: We no longer create tables here as this will be handled by Alembic migrations

--- a/orchestrator/src/idegym/orchestrator/database/database.py
+++ b/orchestrator/src/idegym/orchestrator/database/database.py
@@ -69,35 +69,35 @@ async def init_db(db_url: str, config: SQLAlchemyConfig, clean_database: bool = 
         logger.info("Waiting for migrations to complete...")
         max_wait_time = 300  # 5 minutes timeout
         poll_interval = 1  # Check every second
-        elapsed = 0
 
         # Get the expected migration version from Alembic
         expected_version = migration_manager.get_expected_version()
+        loop = asyncio.get_running_loop()
+        start_time = loop.time()
 
-        while elapsed < max_wait_time:
-            await asyncio.sleep(poll_interval)
-            elapsed += poll_interval
+        async with asyncio.timeout(max_wait_time):
+            while True:
+                await asyncio.sleep(poll_interval)
+                elapsed = int(loop.time() - start_time)
 
-            # Check if migrations are complete by verifying the alembic_version table
-            try:
-                async with migration_manager.engine.begin() as conn:
-                    result = await conn.execute(text("SELECT version_num FROM alembic_version"))
-                    current_version = result.scalar_one_or_none()
+                # Check if migrations are complete by verifying the alembic_version table
+                try:
+                    async with migration_manager.engine.begin() as conn:
+                        result = await conn.execute(text("SELECT version_num FROM alembic_version"))
+                        current_version = result.scalar_one_or_none()
 
-                    if current_version == expected_version:
-                        logger.info(f"Migrations completed successfully at version {current_version}")
-                        break
-                    elif elapsed % 10 == 0:  # Log every 10 seconds
-                        logger.info(
-                            f"Still waiting for migrations... (current: {current_version}, expected: {expected_version}, {elapsed}s elapsed)"
-                        )
-            except Exception:
-                # Alembic version table doesn't exist yet or other error, migrations still running
-                if elapsed % 10 == 0:  # Log every 10 seconds
-                    logger.info(f"Still waiting for migrations... ({elapsed}s elapsed)")
-                continue
-        else:
-            raise TimeoutError(f"Migrations did not complete within {max_wait_time} seconds")
+                        if current_version == expected_version:
+                            logger.info(f"Migrations completed successfully at version {current_version}")
+                            break
+                        elif elapsed % 10 == 0:  # Log every 10 seconds
+                            logger.info(
+                                f"Still waiting for migrations... (current: {current_version}, expected: {expected_version}, {elapsed}s elapsed)"
+                            )
+                except Exception:
+                    # Alembic version table doesn't exist yet or other error, migrations still running
+                    if elapsed % 10 == 0:  # Log every 10 seconds
+                        logger.info(f"Still waiting for migrations... ({elapsed}s elapsed)")
+                    continue
 
     logger.info("Database migrations completed")
 

--- a/orchestrator/src/idegym/orchestrator/migration_manager.py
+++ b/orchestrator/src/idegym/orchestrator/migration_manager.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
+from alembic.script import ScriptDirectory
 from idegym.utils.logging import get_logger
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
@@ -96,3 +97,17 @@ class MigrationManager:
         except Exception as e:
             logger.exception(f"Alembic upgrade failed: {e}")
             raise RuntimeError(f"Database migration failed: {e}") from e
+
+    def get_expected_version(self) -> str:
+        """Get the expected migration version (latest head revision) from Alembic."""
+        try:
+            alembic_cfg = Config(self.alembic_ini_path)
+            script = ScriptDirectory.from_config(alembic_cfg)
+            # Get the head revision(s) - returns a tuple of head revisions
+            heads = script.get_heads()
+            if not heads:
+                raise ValueError("No migration heads found")
+            return heads[0] if heads else None
+        except Exception as e:
+            logger.exception(f"Failed to get expected migration version: {e}")
+            raise RuntimeError(f"Failed to get expected migration version: {e}") from e


### PR DESCRIPTION
This PR adds proper handling of migration locks. If migrations are started by one worker, other workers will wait until they are finished.


Resolves: JBRes-8664
