### PR TITLE
[JBRes-9364] Helm UX improvements

### DIFF
--- a/charts/idegym/Chart.lock
+++ b/charts/idegym/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 12.3.0
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.6.2
+  version: 18.6.4
 - name: prometheus
   repository: oci://ghcr.io/prometheus-community/charts
-  version: 29.5.0
+  version: 29.6.0
 - name: tempo
   repository: oci://ghcr.io/grafana-community/helm-charts
   version: 2.1.0
-digest: sha256:5a3c8de3ddd7373cab99151438c3ffcd351698bf6d660732e782c62c63547ed1
-generated: "2026-05-11T23:05:28.482873+02:00"
+digest: sha256:10451797bb534348daddd3771ae52bacb444a4778700073204e29c60f17ab6a9
+generated: "2026-05-12T22:56:06.969202+02:00"

--- a/charts/idegym/Chart.yaml
+++ b/charts/idegym/Chart.yaml
@@ -5,18 +5,18 @@ version: 0.0.0
 appVersion: ""
 dependencies:
   - name: grafana
-    version: "12.3.0"
+    version: 12.3.0
     repository: oci://ghcr.io/grafana-community/helm-charts
     condition: grafana.enabled
   - name: postgresql
-    version: "18.6.2"
+    version: 18.6.4
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: prometheus
-    version: "29.5.0"
+    version: 29.6.0
     repository: oci://ghcr.io/prometheus-community/charts
     condition: prometheus.enabled
   - name: tempo
-    version: "2.1.0"
+    version: 2.1.0
     repository: oci://ghcr.io/grafana-community/helm-charts
     condition: tempo.enabled

--- a/charts/idegym/templates/deployment.yaml
+++ b/charts/idegym/templates/deployment.yaml
@@ -109,6 +109,12 @@ spec:
             - name: IDEGYM_POD_SNAPSHOT_SERVICE_ACCOUNT_NAME
               value: {{ include "idegym.podSnapshot.serviceAccountName" . | quote }}
             {{- end }}
+            - name: IDEGYM_NODE_POOL_ENABLED
+              value: "True"
+            - name: IDEGYM_NODE_POOL_TAINT_KEY
+              value: "jetbrains.com/idegym"
+            - name: IDEGYM_NODE_POOL_PREFERENCE_WEIGHT
+              value: "100"
             - name: POSTGRES_DB
               {{- if .Values.deployment.database.name }}
               {{- include "idegym.envSource" .Values.deployment.database.name | nindent 14 }}

--- a/charts/idegym/templates/deployment.yaml
+++ b/charts/idegym/templates/deployment.yaml
@@ -92,35 +92,45 @@ spec:
             - name: POSTGRES_DB
               {{- if .Values.deployment.database.name }}
               {{- include "idegym.envSource" .Values.deployment.database.name | nindent 14 }}
-              {{- else }}
+              {{- else if .Values.postgresql.enabled }}
               value: {{ include "idegym.subchart.postgresql.v1.database" . | quote }}
+              {{- else }}
+              {{- required "Database name must be specified!" .Values.deployment.database.name }}
               {{- end }}
             - name: POSTGRES_HOST
               {{- if .Values.deployment.database.host }}
               {{- include "idegym.envSource" .Values.deployment.database.host | nindent 14 }}
-              {{- else }}
+              {{- else if .Values.postgresql.enabled }}
               value: {{ include "idegym.subchart.postgresql.v1.primary.fullname" . | quote }}
+              {{- else }}
+              {{- required "Database host must be specified!" .Values.deployment.database.host }}
               {{- end }}
             - name: POSTGRES_PORT
               {{- if .Values.deployment.database.port }}
               {{- include "idegym.envSource" .Values.deployment.database.port | nindent 14 }}
-              {{- else }}
+              {{- else if .Values.postgresql.enabled }}
               value: {{ include "idegym.subchart.postgresql.v1.service.port" . | quote }}
+              {{- else }}
+              {{- required "Database port must be specified!" .Values.deployment.database.port }}
               {{- end }}
             - name: POSTGRES_USER
               {{- if .Values.deployment.database.username }}
               {{- include "idegym.envSource" .Values.deployment.database.username | nindent 14 }}
-              {{- else }}
+              {{- else if .Values.postgresql.enabled }}
               value: {{ include "idegym.subchart.postgresql.v1.username" . | quote }}
+              {{- else }}
+              {{- required "Database username must be specified!" .Values.deployment.database.username }}
               {{- end }}
             - name: POSTGRES_PASSWORD
               {{- if .Values.deployment.database.password }}
               {{- include "idegym.envSource" .Values.deployment.database.password | nindent 14 }}
-              {{- else }}
+              {{- else if .Values.postgresql.enabled }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "idegym.subchart.postgresql.v1.secretName" . | quote }}
                   key: {{ include "idegym.subchart.postgresql.v1.userPasswordKey" . | quote }}
+              {{- else }}
+              {{- required "Database password must be specified!" .Values.deployment.database.password }}
               {{- end }}
             {{- with .Values.deployment.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/charts/idegym/templates/deployment.yaml
+++ b/charts/idegym/templates/deployment.yaml
@@ -83,11 +83,25 @@ spec:
             {{- end }}
             - name: IDEGYM_UVICORN_WORKERS
               value: {{ .Values.deployment.uvicornWorkers | quote }}
-            {{- with .Values.deployment.sqlalchemy }}
+            {{- with .Values.deployment.sqlalchemy.pool }}
+            {{- if .size }}
             - name: IDEGYM_SQLALCHEMY_POOL_SIZE
-              value: {{ .poolSize | quote }}
+              value: {{ .size | quote }}
+            {{- end }}
+            {{- if .timeout }}
+            - name: IDEGYM_SQLALCHEMY_POOL_TIMEOUT
+              value: {{ .timeout | quote }}
+            {{- end }}
+            {{- if .recycle }}
+            - name: IDEGYM_SQLALCHEMY_POOL_RECYCLE
+              value: {{ .recycle | quote }}
+            {{- end }}
+            - name: IDEGYM_SQLALCHEMY_POOL_PRE_PING
+              value: {{ quote .prePing | title }}
+            {{- end }}
+            {{- if .Values.deployment.sqlalchemy.maxOverflow }}
             - name: IDEGYM_SQLALCHEMY_MAX_OVERFLOW
-              value: {{ .maxOverflow | quote }}
+              value: {{ .Values.deployment.sqlalchemy.maxOverflow | quote }}
             {{- end }}
             - name: POSTGRES_DB
               {{- if .Values.deployment.database.name }}

--- a/charts/idegym/templates/deployment.yaml
+++ b/charts/idegym/templates/deployment.yaml
@@ -103,6 +103,12 @@ spec:
             - name: IDEGYM_SQLALCHEMY_MAX_OVERFLOW
               value: {{ .Values.deployment.sqlalchemy.maxOverflow | quote }}
             {{- end }}
+            {{- if .Values.podSnapshot.enabled }}
+            - name: IDEGYM_POD_SNAPSHOT_ENABLED
+              value: "True"
+            - name: IDEGYM_POD_SNAPSHOT_SERVICE_ACCOUNT_NAME
+              value: {{ include "idegym.podSnapshot.serviceAccountName" . | quote }}
+            {{- end }}
             - name: POSTGRES_DB
               {{- if .Values.deployment.database.name }}
               {{- include "idegym.envSource" .Values.deployment.database.name | nindent 14 }}

--- a/charts/idegym/values.yaml
+++ b/charts/idegym/values.yaml
@@ -18,7 +18,13 @@ deployment:
     tracing: { }
   replicas: 4
   uvicornWorkers: 4
-  sqlalchemy: { }
+  sqlalchemy:
+    pool:
+      size: ""
+      timeout: ""
+      recycle: ""
+      prePing: true
+    maxOverflow: ""
   resources: { }
   securityContext: { }
   serviceAccount:

--- a/charts/idegym/values.yaml
+++ b/charts/idegym/values.yaml
@@ -6,11 +6,11 @@ deployment:
   imagePullSecrets: [ ]
   extraEnv: [ ]
   database:
-    name: ""
-    host: ""
-    port: ""
-    username: ""
-    password: ""
+    name:
+    host:
+    port:
+    username:
+    password:
   log:
     json: true
     level: info

--- a/charts/idegym/values.yaml
+++ b/charts/idegym/values.yaml
@@ -5,7 +5,12 @@ deployment:
     tag: ""
   imagePullSecrets: [ ]
   extraEnv: [ ]
-  database: { }
+  database:
+    name: ""
+    host: ""
+    port: ""
+    username: ""
+    password: ""
   log:
     json: true
     level: info

--- a/e2e-tests/config/values.yaml
+++ b/e2e-tests/config/values.yaml
@@ -9,8 +9,6 @@ deployment:
   extraEnv:
     - name: IDEGYM_CLEAN_DATABASE
       value: "True"
-    - name: IDEGYM_NODE_POOL_ENABLED
-      value: "True"
     - name: KANIKO_INSECURE_REGISTRY
       value: "true"
     - name: DOCKER_REGISTRY


### PR DESCRIPTION
Follow-up to the initial chart publication (#97). Surfaces overrides missing from the chart's value schema and fixes an ambiguous error path when the bundled PostgreSQL is disabled without overrides being provided.

- **Clearer error when `postgresql.enabled=false` with no overrides.** Previously, leaving `deployment.database.*` empty while disabling the bundled PostgreSQL produced a cryptic `no template "postgresql.v1.database"` chain from a failed subchart helper. Each field now uses `required` to fail fast with a clear error message.
- **Explicit `deployment.database` field stubs.** Replaced the opaque empty-map default (`database: {}`) with named empty-string fields (`name`, `host`, `port`, `username`, `password`). The functionality from before is retained, with the added benefit of the override schema being discoverable from IntelliJ autocompletion and from `values.yaml` inspections.
- **All `IDEGYM_SQLALCHEMY_*` overrides exposed.** The chart previously only supported `pool_size` and `max_overflow`. Added other values to match the full set from our configurations.
- **`IDEGYM_POD_SNAPSHOT_*` env vars wired up.** When `podSnapshot.enabled: true`, the orchestrator now receives `IDEGYM_POD_SNAPSHOT_ENABLED=True` and `IDEGYM_POD_SNAPSHOT_SERVICE_ACCOUNT_NAME`. While this is still configurable in the current chart with `deployment.extraEnv`, the need for this step is removed because we now automatically populate these based on values.
- **`IDEGYM_NODE_POOL_*` env vars hardcoded.** Injects `IDEGYM_NODE_POOL_ENABLED=True`, `IDEGYM_NODE_POOL_TAINT_KEY=jetbrains.com/idegym`, `IDEGYM_NODE_POOL_PREFERENCE_WEIGHT=100` to match the affinity/tolerations already defined in `values.yaml`.

Resolves: JBRes-8916

Closes #105
Closes #106
