### PR TITLE
[JBRes-9943] Reduce Dependabot update noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,82 +1,272 @@
 version: 2
+
+# Policy:
+# - Security updates are alert-driven, grouped by SemVer risk, and are not
+#   delayed by this schedule.
+# - Routine minor/patch version updates run quarterly.
+# - Routine major version updates are ignored and must be initiated manually.
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: weekly
-      day: monday
+      interval: "quarterly"
       time: "09:00"
-    cooldown:
-      default-days: 7
-    target-branch: main
+      timezone: "Europe/Amsterdam"
     groups:
-      astral:
+      security-minor-patch:
+        applies-to: "security-updates"
         patterns:
-          - "astral-sh/*"
-      core:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      security-major:
+        applies-to: "security-updates"
         patterns:
-          - "actions/*"
-      docker:
+          - "*"
+        update-types:
+          - "major"
+      actions-minor-patch:
+        applies-to: "version-updates"
         patterns:
-          - "docker/*"
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     commit-message:
       prefix: "[ci] "
     labels:
-      - dependencies
-  - package-ecosystem: docker
-    directory: /orchestrator
+      - "dependencies"
+
+  # NOTE: the server base images (debian/ubuntu) are built from a Jinja template
+  # (Dockerfile.jinja / server.Dockerfile.jinja); their tags live in
+  # scripts/build_server_images.py and CANNOT be tracked by Dependabot. Bump them
+  # manually. The uv helper image is covered here via the concrete /orchestrator
+  # and /watcher Dockerfiles.
+  - package-ecosystem: "docker"
+    directories:
+      - "/orchestrator"
+      - "/watcher"
     schedule:
-      interval: weekly
-      day: monday
+      interval: "quarterly"
       time: "09:00"
-    cooldown:
-      default-days: 7
-    target-branch: main
+      timezone: "Europe/Amsterdam"
     groups:
-      python:
+      security-minor-patch:
+        applies-to: "security-updates"
         patterns:
-          - "python"
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      security-major:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      docker-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     commit-message:
-      prefix: "[orchestrator] "
+      prefix: "[docker] "
     labels:
-      - dependencies
-  - package-ecosystem: helm
-    directory: /charts/idegym
+      - "dependencies"
+
+  - package-ecosystem: "helm"
+    directory: "/charts/idegym"
     schedule:
-      interval: weekly
-      day: monday
+      interval: "quarterly"
       time: "09:00"
-    cooldown:
-      default-days: 7
-    target-branch: main
+      timezone: "Europe/Amsterdam"
     groups:
-      observability:
+      security-minor-patch:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      security-major:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      observability-minor-patch:
+        applies-to: "version-updates"
         patterns:
           - "grafana"
           - "prometheus"
           - "tempo"
+        update-types:
+          - "minor"
+          - "patch"
+      data-services-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "postgresql"
+        update-types:
+          - "minor"
+          - "patch"
+      helm-other-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     commit-message:
       prefix: "[helm] "
     labels:
-      - dependencies
-  - package-ecosystem: uv
-    directory: /
+      - "dependencies"
+
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
-      interval: weekly
-      day: monday
+      interval: "quarterly"
       time: "09:00"
-    cooldown:
-      default-days: 7
-    target-branch: main
+      timezone: "Europe/Amsterdam"
     groups:
-      opentelemetry:
+      security-minor-patch:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      security-major:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      python-web-stack-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "fastapi*"
+          - "starlette"
+          - "uvicorn"
+          - "anyio"
+          - "pydantic*"
+          - "python-multipart"
+          - "aiohttp"
+        update-types:
+          - "minor"
+          - "patch"
+      python-database-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "sqlalchemy"
+          - "alembic"
+          - "greenlet"
+          - "asyncpg"
+          - "psycopg*"
+        update-types:
+          - "minor"
+          - "patch"
+      python-auth-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "cryptography"
+          - "joserfc"
+          - "pyjwt"
+        update-types:
+          - "minor"
+          - "patch"
+      python-observability-minor-patch:
+        applies-to: "version-updates"
         patterns:
           - "opentelemetry-*"
-      testing:
+          - "structlog"
+        update-types:
+          - "minor"
+          - "patch"
+      python-testing-tooling-minor-patch:
+        applies-to: "version-updates"
         patterns:
           - "pytest*"
-          - "testcontainers"
+          - "testcontainers*"
+          - "junitparser"
+          - "ruff"
+          - "pre-commit"
+        update-types:
+          - "minor"
+          - "patch"
+      python-platform-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "kubernetes"
+          - "kubernetes-asyncio"
+          - "python-on-whales"
+        update-types:
+          - "minor"
+          - "patch"
+      python-other-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     commit-message:
       prefix: "[dependencies] "
     labels:
-      - dependencies
+      - "dependencies"
+
+  # /examples has its own uv.lock and has received separate security PRs.
+  - package-ecosystem: "uv"
+    directory: "/examples"
+    schedule:
+      interval: "quarterly"
+      time: "09:00"
+      timezone: "Europe/Amsterdam"
+    groups:
+      security-minor-patch:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      security-major:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      examples-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+    commit-message:
+      prefix: "[examples] "
+    labels:
+      - "dependencies"

--- a/.github/workflows/dependabot-security-automerge.yml
+++ b/.github/workflows/dependabot-security-automerge.yml
@@ -1,0 +1,46 @@
+name: Dependabot security auto-merge
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: dependabot-security-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  enable-auto-merge:
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.repository == 'JetBrains-Research/idegym' &&
+      !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    steps:
+      - name: Read Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        with:
+          github-token: ${{ github.token }}
+
+      # Fail closed: only the explicitly named security group and recognized
+      # minor/patch SemVer updates are eligible. Major or unclassified security
+      # updates remain open for human review.
+      - name: Enable auto-merge for minor and patch security updates
+        if: >-
+          steps.dependabot-metadata.outputs.dependency-group == 'security-minor-patch' &&
+          (steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' ||
+           steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
# Reduce Dependabot update noise

## What changes

- Routine minor/patch updates move from **weekly to quarterly**. Routine major updates are ignored
  (human-initiated).
- Routine updates are grouped by ecosystem and recent review history.
- Docker `/orchestrator` and `/watcher` are covered by one group (they share identical base images).
- Adds Dependabot coverage for `/examples` (separate `uv.lock`).
- Removes `target-branch: main` and the 7-day cooldown from every ecosystem.
- Security updates are grouped by SemVer risk. A new workflow (`dependabot-security-automerge.yml`)
  enables auto-merge for **patch/minor security updates only**, after required checks pass. Major and
  unclassified security updates are left for human review.

## Why

Recent Dependabot history was a steady stream of individual weekly PRs (FastAPI/Uvicorn/AnyIO, Ruff,
Greenlet/Alembic, Kubernetes clients, PostgreSQL, and Actions outside the existing groups). Quarterly
cadence plus history-based groups reduces this to a few reviewable PRs per quarter, while security
fixes stay alert-driven and low-touch.

## Human actions required

Repository settings, not part of this PR — complete them before merge:

1. Enable Dependabot alerts and security updates.
2. Enable **Allow auto-merge** and grant GitHub Actions **write** permission.
3. Add these as **required status checks** on `main` (without them, auto-merge would merge a security
   PR immediately):
   - `Lint / Python`
   - `Lint / Helm`
   - `CI / Run unit tests`
   - `CI / Run integration tests`
   - `CI / Run e2e tests (excluding IDE integrations)`
   - `CI / Run e2e IDE integration tests`

   Do **not** require `Deploy docs website` (path-filtered — would block dependency PRs) or `Publish`
   (tags only).
4. Mark this PR ready and merge once the above are in place.
