### PR TITLE
[JBRes-6154] Use secret reference for tracing credentials

### DIFF
--- a/orchestrator/kubernetes/orchestrator/deployment.yaml
+++ b/orchestrator/kubernetes/orchestrator/deployment.yaml
@@ -64,6 +64,18 @@ spec:
               value: orchestrator
             - name: IDEGYM_OTEL_TRACING_ENDPOINT
               value: "http://tempo:4318/v1/traces"
+            - name: IDEGYM_OTEL_TRACING_AUTH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: tracing
+                  key: username
+                  optional: true
+            - name: IDEGYM_OTEL_TRACING_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: tracing
+                  key: password
+                  optional: true
             - name: POSTGRES_HOST
               value: postgresql
             - name: POSTGRES_PORT

--- a/orchestrator/src/idegym/orchestrator/router/server.py
+++ b/orchestrator/src/idegym/orchestrator/router/server.py
@@ -239,11 +239,23 @@ async def _task_start_server(config: Config, request: StartServerRequest, async_
                 },
                 {
                     "name": "IDEGYM_OTEL_TRACING_AUTH_USERNAME",
-                    "value": otel_config.tracing.auth.username,
+                    "valueFrom": {
+                        "secretKeyRef": {
+                            "name": "tracing",
+                            "key": "username",
+                            "optional": True,
+                        }
+                    },
                 },
                 {
                     "name": "IDEGYM_OTEL_TRACING_AUTH_PASSWORD",
-                    "value": password.get_secret_value() if (password := otel_config.tracing.auth.password) else None,
+                    "valueFrom": {
+                        "secretKeyRef": {
+                            "name": "tracing",
+                            "key": "password",
+                            "optional": True,
+                        }
+                    },
                 },
                 {
                     "name": "IDEGYM_OTEL_TRACING_TIMEOUT",


### PR DESCRIPTION
Rather than propagating the secret in plain from orchestrator to environments, or doing convoluted things like passing the reference name like Claude suggested, I opted for a basic approach: since the service hosts already control the underlying monitoring stack, they then dictate which secrets are passed where for observability purposes. The secret name is fixed to `tracing` and must contain the `username` and `password` keys. The key here is to mark the secret as **`optional`**. In this way, the absence of the secret will just disable sending traces, instead of the deployment failing at startup.

Resolves: JBRes-6154
