### PR TITLE
[JBRes-9012] CI changes

### DIFF
--- a/.github/actions/build-packages/action.yml
+++ b/.github/actions/build-packages/action.yml
@@ -1,0 +1,8 @@
+name: "Build Python Packages"
+description: "Iteratively build all packages in the repository"
+runs:
+  using: "composite"
+  steps:
+    - name: Build packages
+      shell: bash
+      run: .github/scripts/build-packages.sh

--- a/.github/actions/prepare-docker-build/action.yml
+++ b/.github/actions/prepare-docker-build/action.yml
@@ -10,6 +10,9 @@ runs:
     - name: Prepare Repository
       uses: ./.github/actions/prepare-repository
 
+    - name: Remove Unwanted Software
+      uses: ./.github/actions/remove-unwanted-software
+
     - name: Install Docker
       uses: docker/setup-docker-action@v4
 

--- a/.github/actions/prepare-repository/action.yml
+++ b/.github/actions/prepare-repository/action.yml
@@ -3,9 +3,6 @@ description: "Set up common environment preparation steps for all jobs"
 runs:
   using: "composite"
   steps:
-    - name: Remove Unwanted Software
-      uses: ./.github/actions/remove-unwanted-software
-
     - name: Extract version from tag
       shell: bash
       run: |

--- a/.github/actions/prepare-repository/action.yml
+++ b/.github/actions/prepare-repository/action.yml
@@ -3,11 +3,6 @@ description: "Set up common environment preparation steps for all jobs"
 runs:
   using: "composite"
   steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-      with:
-        ref: ${{ github.ref_name }}
-
     - name: Remove Unwanted Software
       uses: ./.github/actions/remove-unwanted-software
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,16 @@ updates:
     cooldown:
       default-days: 7
     target-branch: main
+    groups:
+      astral:
+        patterns:
+          - "astral-sh/*"
+      core:
+        patterns:
+          - "actions/*"
+      docker:
+        patterns:
+          - "docker/*"
     commit-message:
       prefix: "[ci] "
     labels:
@@ -28,6 +38,17 @@ updates:
     cooldown:
       default-days: 7
     target-branch: main
+    groups:
+      database:
+        patterns:
+          - "postgres"
+      observability:
+        patterns:
+          - "grafana/*"
+          - "prom/*"
+      python:
+        patterns:
+          - "python"
     commit-message:
       prefix: "[orchestrator] "
     labels:
@@ -41,6 +62,14 @@ updates:
     cooldown:
       default-days: 7
     target-branch: main
+    groups:
+      opentelemetry:
+        patterns:
+          - "opentelemetry-*"
+      testing:
+        patterns:
+          - "pytest*"
+          - "testcontainers"
     commit-message:
       prefix: "[dependencies] "
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: weekly
       day: monday
       time: "09:00"
+    cooldown:
+      default-days: 7
     target-branch: main
     commit-message:
       prefix: "[ci] "
@@ -23,6 +25,8 @@ updates:
       interval: weekly
       day: monday
       time: "09:00"
+    cooldown:
+      default-days: 7
     target-branch: main
     commit-message:
       prefix: "[orchestrator] "
@@ -34,6 +38,8 @@ updates:
       interval: weekly
       day: monday
       time: "09:00"
+    cooldown:
+      default-days: 7
     target-branch: main
     commit-message:
       prefix: "[dependencies] "

--- a/.github/scripts/build-packages.sh
+++ b/.github/scripts/build-packages.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+exclude="idegym idegym-orchestrator idegym-server"
+
+for workspace in $(uv workspace list); do
+  echo "$exclude" | grep -qw "$workspace" && continue
+  uv build --package "$workspace"
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,52 +86,52 @@ jobs:
         env:
           IDEGYM_TEST_REGISTRY: ${{ matrix.registry }}
 
-#  e2e:
-#    name: Run e2e tests
-#    runs-on: ubuntu-latest-8-cores-x64
-#
-#    steps:
-#      - name: Checkout latest
-#        uses: actions/checkout@v6
-#
-#      - name: Start minikube
-#        uses: medyagh/setup-minikube@v0.0.21
-#        with:
-#          addons: gvisor,ingress,registry
-#          container-runtime: containerd
-#          kubernetes-version: v1.35.0
-#          start-args: --docker-opt containerd=/var/run/containerd/containerd.sock
-#
-#      - name: Configure hosts and wait for ingress controller to be ready
-#        run: |
-#          echo "127.0.0.1 idegym-local.test" | sudo tee -a /etc/hosts
-#          kubectl wait pod \
-#            --namespace=ingress-nginx \
-#            --for=condition=ready \
-#            --selector=app.kubernetes.io/component=controller \
-#            --timeout=120s
-#
-#      - name: Install uv
-#        uses: astral-sh/setup-uv@v7
-#        with:
-#          enable-cache: true
-#          cache-dependency-glob: "uv.lock"
-#
-#      - name: Set up Python
-#        run: uv python install
-#
-#      - name: Login to Docker registry
-#        uses: docker/login-action@v4
-#        with:
-#          registry: ghcr.io
-#          username: github-actions[bot]
-#          password: ${{ secrets.GITHUB_TOKEN }}
-#
-#      - name: Install dependencies
-#        run: uv sync --all-packages --all-extras --all-groups
-#
-#      - name: Run e2e tests
-#        run: |
-#          sudo -E kubectl port-forward -n ingress-nginx svc/ingress-nginx-controller 80:80 > /dev/null 2>&1 &
-#          sleep 5
-#          uv run pytest -m "e2e" -vv
+  e2e:
+    name: Run e2e tests
+    runs-on: Ubuntu-Latest-8-32-x64
+
+    steps:
+      - name: Checkout latest
+        uses: actions/checkout@v6
+
+      - name: Start minikube
+        uses: medyagh/setup-minikube@v0.0.21
+        with:
+          addons: gvisor,ingress,registry
+          container-runtime: containerd
+          kubernetes-version: v1.35.0
+          start-args: --docker-opt containerd=/var/run/containerd/containerd.sock
+
+      - name: Configure hosts and wait for ingress controller to be ready
+        run: |
+          echo "127.0.0.1 idegym-local.test" | sudo tee -a /etc/hosts
+          kubectl wait pod \
+            --namespace=ingress-nginx \
+            --for=condition=ready \
+            --selector=app.kubernetes.io/component=controller \
+            --timeout=120s
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Login to Docker registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: github-actions[bot]
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: uv sync --all-packages --all-extras --all-groups
+
+      - name: Run e2e tests
+        run: |
+          sudo -E kubectl port-forward -n ingress-nginx svc/ingress-nginx-controller 80:80 > /dev/null 2>&1 &
+          sleep 5
+          uv run pytest -m "e2e" -vv

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,4 +97,4 @@ jobs:
       - name: Build packages
         uses: ./.github/actions/build-packages
       - name: Publish packages
-        uses: pypa/gh-action-pypi-publish@release/v1
+        run: uv publish --trusted-publishing always

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,6 +95,6 @@ jobs:
       - name: Prepare Repository
         uses: ./.github/actions/prepare-repository
       - name: Build packages
-        run: uv build --all-packages
+        uses: ./.github/actions/build-packages
       - name: Publish packages
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/image-builder/src/idegym/image/__init__.py
+++ b/image-builder/src/idegym/image/__init__.py
@@ -11,8 +11,25 @@ Core types:
 Built-in plugins are in ``idegym.image.plugins`` and are auto-registered on import of this package.
 """
 
+from importlib.metadata import PackageNotFoundError, version
+
 from idegym.api.docker import BaseImage as Base
 from idegym.image.builder import Image
 from idegym.image.plugin import BuildContext, PluginBase, image_plugin
 
-__all__ = ("Base", "BuildContext", "Image", "PluginBase", "image_plugin")
+try:
+    __version__ = version("idegym-image-builder")
+except PackageNotFoundError:
+    __version__ = "0.0.0.dev0"
+
+if __version__ == "0.0.0.dev0":
+    __version__ = "latest"
+
+__all__ = (
+    "__version__",
+    "Base",
+    "BuildContext",
+    "Image",
+    "PluginBase",
+    "image_plugin",
+)


### PR DESCRIPTION
### Changelog

- Create composite action for building packages.
- Run `remove-unwanted-software` only in jobs that involve image builds.
- Switch to `uv publish` for pushing packages to PyPI.
- Add dependency groups and `cooldown` period for Dependabot.
- Fix double checkout issues in composite action.
- Add missing `__version__` constant to `idegym-image-builder` package.

Resolves: JBRes-5153 & JBRes-9012
