### PR TITLE
[JBRes-9795] Fix mcp-steroid version regex and IDE start-script naming

### DIFF
--- a/documentation/mcp.md
+++ b/documentation/mcp.md
@@ -314,6 +314,6 @@ When `mcp_steroid=True`:
 - `get_mcp_upstream()` advertises port 6315 instead of 64342
 - If `open_project=False` (or no `Project` plugin in the pipeline), the IDE starts without a
   project — agents can open one at runtime via the `steroid_open_project` tool
-- The plugin version can be pinned with `mcp_steroid_version` (format: `X.Y.Z` or `X.Y.Z-HASH`)
+- The plugin version can be pinned with `mcp_steroid_version` (format: `X.Y` or `X.Y.Z`, optionally with a `-HASH` suffix — e.g. `0.94.0-8682a5ce` or `0.100-409f23a2`)
 
 See [Tools Reference](tools.md#mcp-steroid-tools) for the full list of mcp-steroid tools and resources.

--- a/integration-tests/docker_tests/test_pycharm_plugin.py
+++ b/integration-tests/docker_tests/test_pycharm_plugin.py
@@ -72,7 +72,7 @@ def test_pycharm_image_contains_pycharm_and_project():
         [
             "bash",
             "-c",
-            "test -x /opt/pycharm/bin/pycharm.sh && test -x /usr/local/bin/start-pycharm.sh && test -f /test-project/hello.py && echo OK",
+            "test -x /opt/pycharm/bin/pycharm.sh && test -x /usr/local/bin/start-pycharm && test -f /test-project/hello.py && echo OK",
         ],
         remove=True,
     )

--- a/plugins/idea/README.md
+++ b/plugins/idea/README.md
@@ -21,7 +21,8 @@ When added to an IdeGYM image pipeline, the `Idea` plugin:
 5. Optionally installs the **open-project** plugin and registers a supervisord
    service that opens the project directory on container start.
 
-At runtime supervisord calls `start-idea.sh`, which:
+At runtime supervisord calls the `start-idea.sh` script (installed as
+`/usr/local/bin/start-idea`), which:
 
 1. Exports `JAVA_TOOL_OPTIONS="-Djava.awt.headless=true"` so the JVM reads the flag
    before any application code runs — IDEA supports true headless mode and

--- a/plugins/idea/scripts/start-idea.sh
+++ b/plugins/idea/scripts/start-idea.sh
@@ -112,7 +112,13 @@ trap cleanup EXIT INT TERM
 
 # ── Wait for MCP endpoint ─────────────────────────────────────────────────────
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/check-mcp.sh"
+# Installed as a bare command (/usr/local/bin/check-mcp) inside IdeGYM images;
+# fall back to the .sh name when running from the source tree.
+if [ -f "${SCRIPT_DIR}/check-mcp" ]; then
+    source "${SCRIPT_DIR}/check-mcp"
+else
+    source "${SCRIPT_DIR}/check-mcp.sh"
+fi
 
 echo "Waiting for MCP endpoint (timeout: ${WAIT_SECONDS}s)..."
 for i in $(seq 1 "${WAIT_SECONDS}"); do

--- a/plugins/idea/scripts/supervisord-idea.conf
+++ b/plugins/idea/scripts/supervisord-idea.conf
@@ -1,5 +1,5 @@
 [program:idea]
-command=/usr/local/bin/start-idea.sh
+command=/usr/local/bin/start-idea
 priority=10
 autostart=true
 autorestart=false

--- a/plugins/idea/src/idegym/plugins/idea/image.py
+++ b/plugins/idea/src/idegym/plugins/idea/image.py
@@ -8,7 +8,7 @@ from jinja2 import BaseLoader, Environment
 from pydantic import field_validator
 
 _IDEA_VERSION_RE = re.compile(r"^\d{4}\.\d+(\.\d+)?$")
-_MCP_STEROID_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(-[a-f0-9]+)?$")
+_MCP_STEROID_VERSION_RE = re.compile(r"^\d+\.\d+(\.\d+)?(-[a-f0-9]+)?$")
 
 _MCP_PORT = 64342
 _BRIDGE_PORT = 64343
@@ -72,9 +72,9 @@ class Idea(PluginBase):
         mcp_steroid: Download and install the mcp-steroid plugin at build time.
             When ``True`` and ``open_project`` resolves to ``False``, the IDE starts
             without a project and agents can open one via the ``open-project`` MCP tool.
-        mcp_steroid_version: mcp-steroid version to install. Format: ``X.Y.Z`` or
-            ``X.Y.Z-HASH`` (e.g. ``0.94.0-8682a5ce``). Defaults to the latest tested
-            version.
+        mcp_steroid_version: mcp-steroid version to install. Format: ``X.Y`` or
+            ``X.Y.Z``, optionally with a ``-HASH`` suffix (e.g. ``0.94.0-8682a5ce`` or
+            ``0.100-409f23a2``). Defaults to the latest tested version.
         user: User to switch back to after installation. Defaults to ``ctx.current_user``.
     """
 
@@ -95,7 +95,9 @@ class Idea(PluginBase):
     @classmethod
     def _validate_mcp_steroid_version(cls, v: str) -> str:
         if not _MCP_STEROID_VERSION_RE.match(v):
-            raise ValueError(f"Invalid mcp-steroid version: {v!r}. Expected format: X.Y.Z or X.Y.Z-HASH")
+            raise ValueError(
+                f"Invalid mcp-steroid version: {v!r}. Expected format: X.Y or X.Y.Z, optionally with a -HASH suffix"
+            )
         return v
 
     @field_validator("user")

--- a/plugins/idea/src/idegym/plugins/idea/resources/Dockerfile.mcp_steroid_start.j2
+++ b/plugins/idea/src/idegym/plugins/idea/resources/Dockerfile.mcp_steroid_start.j2
@@ -1,11 +1,13 @@
 # Configure IDEA to start without a project and wait for mcp-steroid.
 # Agents can open any project at runtime via the mcp-steroid MCP tools.
 #
-# MCP_STEROID=true switches start-idea.sh to mcp-steroid mode: no project arg,
+# MCP_STEROID=true switches start-idea to mcp-steroid mode: no project arg,
 # waits for mcp-steroid on {{ mcp_steroid_port }}, then bridges
 # 0.0.0.0:{{ mcp_steroid_bridge_port }} -> 127.0.0.1:{{ mcp_steroid_port }} via socat.
+# Scripts are installed without the .sh suffix so their names survive
+# IdeGYMServer's /usr/local/bin/*.{py,sh} → bare-command rename pass.
 ENV MCP_STEROID=true
-COPY plugins/idea/scripts/check-mcp.sh /usr/local/bin/check-mcp.sh
-COPY plugins/idea/scripts/start-idea.sh /usr/local/bin/start-idea.sh
-RUN chmod +x /usr/local/bin/check-mcp.sh /usr/local/bin/start-idea.sh
+COPY plugins/idea/scripts/check-mcp.sh /usr/local/bin/check-mcp
+COPY plugins/idea/scripts/start-idea.sh /usr/local/bin/start-idea
+RUN chmod +x /usr/local/bin/check-mcp /usr/local/bin/start-idea
 COPY plugins/idea/scripts/supervisord-idea.conf /etc/supervisor/conf.d/idea.conf

--- a/plugins/idea/src/idegym/plugins/idea/resources/Dockerfile.open_project.j2
+++ b/plugins/idea/src/idegym/plugins/idea/resources/Dockerfile.open_project.j2
@@ -34,10 +34,13 @@ RUN set -eux; \
         '  </component>' \
         '</application>' > "{{ config_dir }}/options/privacyPolicy.xml"
 
-# start-idea.sh: launches IDEA headless, waits for MCP on {{ mcp_port }},
+# start-idea: launches IDEA headless, waits for MCP on {{ mcp_port }},
 # then bridges 0.0.0.0:{{ bridge_port }} → 127.0.0.1:{{ mcp_port }} via socat.
-# check-mcp.sh: script for checking MCP endpoint availability.
-COPY plugins/idea/scripts/check-mcp.sh /usr/local/bin/check-mcp.sh
-COPY plugins/idea/scripts/start-idea.sh /usr/local/bin/start-idea.sh
-RUN chmod +x /usr/local/bin/check-mcp.sh /usr/local/bin/start-idea.sh
+# check-mcp: script for checking MCP endpoint availability.
+# Installed without the .sh suffix so the names survive IdeGYMServer's
+# /usr/local/bin/*.{py,sh} → bare-command rename pass (which would otherwise
+# strip the suffix and break the supervisord command / internal source below).
+COPY plugins/idea/scripts/check-mcp.sh /usr/local/bin/check-mcp
+COPY plugins/idea/scripts/start-idea.sh /usr/local/bin/start-idea
+RUN chmod +x /usr/local/bin/check-mcp /usr/local/bin/start-idea
 COPY plugins/idea/scripts/supervisord-idea.conf /etc/supervisor/conf.d/idea.conf

--- a/plugins/pycharm/README.md
+++ b/plugins/pycharm/README.md
@@ -19,7 +19,8 @@ When added to an IdeGYM image pipeline, the `PyCharm` plugin:
 4. Optionally installs the **open-project** plugin and registers a supervisord
    service that opens the project directory on container start.
 
-At runtime supervisord calls `start-pycharm.sh`, which:
+At runtime supervisord calls the `start-pycharm.sh` script (installed as
+`/usr/local/bin/start-pycharm`), which:
 
 1. Starts **Xvfb** on `:99` — PyCharm requires a display; `java.awt.headless=true`
    is not supported.

--- a/plugins/pycharm/scripts/start-pycharm.sh
+++ b/plugins/pycharm/scripts/start-pycharm.sh
@@ -123,7 +123,13 @@ trap cleanup EXIT INT TERM
 
 # ── Wait for MCP endpoint ─────────────────────────────────────────────────────
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/check-mcp.sh"
+# Installed as a bare command (/usr/local/bin/check-mcp) inside IdeGYM images;
+# fall back to the .sh name when running from the source tree.
+if [ -f "${SCRIPT_DIR}/check-mcp" ]; then
+    source "${SCRIPT_DIR}/check-mcp"
+else
+    source "${SCRIPT_DIR}/check-mcp.sh"
+fi
 
 echo "Waiting for MCP endpoint (timeout: ${WAIT_SECONDS}s)..."
 for i in $(seq 1 "${WAIT_SECONDS}"); do

--- a/plugins/pycharm/scripts/supervisord-pycharm.conf
+++ b/plugins/pycharm/scripts/supervisord-pycharm.conf
@@ -1,5 +1,5 @@
 [program:pycharm]
-command=/usr/local/bin/start-pycharm.sh
+command=/usr/local/bin/start-pycharm
 priority=10
 autostart=true
 autorestart=false

--- a/plugins/pycharm/src/idegym/plugins/pycharm/image.py
+++ b/plugins/pycharm/src/idegym/plugins/pycharm/image.py
@@ -8,7 +8,7 @@ from jinja2 import BaseLoader, Environment
 from pydantic import field_validator
 
 _PYCHARM_VERSION_RE = re.compile(r"^\d{4}\.\d+(\.\d+)?$")
-_MCP_STEROID_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(-[a-f0-9]+)?$")
+_MCP_STEROID_VERSION_RE = re.compile(r"^\d+\.\d+(\.\d+)?(-[a-f0-9]+)?$")
 
 _MCP_PORT = 64342
 _BRIDGE_PORT = 64343
@@ -75,9 +75,9 @@ class PyCharm(PluginBase):
         mcp_steroid: Download and install the mcp-steroid plugin at build time.
             When ``True`` and ``open_project`` resolves to ``False``, the IDE starts
             without a project and agents can open one via the ``open-project`` MCP tool.
-        mcp_steroid_version: mcp-steroid version to install. Format: ``X.Y.Z`` or
-            ``X.Y.Z-HASH`` (e.g. ``0.94.0-8682a5ce``). Defaults to the latest tested
-            version.
+        mcp_steroid_version: mcp-steroid version to install. Format: ``X.Y`` or
+            ``X.Y.Z``, optionally with a ``-HASH`` suffix (e.g. ``0.94.0-8682a5ce`` or
+            ``0.100-409f23a2``). Defaults to the latest tested version.
         user: User to switch back to after installation. Defaults to ``ctx.current_user``.
     """
 
@@ -98,7 +98,9 @@ class PyCharm(PluginBase):
     @classmethod
     def _validate_mcp_steroid_version(cls, v: str) -> str:
         if not _MCP_STEROID_VERSION_RE.match(v):
-            raise ValueError(f"Invalid mcp-steroid version: {v!r}. Expected format: X.Y.Z or X.Y.Z-HASH")
+            raise ValueError(
+                f"Invalid mcp-steroid version: {v!r}. Expected format: X.Y or X.Y.Z, optionally with a -HASH suffix"
+            )
         return v
 
     @field_validator("user")

--- a/plugins/pycharm/src/idegym/plugins/pycharm/resources/Dockerfile.mcp_steroid_start.j2
+++ b/plugins/pycharm/src/idegym/plugins/pycharm/resources/Dockerfile.mcp_steroid_start.j2
@@ -1,11 +1,13 @@
 # Configure PyCharm to start without a project and wait for mcp-steroid.
 # Agents can open any project at runtime via the mcp-steroid MCP tools.
 #
-# MCP_STEROID=true switches start-pycharm.sh to mcp-steroid mode: no project arg,
+# MCP_STEROID=true switches start-pycharm to mcp-steroid mode: no project arg,
 # waits for mcp-steroid on {{ mcp_steroid_port }}, then bridges
 # 0.0.0.0:{{ mcp_steroid_bridge_port }} -> 127.0.0.1:{{ mcp_steroid_port }} via socat.
+# Scripts are installed without the .sh suffix so their names survive
+# IdeGYMServer's /usr/local/bin/*.{py,sh} → bare-command rename pass.
 ENV MCP_STEROID=true
-COPY plugins/pycharm/scripts/check-mcp.sh /usr/local/bin/check-mcp.sh
-COPY plugins/pycharm/scripts/start-pycharm.sh /usr/local/bin/start-pycharm.sh
-RUN chmod +x /usr/local/bin/check-mcp.sh /usr/local/bin/start-pycharm.sh
+COPY plugins/pycharm/scripts/check-mcp.sh /usr/local/bin/check-mcp
+COPY plugins/pycharm/scripts/start-pycharm.sh /usr/local/bin/start-pycharm
+RUN chmod +x /usr/local/bin/check-mcp /usr/local/bin/start-pycharm
 COPY plugins/pycharm/scripts/supervisord-pycharm.conf /etc/supervisor/conf.d/pycharm.conf

--- a/plugins/pycharm/src/idegym/plugins/pycharm/resources/Dockerfile.open_project.j2
+++ b/plugins/pycharm/src/idegym/plugins/pycharm/resources/Dockerfile.open_project.j2
@@ -35,10 +35,13 @@ RUN set -eux; \
         '  </component>' \
         '</application>' > "{{ config_dir }}/options/trusted-paths.xml"
 
-# start-pycharm.sh: starts Xvfb on :99 (PyCharm CE requires a display), launches PyCharm,
+# start-pycharm: starts Xvfb on :99 (PyCharm CE requires a display), launches PyCharm,
 # waits for MCP on {{ mcp_port }}, bridges 0.0.0.0:{{ bridge_port }} → 127.0.0.1:{{ mcp_port }} via socat.
-# check-mcp.sh: script for checking MCP endpoint availability.
-COPY plugins/pycharm/scripts/check-mcp.sh /usr/local/bin/check-mcp.sh
-COPY plugins/pycharm/scripts/start-pycharm.sh /usr/local/bin/start-pycharm.sh
-RUN chmod +x /usr/local/bin/check-mcp.sh /usr/local/bin/start-pycharm.sh
+# check-mcp: script for checking MCP endpoint availability.
+# Installed without the .sh suffix so the names survive IdeGYMServer's
+# /usr/local/bin/*.{py,sh} → bare-command rename pass (which would otherwise
+# strip the suffix and break the supervisord command / internal source below).
+COPY plugins/pycharm/scripts/check-mcp.sh /usr/local/bin/check-mcp
+COPY plugins/pycharm/scripts/start-pycharm.sh /usr/local/bin/start-pycharm
+RUN chmod +x /usr/local/bin/check-mcp /usr/local/bin/start-pycharm
 COPY plugins/pycharm/scripts/supervisord-pycharm.conf /etc/supervisor/conf.d/pycharm.conf

--- a/unit-tests/test_image_builder.py
+++ b/unit-tests/test_image_builder.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+from pathlib import Path
 from textwrap import dedent
 
 from idegym.api.plugin import BuildContext, PluginBase, get_all_server_plugins, image_plugin, server_plugin
@@ -980,6 +981,11 @@ def test_idea_render_installs_open_project_plugin_when_project_in_ctx():
     # Start script and supervisord config are COPY'd from the build context
     assert "COPY plugins/idea/scripts/start-idea.sh" in fragment
     assert "COPY plugins/idea/scripts/supervisord-idea.conf" in fragment
+    # Installed under bare names so IdeGYMServer's /usr/local/bin/*.{py,sh} rename
+    # pass leaves them intact and the supervisord command keeps resolving.
+    assert "chmod +x /usr/local/bin/check-mcp /usr/local/bin/start-idea" in fragment
+    assert "/usr/local/bin/start-idea.sh" not in fragment
+    assert "/usr/local/bin/check-mcp.sh" not in fragment
 
 
 def test_idea_render_skips_open_project_plugin_when_open_project_false():
@@ -1864,6 +1870,8 @@ def test_pycharm_mcp_steroid_default_version():
         param("0.94.0-8682a5ce", id="with-hash"),
         param("0.94.0", id="without-hash"),
         param("1.0.0", id="major-only-parts"),
+        param("0.94", id="two-part"),
+        param("0.100-409f23a2", id="two-part-with-hash"),
     ],
 )
 def test_pycharm_mcp_steroid_accepts_valid_version(version):
@@ -1873,7 +1881,7 @@ def test_pycharm_mcp_steroid_accepts_valid_version(version):
 @mark.parametrize(
     "version",
     [
-        param("0.94", id="missing-patch"),
+        param("0", id="major-only"),
         param("latest", id="non-numeric"),
         param("v0.94.0", id="v-prefix"),
         param("0.94.0-SNAPSHOT", id="non-hex-suffix"),
@@ -1918,6 +1926,11 @@ def test_pycharm_mcp_steroid_copies_start_script_when_no_project():
     assert "COPY plugins/pycharm/scripts/supervisord-pycharm.conf" in fragment
     # project-opener must not be present
     assert "open-project.zip" not in fragment
+    # Installed under bare names so IdeGYMServer's /usr/local/bin/*.{py,sh} rename
+    # pass leaves them intact and the supervisord command keeps resolving.
+    assert "chmod +x /usr/local/bin/check-mcp /usr/local/bin/start-pycharm" in fragment
+    assert "/usr/local/bin/start-pycharm.sh" not in fragment
+    assert "/usr/local/bin/check-mcp.sh" not in fragment
 
 
 def test_pycharm_mcp_steroid_no_start_script_when_open_project_active():
@@ -1969,6 +1982,34 @@ def test_idea_mcp_steroid_default_version():
     assert plugin.mcp_steroid_version == "0.94.0-8682a5ce"
 
 
+@mark.parametrize(
+    "version",
+    [
+        param("0.94.0-8682a5ce", id="with-hash"),
+        param("0.94.0", id="without-hash"),
+        param("1.0.0", id="major-only-parts"),
+        param("0.94", id="two-part"),
+        param("0.100-409f23a2", id="two-part-with-hash"),
+    ],
+)
+def test_idea_mcp_steroid_accepts_valid_version(version):
+    assert Idea(mcp_steroid=True, mcp_steroid_version=version).mcp_steroid_version == version
+
+
+@mark.parametrize(
+    "version",
+    [
+        param("0", id="major-only"),
+        param("latest", id="non-numeric"),
+        param("v0.94.0", id="v-prefix"),
+        param("0.94.0-SNAPSHOT", id="non-hex-suffix"),
+    ],
+)
+def test_idea_mcp_steroid_rejects_invalid_version(version):
+    with raises(ValueError, match="mcp-steroid"):
+        Idea(mcp_steroid=True, mcp_steroid_version=version)
+
+
 def test_idea_mcp_steroid_render_downloads_plugin():
     plugin = Idea(mcp_steroid=True)
     ctx = BuildContext(base="debian:bookworm-slim")
@@ -1994,6 +2035,33 @@ def test_idea_mcp_steroid_copies_start_script_when_no_project():
     assert "ENV MCP_STEROID=true" in fragment
     assert "COPY plugins/idea/scripts/supervisord-idea.conf" in fragment
     assert "open-project.zip" not in fragment
+    # Installed under bare names so IdeGYMServer's /usr/local/bin/*.{py,sh} rename
+    # pass leaves them intact and the supervisord command keeps resolving.
+    assert "chmod +x /usr/local/bin/check-mcp /usr/local/bin/start-idea" in fragment
+    assert "/usr/local/bin/start-idea.sh" not in fragment
+    assert "/usr/local/bin/check-mcp.sh" not in fragment
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@mark.parametrize(
+    ("ide", "start_script"),
+    [
+        param("idea", "start-idea", id="idea"),
+        param("pycharm", "start-pycharm", id="pycharm"),
+    ],
+)
+def test_ide_start_scripts_installed_without_sh_suffix(ide, start_script):
+    # IdeGYMServer renames /usr/local/bin/*.{py,sh} to bare hyphenated commands.
+    # The supervisord program command and the start script's `source` of check-mcp
+    # must therefore reference the bare names, not the .sh source filenames.
+    scripts = _REPO_ROOT / "plugins" / ide / "scripts"
+    supervisord = (scripts / f"supervisord-{ide}.conf").read_text()
+    assert f"command=/usr/local/bin/{start_script}\n" in supervisord
+    assert f"{start_script}.sh" not in supervisord
+    start = (scripts / f"{start_script}.sh").read_text()
+    assert 'source "${SCRIPT_DIR}/check-mcp"' in start
 
 
 def test_idea_mcp_steroid_no_start_script_when_open_project_active():


### PR DESCRIPTION
Two related fixes to the `idea` and `pycharm` image plugins, found while running mcp-steroid `0.100-409f23a2` on a built env image. Both plugins had the identical bugs, so both are fixed.

## 1. mcp-steroid version regex rejected 2-part versions

`_MCP_STEROID_VERSION_RE` required three numeric parts (`^\d+\.\d+\.\d+(-[a-f0-9]+)?$`), so a real release tag like `0.100-409f23a2` (major.minor + commit hash) failed validation:

```
ValueError: Invalid mcp-steroid version: '0.100-409f23a2'. Expected format: X.Y.Z or X.Y.Z-HASH
```

Relaxed to `^\d+\.\d+(\.\d+)?(-[a-f0-9]+)?$` (third component optional). Docstrings, the validator error message, and `documentation/mcp.md` updated to match. Existing 3-part forms still validate; `0`, `v0.94.0`, `0.94.0-SNAPSHOT`, `0.94.0.1` still rejected.

## 2. `start-idea` / `start-pycharm` went FATAL after a normal build

`IdeGYMServer` installs helper scripts by renaming `/usr/local/bin/*.{py,sh}` to bare, hyphenated command names — that's how `idegym` and `kill-supervisor` are invoked from supervisord (see the rename loop in `plugins/defaults/.../image.py`).

The idea/pycharm plugins, though, **copied** their `start-*.sh` / `check-mcp.sh` scripts with the `.sh` suffix **and referenced them with the suffix**:
- `supervisord-*.conf`: `command=/usr/local/bin/start-idea.sh`
- inside the start script: `source "${SCRIPT_DIR}/check-mcp.sh"`

So after a normal build (IDE plugin **+** `IdeGYMServer`), the rename pass strips the suffix → the `.sh` references no longer resolve → the `idea`/`pycharm` supervisord program goes **FATAL**, the IDE never starts, and mcp-steroid never binds its port (only the built-in MCP tools appear).

**Fix:** install these scripts under their bare names (`/usr/local/bin/start-idea`, `/usr/local/bin/check-mcp`, …) and reference the bare names from the supervisord `command=` and the internal `source` (with a `.sh` fallback for running from the source tree). The names are now stable whether or not the rename pass runs, matching the existing bare-command convention in `/usr/local/bin`. Works in all three cases: built with `IdeGYMServer`, standalone (no rename), and run from the repo.

## Tests
- Added IDEA `mcp_steroid_version` accept/reject cases (it had none); extended PyCharm's to cover 2-part versions including `0.100-409f23a2`.
- Assert the rendered Dockerfiles install bare names and contain no `/usr/local/bin/*.sh` target.
- New `test_ide_start_scripts_installed_without_sh_suffix`: each supervisord command matches the bare install name and the start script sources `check-mcp` by its bare name.
- Updated the PyCharm docker integration test's path assertion (`/usr/local/bin/start-pycharm`).

`uv run --no-sync pytest unit-tests/test_image_builder.py -m unit` → 269 passed; `ruff check` clean.

> Note: the end-to-end run that surfaced this was on IDEA; the PyCharm side is fixed by symmetry (identical code path) and covered by unit + docker-integration tests, but was not exercised on a live cluster.