### PR TITLE
[JBRes-9303] Clean Trigger's CRD after snapshotting, wait for snapshot being taken as async operation

### DIFF
--- a/api/src/idegym/api/config.py
+++ b/api/src/idegym/api/config.py
@@ -138,6 +138,14 @@ class PodSnapshotConfig(BaseModel):
     service_account_name: str = Field(
         description="Kubernetes service account shared by all snapshot-enabled pods", default="idegym"
     )
+    completion_timeout: Duration = Field(
+        description="Maximum time to wait for a PodSnapshotManualTrigger to reach a terminal status",
+        default=Duration(minutes=2),
+    )
+    poll_interval: Duration = Field(
+        description="Interval between PodSnapshotManualTrigger status polls",
+        default=Duration(seconds=2),
+    )
 
 
 class WatcherConfig(BaseModel):

--- a/api/src/idegym/api/orchestrator/snapshots.py
+++ b/api/src/idegym/api/orchestrator/snapshots.py
@@ -5,10 +5,24 @@ from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
 
+class OwnerReference(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    api_version: str
+    kind: str
+    name: str
+    uid: str
+    controller: bool = False
+    block_owner_deletion: bool = False
+
+
 class PodSnapshotManualTriggerMetadata(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     name: str
     namespace: str
     labels: dict[str, str]
+    owner_references: list[OwnerReference] = Field(default_factory=list)
 
 
 class PodSnapshotManualTriggerSpec(BaseModel):

--- a/api/src/idegym/api/orchestrator/snapshots.py
+++ b/api/src/idegym/api/orchestrator/snapshots.py
@@ -13,7 +13,8 @@ class CreateSnapshotRequest(BaseModel):
 class CreateSnapshotResponse(BaseModel):
     server_id: int = Field(description="ID of the server that was snapshotted")
     server_name: str = Field(description="Logical server name used as the Kubernetes resource name")
-    trigger_name: str = Field(
-        description="Name of the PodSnapshotManualTrigger resource created to initiate the snapshot"
+    snapshot_id: Optional[str] = Field(
+        default=None,
+        description="ID of the taken snapshot. By implementation, equals the snapshot_id / name of the snapshotted pod.",
     )
     operation_id: Optional[int] = Field(default=None, description="Async operation ID to poll for snapshot status")

--- a/orchestrator/src/idegym/orchestrator/pod_snapshot.py
+++ b/orchestrator/src/idegym/orchestrator/pod_snapshot.py
@@ -1,24 +1,38 @@
+import asyncio
+import time
+from http import HTTPStatus
+from typing import Any
+
 from idegym.api.config import PodSnapshotConfig
-from idegym.backend.utils.kubernetes_client import async_kube_api
+from idegym.backend.utils.kubernetes_client import ApiException, async_kube_api
 from idegym.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
 CRD_GROUP = "podsnapshot.gke.io"
 CRD_VERSION = "v1"
+CRD_PLURAL = "podsnapshotmanualtriggers"
+
+
+class SnapshotFailedError(RuntimeError):
+    """Raised when the PodSnapshotManualTrigger reports a non-successful terminal status."""
+
+
+class SnapshotTimeoutError(RuntimeError):
+    """Raised when the PodSnapshotManualTrigger does not reach a terminal status within the configured timeout."""
 
 
 class PodSnapshotService:
     """
-    Triggers pod snapshots via PodSnapshotManualTrigger CRD.
+    Drives the full lifecycle of a manual pod snapshot: create the trigger, wait for completion, delete the trigger.
     """
 
     def __init__(self, config: PodSnapshotConfig, namespace: str):
         self._config = config
         self._namespace = namespace
 
-    async def get_pod_name_for_server(self, server_name: str) -> str:
-        """Resolve the running pod name for a server via label selector."""
+    async def get_pod_for_server(self, server_name: str) -> tuple[str, str]:
+        """Resolve (pod_name, pod_uid) for the running pod backing the given server."""
         async with async_kube_api() as (_, _, core, _, _):
             pods = (
                 await core.list_namespaced_pod(
@@ -34,12 +48,12 @@ class PodSnapshotService:
         if not running_pods:
             raise RuntimeError(f"No running pod found for server '{server_name}' in namespace '{self._namespace}'")
 
-        pod_name = running_pods[0].metadata.name
-        logger.debug(f"Resolved pod name '{pod_name}' for server '{server_name}'")
-        return pod_name
+        md = running_pods[0].metadata
+        logger.debug(f"Resolved pod '{md.name}' (uid={md.uid}) for server '{server_name}'")
+        return md.name, md.uid
 
-    async def create_trigger(self, server_name: str, pod_name: str) -> str:
-        """Create a PodSnapshotManualTrigger targeting the given pod."""
+    async def create_trigger(self, server_name: str, pod_name: str, pod_uid: str) -> str:
+        """Create a PodSnapshotManualTrigger targeting the given pod, owned by it for GC safety."""
         trigger_name = f"snapshot-{pod_name}"
 
         body = {
@@ -48,13 +62,19 @@ class PodSnapshotService:
             "metadata": {
                 "name": trigger_name,
                 "namespace": self._namespace,
-                "labels": {
-                    "app": server_name,
-                },
+                "labels": {"app": server_name},
+                "ownerReferences": [
+                    {
+                        "apiVersion": "v1",
+                        "kind": "Pod",
+                        "name": pod_name,
+                        "uid": pod_uid,
+                        "controller": False,
+                        "blockOwnerDeletion": False,
+                    }
+                ],
             },
-            "spec": {
-                "targetPod": pod_name,
-            },
+            "spec": {"targetPod": pod_name},
         }
 
         async with async_kube_api() as (_, _, _, _, custom):
@@ -62,15 +82,88 @@ class PodSnapshotService:
                 group=CRD_GROUP,
                 version=CRD_VERSION,
                 namespace=self._namespace,
-                plural="podsnapshotmanualtriggers",
+                plural=CRD_PLURAL,
                 body=body,
             )
         logger.info(f"Created PodSnapshotManualTrigger '{trigger_name}' in namespace '{self._namespace}'")
         return trigger_name
 
-    async def snapshot_server(self, server_name: str) -> str:
-        """Resolve the running pod for a server and create a manual snapshot trigger."""
-        pod_name = await self.get_pod_name_for_server(server_name)
-        trigger_name = await self.create_trigger(server_name=server_name, pod_name=pod_name)
-        logger.info(f"Snapshot initiated for server '{server_name}' via trigger '{trigger_name}'")
-        return trigger_name
+    async def wait_for_completion(self, trigger_name: str) -> None:
+        """
+        Poll the trigger until its `Triggered` condition becomes True (success) or False (failure).
+
+        Raises SnapshotFailedError on terminal failure, or SnapshotTimeoutError if the configured
+        timeout elapses first.
+        """
+        timeout = self._config.completion_timeout.total_seconds()
+        poll_interval = self._config.poll_interval.total_seconds()
+        deadline = time.monotonic() + timeout
+
+        while True:
+            async with async_kube_api() as (_, _, _, _, custom):
+                obj = await custom.get_namespaced_custom_object(
+                    group=CRD_GROUP,
+                    version=CRD_VERSION,
+                    namespace=self._namespace,
+                    plural=CRD_PLURAL,
+                    name=trigger_name,
+                )
+
+            condition = self._triggered_condition(obj)
+            if condition:
+                status = condition.get("status")
+                if status == "True":
+                    internal_name = ((obj.get("status") or {}).get("snapshotCreated") or {}).get("name") or ""
+                    logger.info(
+                        f"PodSnapshotManualTrigger '{trigger_name}' completed, snapshot name: '{internal_name}'"
+                    )
+                    return
+                if status == "False":
+                    message = condition.get("message") or condition.get("reason") or "unknown reason"
+                    raise SnapshotFailedError(f"PodSnapshotManualTrigger '{trigger_name}' failed: {message}")
+
+            if time.monotonic() >= deadline:
+                raise SnapshotTimeoutError(
+                    f"PodSnapshotManualTrigger '{trigger_name}' did not complete within {timeout:.0f}s"
+                )
+
+            await asyncio.sleep(poll_interval)
+
+    async def delete_trigger(self, trigger_name: str) -> None:
+        try:
+            async with async_kube_api() as (_, _, _, _, custom):
+                await custom.delete_namespaced_custom_object(
+                    group=CRD_GROUP,
+                    version=CRD_VERSION,
+                    namespace=self._namespace,
+                    plural=CRD_PLURAL,
+                    name=trigger_name,
+                )
+            logger.info(f"Deleted PodSnapshotManualTrigger '{trigger_name}'")
+        except ApiException as ex:
+            if ex.status == HTTPStatus.NOT_FOUND:
+                logger.debug(f"PodSnapshotManualTrigger '{trigger_name}' already gone")
+                return
+            raise
+
+    async def snapshot_server(self, server_name: str) -> None:
+        """
+        End-to-end snapshot flow: resolve pod, create trigger, wait for completion, delete trigger.
+        """
+        pod_name, pod_uid = await self.get_pod_for_server(server_name)
+        trigger_name = await self.create_trigger(server_name=server_name, pod_name=pod_name, pod_uid=pod_uid)
+        try:
+            await self.wait_for_completion(trigger_name)
+        finally:
+            try:
+                await self.delete_trigger(trigger_name)
+            except Exception:
+                logger.exception(f"Failed to delete PodSnapshotManualTrigger '{trigger_name}'")
+
+    @staticmethod
+    def _triggered_condition(obj: dict[str, Any]) -> dict[str, Any] | None:
+        """Return the `Triggered` condition from the trigger's status, or None if not yet emitted."""
+        for cond in (obj.get("status") or {}).get("conditions") or []:
+            if cond.get("type") == "Triggered":
+                return cond
+        return None

--- a/orchestrator/src/idegym/orchestrator/pod_snapshot.py
+++ b/orchestrator/src/idegym/orchestrator/pod_snapshot.py
@@ -1,13 +1,12 @@
 import asyncio
 import time
 from http import HTTPStatus
-from typing import Any
-
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import HTTPException, status
 from idegym.api.config import PodSnapshotConfig
 from idegym.api.orchestrator.snapshots import (
+    OwnerReference,
     PodSnapshotManualTrigger,
     PodSnapshotManualTriggerMetadata,
     PodSnapshotManualTriggerSpec,
@@ -45,7 +44,6 @@ class PodSnapshotService:
         self._namespace = namespace
 
     async def get_pod_for_server(self, server_name: str) -> tuple[str, str, str]:
-        """Resolve (pod_name, pod_uid) for the running pod backing the given server."""
         async with async_kube_api() as (_, _, core, _, _):
             pods = (
                 await core.list_namespaced_pod(
@@ -65,11 +63,12 @@ class PodSnapshotService:
         pod_name = pod.metadata.name
         pod_uid = pod.metadata.uid
         node_name = pod.spec.node_name
-        logger.debug(f"Resolved pod name '{pod_name}' with uid '{pod_uid}' on node '{node_name}' for server '{server_name}'")
+        logger.debug(
+            f"Resolved pod name '{pod_name}' with uid '{pod_uid}' on node '{node_name}' for server '{server_name}'"
+        )
         return pod_name, pod_uid, node_name
 
     async def validate_node_eligible_for_snapshot(self, node_name: Optional[str]) -> None:
-        """Raise if the node's GCP instance type does not support pod snapshots (e.g., E2 instances)."""
         if not node_name:
             logger.debug("No node name available; skipping E2 instance type check")
             return
@@ -90,29 +89,8 @@ class PodSnapshotService:
             )
 
     async def create_trigger(self, server_name: str, pod_name: str, pod_uid: str) -> str:
-        """Create a PodSnapshotManualTrigger targeting the given pod, owned by it for GC safety."""
         trigger_name = f"snapshot-{pod_name}"
 
-        body = {
-            "apiVersion": f"{CRD_GROUP}/{CRD_VERSION}",
-            "kind": "PodSnapshotManualTrigger",
-            "metadata": {
-                "name": trigger_name,
-                "namespace": self._namespace,
-                "labels": {"app": server_name},
-                "ownerReferences": [
-                    {
-                        "apiVersion": "v1",
-                        "kind": "Pod",
-                        "name": pod_name,
-                        "uid": pod_uid,
-                        "controller": False,
-                        "blockOwnerDeletion": False,
-                    }
-                ],
-            },
-            "spec": {"targetPod": pod_name},
-        }
         trigger = PodSnapshotManualTrigger(
             api_version=f"{CRD_GROUP}/{CRD_VERSION}",
             kind="PodSnapshotManualTrigger",
@@ -120,6 +98,14 @@ class PodSnapshotService:
                 name=trigger_name,
                 namespace=self._namespace,
                 labels={"app": server_name},
+                owner_references=[
+                    OwnerReference(
+                        api_version="v1",
+                        kind="Pod",
+                        name=pod_name,
+                        uid=pod_uid,
+                    )
+                ],
             ),
             spec=PodSnapshotManualTriggerSpec(target_pod=pod_name),
         )
@@ -135,21 +121,7 @@ class PodSnapshotService:
         logger.info(f"Created PodSnapshotManualTrigger '{trigger_name}' in namespace '{self._namespace}'")
         return trigger_name
 
-    async def snapshot_server(self, server_name: str) -> str:
-        """Resolve the running pod for a server, validate eligibility, and create a snapshot trigger."""
-        pod_name, node_name = await self.get_pod_name_for_server(server_name)
-        await self.validate_node_eligible_for_snapshot(node_name)
-        trigger_name = await self.create_trigger(server_name=server_name, pod_name=pod_name)
-        logger.info(f"Snapshot initiated for server '{server_name}' via trigger '{trigger_name}'")
-        return trigger_name
-
     async def wait_for_completion(self, trigger_name: str) -> None:
-        """
-        Poll the trigger until its `Triggered` condition becomes True (success) or False (failure).
-
-        Raises SnapshotFailedError on terminal failure, or SnapshotTimeoutError if the configured
-        timeout elapses first.
-        """
         timeout = self._config.completion_timeout.total_seconds()
         poll_interval = self._config.poll_interval.total_seconds()
         deadline = time.monotonic() + timeout
@@ -166,14 +138,14 @@ class PodSnapshotService:
 
             condition = self._triggered_condition(obj)
             if condition:
-                status = condition.get("status")
-                if status == "True":
+                triggered = condition.get("status") == "True"
+                if triggered:
                     internal_name = ((obj.get("status") or {}).get("snapshotCreated") or {}).get("name") or ""
                     logger.info(
                         f"PodSnapshotManualTrigger '{trigger_name}' completed, snapshot name: '{internal_name}'"
                     )
                     return
-                if status == "False":
+                else:
                     message = condition.get("message") or condition.get("reason") or "unknown reason"
                     raise SnapshotFailedError(f"PodSnapshotManualTrigger '{trigger_name}' failed: {message}")
 
@@ -202,10 +174,8 @@ class PodSnapshotService:
             raise
 
     async def snapshot_server(self, server_name: str) -> None:
-        """
-        End-to-end snapshot flow: resolve pod, create trigger, wait for completion, delete trigger.
-        """
-        pod_name, pod_uid = await self.get_pod_for_server(server_name)
+        pod_name, pod_uid, node_name = await self.get_pod_for_server(server_name)
+        await self.validate_node_eligible_for_snapshot(node_name)
         trigger_name = await self.create_trigger(server_name=server_name, pod_name=pod_name, pod_uid=pod_uid)
         try:
             await self.wait_for_completion(trigger_name)
@@ -217,7 +187,6 @@ class PodSnapshotService:
 
     @staticmethod
     def _triggered_condition(obj: dict[str, Any]) -> dict[str, Any] | None:
-        """Return the `Triggered` condition from the trigger's status, or None if not yet emitted."""
         for cond in (obj.get("status") or {}).get("conditions") or []:
             if cond.get("type") == "Triggered":
                 return cond

--- a/orchestrator/src/idegym/orchestrator/router/snapshot.py
+++ b/orchestrator/src/idegym/orchestrator/router/snapshot.py
@@ -56,7 +56,6 @@ async def create_snapshot(request: CreateSnapshotRequest, low_level_request: Req
     return CreateSnapshotResponse(
         server_id=server.id,
         server_name=server.generated_name,
-        trigger_name="",
         operation_id=async_operation_id,
     )
 
@@ -79,7 +78,7 @@ async def _task_create_snapshot(
             config=config.orchestrator.pod_snapshot,
             namespace=namespace,
         )
-        trigger_name = await service.snapshot_server(server_name=server_generated_name)
+        await service.snapshot_server(server_name=server_generated_name)
 
         await update_operation_status(
             async_operation_id=async_operation_id,
@@ -87,15 +86,12 @@ async def _task_create_snapshot(
             result=CreateSnapshotResponse(
                 server_id=server_id,
                 server_name=server_generated_name,
-                trigger_name=trigger_name,
+                snapshot_id=server_generated_name,
                 operation_id=async_operation_id,
             ),
         )
 
-        logger.info(
-            f"Snapshot operation {async_operation_id} succeeded for server {server_generated_name} "
-            f"(trigger: {trigger_name})"
-        )
+        logger.info(f"Snapshot operation {async_operation_id} succeeded for server {server_generated_name}")
 
     except asyncio.CancelledError:
         logger.warning(f"Snapshot task cancelled for server {server_generated_name}, operation ID {async_operation_id}")


### PR DESCRIPTION
<!--
    Add your PR description here.
    Describe how and what was changed, as well as why the change was made.
    Although this section is optional, please consider adding a summary for the reviewers.
-->

Resolves: JBRes-9303

<!--
    Remember to include the full YouTrack ticket ID in the PR title,
    surrounded with square brackets and separated from the title with a single space.
-->

In this PR I suggest an updated behaviour for snapshotting. 
- add OwnerReference to the Trigger to delete it along with the owner pod. 
- wait for the snapshot completion before finishing the async operation. 




Example schema for PodSnapshotTrigger:

```
{
    "apiVersion": "podsnapshot.gke.io/v1",
    "kind": "PodSnapshotManualTrigger",
    "metadata": {
        "creationTimestamp": "2026-05-20T16:43:30Z",
        "generation": 1,
        "labels": {
            "app": "n4-example-server-37",
            "podsnapshot.gke.io/targetNode": "..."
        },
        "name": "snapshot-n4-example-server-37-7dc4dcb845-klmgv",
        "namespace": "idegym",
        "resourceVersion": "...",
        "uid": "..."
    },
    "spec": {
        "targetPod": "n4-example-server-37-7dc4dcb845-klmgv"
    },
    "status": {
        "conditions": [
            {
                "lastTransitionTime": "2026-05-20T16:43:30Z",
                "message": "checkpoint completed successfully",
                "reason": "Complete",
                "status": "True",
                "type": "Triggered"
            }
        ],
        "observedGeneration": 1,
        "snapshotCreated": {
            "name": "1cc51416-...-...-..."
        }
    }
}

```