### PR TITLE
[JBRes-9799] Fix stale IdeGYM import paths in documentation

### DIFF
--- a/documentation/client.md
+++ b/documentation/client.md
@@ -473,7 +473,7 @@ import asyncio
 from pathlib import Path
 from idegym.client.client import IdeGYMClient
 from idegym.image.builder import Image
-from idegym.image.plugins import User, Project
+from idegym.plugins.defaults.image import User, Project
 
 async def train_step(client: IdeGYMClient, image_tag: str, patch: str) -> float:
     """Apply a patch and return a test-pass reward."""

--- a/documentation/full_flow_example.md
+++ b/documentation/full_flow_example.md
@@ -33,7 +33,7 @@ installation is already baked into the base.
 
 ```python
 from idegym.image.builder import Image
-from idegym.image.plugins import Permissions, Project, User
+from idegym.plugins.defaults.image import Permissions, Project, User
 
 BASE_IMAGE = "ghcr.io/jetbrains-research/idegym/server-debian-bookworm-20250520-slim:latest"
 # When deploying to Minikube via e2e tests, use the cluster-local registry:
@@ -148,7 +148,7 @@ Requires `git` in the base image. `BaseSystem()` (the default package set) alrea
 
 ```python
 from idegym.image.builder import Image
-from idegym.image.plugins import BaseSystem, IdeGYMServer, Project, User
+from idegym.plugins.defaults.image import BaseSystem, IdeGYMServer, Project, User
 
 IDEGYM_REPO = "https://github.com/jetbrains-research/idegym-oss.git"
 IDEGYM_REF  = "main"   # pin to a tag or commit SHA for reproducibility

--- a/documentation/image_builder.md
+++ b/documentation/image_builder.md
@@ -144,7 +144,7 @@ image = image.with_runtime(
 
 ```python
 from idegym.image.builder import Image
-from idegym.image.plugins import BaseSystem, User, Project, Permissions
+from idegym.plugins.defaults.image import BaseSystem, User, Project, Permissions
 
 image = (
     Image.from_base("ghcr.io/jetbrains-research/idegym/server-debian-bookworm-20250520-slim:latest")
@@ -249,7 +249,7 @@ Installs system packages via `apt-get`. Use this as the first plugin when starti
 
 **Python:**
 ```python
-from idegym.image.plugins import BaseSystem
+from idegym.plugins.defaults.image import BaseSystem
 
 # Default packages (bash, ca-certificates, curl, dumb-init, findutils, git, netcat-openbsd, sudo)
 BaseSystem()
@@ -285,7 +285,7 @@ are updated to the new user, so subsequent plugins and commands run in the corre
 
 **Python:**
 ```python
-from idegym.image.plugins import User
+from idegym.plugins.defaults.image import User
 
 User(
     username="appuser",
@@ -325,7 +325,7 @@ creating directories.
 
 **Python:**
 ```python
-from idegym.image.plugins import Permissions
+from idegym.plugins.defaults.image import Permissions
 
 Permissions(
     paths={
@@ -373,7 +373,7 @@ optional auth token are injected as Docker ARGs so they are evaluated at build t
 via `--build-arg`). Use this for pinned commits and private repos with token auth.
 
 ```python
-from idegym.image.plugins import Project
+from idegym.plugins.defaults.image import Project
 
 Project.from_git(
     url="https://github.com/your-org/your-repo.git",
@@ -512,7 +512,7 @@ Use during development or in CI, when the IdeGYM repository is available on the 
 The Docker build context is set to the repository root, and all workspace packages are `COPY`ed in.
 
 ```python
-from idegym.image.plugins import IdeGYMServer
+from idegym.plugins.defaults.image import IdeGYMServer
 from from_root import from_root
 
 IdeGYMServer.from_local(root=from_root())   # from_root() returns the repository root
@@ -559,7 +559,7 @@ IdeGYMServer.from_git(
 
 ```python
 from idegym.image.builder import Image
-from idegym.image.plugins import BaseSystem, IdeGYMServer, User, Project
+from idegym.plugins.defaults.image import BaseSystem, IdeGYMServer, User, Project
 from from_root import from_root
 
 # Local build (development / CI)
@@ -633,7 +633,7 @@ Build an image using your local Docker daemon:
 
 ```python
 from idegym.image.builder import Image
-from idegym.image.plugins import BaseSystem, User
+from idegym.plugins.defaults.image import BaseSystem, User
 
 image = (
     Image.from_base("ghcr.io/jetbrains-research/idegym/server-debian-bookworm-20250520-slim:latest")

--- a/documentation/tools.md
+++ b/documentation/tools.md
@@ -169,7 +169,7 @@ results = await server.execute_bash(f"cat {output_dir}/*.xml")
 ### Via Python Client
 
 ```python
-from idegym.client import IdeGYMClient
+from idegym.client.client import IdeGYMClient
 
 client = IdeGYMClient(...)
 server = await client.start_server(...)

--- a/examples/verl/image/build.py
+++ b/examples/verl/image/build.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 from idegym.image.builder import Image
 from idegym.image.docker_api import IdeGYMDockerAPI
-from idegym.image.plugins import BaseSystem, IdeGYMServer, Project, User
+from idegym.plugins.defaults.image import BaseSystem, IdeGYMServer, Project, User
 
 IMAGE_NAME = "django-for-verl"
 IMAGE_TAG = "ghcr.io/jetbrains-research/idegym/django-for-verl:rebuilt"

--- a/unit-tests/test_image_builder.py
+++ b/unit-tests/test_image_builder.py
@@ -412,10 +412,10 @@ def test_image_load_all_with_project_plugin():
 
 def test_builtin_plugins_auto_registered_on_builder_import():
     # Verify that importing only `idegym.image.builder` (without importing
-    # `idegym.image.plugins` explicitly) is sufficient for YAML deserialization
+    # `idegym.plugins.defaults.image` explicitly) is sufficient for YAML deserialization
     # of built-in plugin types to succeed.
     script = dedent("""\
-        # Intentionally do NOT import idegym.image.plugins
+        # Intentionally do NOT import idegym.plugins.defaults.image
         from idegym.image.builder import Image
 
         yaml_text = '''


### PR DESCRIPTION
## What

Several docs (and one shipped example) imported the built-in image plugins from the **deleted** `idegym.image.plugins` module. Those plugins now live in `idegym.plugins.defaults.image`. This PR fixes every stale path.

## Why

`image-builder/src/idegym/image/plugins.py` no longer exists — `BaseSystem`, `User`, `Project`, `Permissions`, `IdeGYMServer`, `MCPUpstream` are all defined in `plugins/defaults/src/idegym/plugins/defaults/image.py`. `documentation/image_builder.md` was even self-inconsistent: one snippet already used the new path while seven others didn't. Copy-pasting the old snippets gives `ModuleNotFoundError`.

## Changes

`from idegym.image.plugins import …` → `from idegym.plugins.defaults.image import …` in:

- `documentation/client.md`
- `documentation/full_flow_example.md`
- `documentation/image_builder.md` (8 snippets)
- `examples/verl/image/build.py` — same broken import in runnable example code
- `unit-tests/test_image_builder.py` — stale comment referencing the dead module

Plus `documentation/tools.md`: `from idegym.client import IdeGYMClient` → `from idegym.client.client import IdeGYMClient` for consistency with every other doc (the `idegym.client` re-export still works, so this is cosmetic).

The other paths called out as canonical were already correct in the docs and are left unchanged: `idegym.image.builder:Image`, `idegym.image.docker_api:IdeGYMDockerAPI`, `idegym.plugins.idea.image:Idea`, `idegym.plugins.pycharm.image:PyCharm`, `idegym.client.client:IdeGYMClient`, `idegym.api.auth:BasicAuth`. The server-side MCP docs (`documentation/mcp.md`, `tools.md`) already reference the orchestrator `/mcp` tools `list_server_mcp_tools` / `call_server_mcp_tool` correctly (the names match `api/.../orchestrator/mcp.py`).

## Verification

Imported every documented path against the package layout — all resolve:

```
OK  from idegym.image.builder import Image
OK  from idegym.image.docker_api import IdeGYMDockerAPI
OK  from idegym.plugins.defaults.image import IdeGYMServer / BaseSystem / User / Project / Permissions / MCPUpstream
OK  from idegym.plugins.idea.image import Idea
OK  from idegym.plugins.pycharm.image import PyCharm
OK  from idegym.client.client import IdeGYMClient
OK  from idegym.api.auth import BasicAuth
```

Docs-only change (plus one example import + one test comment); no production logic touched.