### PR TITLE
[JBRes-8864] Fix incomplete logging on orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Think of it as **GitHub Codespaces for RL training** — but designed for thousa
 - **Scalable orchestration** — spin up and tear down Kubernetes-based environments on demand
 - **Plugin-based image builder** — compose Docker images from reusable plugins via a Python API or YAML
 - **Flexible project loading** — clone from Git, download and extract a project archive, or mount a volume with a project directly into the image
-- **HTTP and WebSocket forwarding** — the orchestrator proxies requests directly to running server pods; WebSocket support enables integration with [OpenEnv](https://github.com/openenv)-compatible environments
+- **HTTP and WebSocket forwarding** — the orchestrator proxies requests directly to running server pods; WebSocket support enables integration with [OpenEnv](https://github.com/meta-pytorch/OpenEnv)-compatible environments
 - **Persistent request history** — every forwarded request and its response is stored in the database and retrievable later, enabling offline reward computation and reproducible evaluation
 - **Automatic resource cleanup** — a background watcher periodically reconciles the database against live Kubernetes state, evicting stale servers and reclaiming resources without manual intervention
 - **Full observability** — built-in Prometheus metrics, Grafana dashboards, and distributed tracing via Tempo

--- a/backend-utils/src/idegym/backend/utils/logging.py
+++ b/backend-utils/src/idegym/backend/utils/logging.py
@@ -39,6 +39,13 @@ JSONProcessors: list[Processor] = [
 ]
 
 
+def _create_formatter(renderer: Processor, processors: list[Processor]) -> ProcessorFormatter:
+    return ProcessorFormatter(
+        processor=renderer,
+        foreign_pre_chain=processors,
+    )
+
+
 def configure_logging(config: LoggingConfig = LoggingConfig()):
     renderer = JSONRenderer() if config.json_format else ConsoleRenderer()
     processors = JSONProcessors if config.json_format else ConsoleProcessors
@@ -54,7 +61,7 @@ def configure_logging(config: LoggingConfig = LoggingConfig()):
     root_logger.setLevel(config.level)
 
     console_handler = StreamHandler(stdout)
-    console_handler.setFormatter(ProcessorFormatter(processor=renderer))
+    console_handler.setFormatter(_create_formatter(renderer=renderer, processors=processors))
     root_logger.addHandler(console_handler)
 
     file_handler = RotatingFileHandler(
@@ -62,7 +69,7 @@ def configure_logging(config: LoggingConfig = LoggingConfig()):
         maxBytes=config.max_file_size.bytes,
         backupCount=config.max_file_count,
     )
-    file_handler.setFormatter(ProcessorFormatter(processor=renderer))
+    file_handler.setFormatter(_create_formatter(renderer=renderer, processors=processors))
     root_logger.addHandler(file_handler)
     get_named_logger(__name__).info(f"Logging to file: {config.file_path}")
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ with its own lock file lets uv resolve these dependencies independently.
 
 | Integration | Directory | Description |
 |-------------|-----------|-------------|
-| OpenEnv | [`openenv/`](openenv/README.md) | Run any [OpenEnv](https://github.com/facebookresearch/openenv)-compatible environment as a Kubernetes pod with WebSocket forwarding. Includes echo_env (smoke-test) and TBench2 (terminal benchmark). |
+| OpenEnv | [`openenv/`](openenv/README.md) | Run any [OpenEnv](https://github.com/meta-pytorch/OpenEnv)-compatible environment as a Kubernetes pod with WebSocket forwarding. Includes echo_env (smoke-test) and TBench2 (terminal benchmark). |
 
 ---
 

--- a/examples/openenv/README.md
+++ b/examples/openenv/README.md
@@ -1,6 +1,6 @@
 # OpenEnv Integration
 
-IdeGYM can run any [OpenEnv](https://github.com/facebookresearch/openenv)-compatible environment
+IdeGYM can run any [OpenEnv](https://github.com/meta-pytorch/OpenEnv)-compatible environment
 as a Kubernetes pod and proxy WebSocket connections to it. This directory contains two working
 examples.
 

--- a/orchestrator/src/idegym/orchestrator/main.py
+++ b/orchestrator/src/idegym/orchestrator/main.py
@@ -137,6 +137,8 @@ def create_app() -> FastAPI:
 def main() -> None:
     config = load_config()
     prepare_prometheus_multiprocess_dir(config)
+    if config.orchestrator.workers > 1:
+        configure_logging(config=config.logging)
 
     uvicorn.run(
         app="idegym.orchestrator.main:create_app",

--- a/orchestrator/src/idegym/orchestrator/main.py
+++ b/orchestrator/src/idegym/orchestrator/main.py
@@ -137,8 +137,7 @@ def create_app() -> FastAPI:
 def main() -> None:
     config = load_config()
     prepare_prometheus_multiprocess_dir(config)
-    if config.orchestrator.workers > 1:
-        configure_logging(config=config.logging)
+    configure_logging(config=config.logging)
 
     uvicorn.run(
         app="idegym.orchestrator.main:create_app",


### PR DESCRIPTION
- root handlers were formatting foreign stdlib records without the shared processors
- so logs were emitted, but fields like logger, level, timestamp, pid, and trace context were missing

Resolves: JBRes-8864

<!--
    Remember to include the full YouTrack ticket ID in the PR title,
    surrounded with square brackets and separated from the title with a single space.
-->
