### PR TITLE
[JBRes-9821] fix security context at helm chart for watcher

### DIFF
--- a/charts/idegym/values.yaml
+++ b/charts/idegym/values.yaml
@@ -72,7 +72,10 @@ watcher:
       prePing: true
     maxOverflow: ""
   resources: { }
-  securityContext: { }
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
   serviceAccount:
     create: true
     name: ""


### PR DESCRIPTION
Watcher hasn't been able to start without a root. 


Resolves: JBRes-9821

<!--
    Remember to include the full YouTrack ticket ID in the PR title,
    surrounded with square brackets and separated from the title with a single space.
-->
