### PR TITLE
[idea/pycharm] mcp-steroid headless fixes + reflect recent features in the website

### DIFF
--- a/plugins/idea/scripts/check-mcp.sh
+++ b/plugins/idea/scripts/check-mcp.sh
@@ -35,14 +35,11 @@ check_mcp_endpoint() {
         fi
         return 1
     else
-        # For /stream and /mcp endpoints, try JSON-RPC initialize
-
-        # Fast probe - check for jsonrpc response
-        if ! curl -s --max-time 3 "${url}" 2>/dev/null | grep -q '"jsonrpc"'; then
-            return 1
-        fi
-
-        # Try proper MCP initialize
+        # For /stream and /mcp endpoints, the authoritative readiness signal is a JSON-RPC
+        # `initialize` that returns a result. Do NOT gate on a GET "fast probe": some mcp-steroid
+        # builds answer a plain GET with a bare server-info object (e.g.
+        # {"name":"mcp-steroid","status":"available"}) that has no "jsonrpc" field, so the old probe
+        # reported not-ready forever — start-idea.sh then hit its WAIT_SECONDS timeout and killed the IDE.
         local init_resp=$(curl -s --max-time 3 "${url}" \
             -H "Content-Type: application/json" \
             -H "Accept: application/json, text/event-stream" \
@@ -91,38 +88,34 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
                 echo "  ✖ SSE endpoint not ready (HTTP ${http_code:-000})"
             fi
         else
-            # JSON-RPC endpoint - try initialize
-            if ! curl -s --max-time 3 "$url" 2>/dev/null | grep -q '"jsonrpc"'; then
-                echo "  ✖ Not an MCP endpoint"
-            else
-                echo "  ✔ MCP-like response detected"
-
-                init_resp=$(curl -s --max-time 3 "$url" \
-                    -H "Content-Type: application/json" \
-                    -H "Accept: application/json, text/event-stream" \
-                    -d '{
-                        "jsonrpc": "2.0",
-                        "id": 1,
-                        "method": "initialize",
-                        "params": {
-                            "protocolVersion": "2025-03-26",
-                            "capabilities": {},
-                            "clientInfo": {
-                                "name": "idegym-check",
-                                "version": "0.1.0"
-                            }
+            # JSON-RPC endpoint - the real check is an `initialize` that returns a result. (No GET
+            # "fast probe": mcp-steroid answers GET with a bare server-info object that lacks
+            # "jsonrpc", which would make the probe wrongly declare it not an MCP endpoint.)
+            init_resp=$(curl -s --max-time 3 "$url" \
+                -H "Content-Type: application/json" \
+                -H "Accept: application/json, text/event-stream" \
+                -d '{
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "clientInfo": {
+                            "name": "idegym-check",
+                            "version": "0.1.0"
                         }
-                    }' 2>/dev/null)
+                    }
+                }' 2>/dev/null)
 
-                if echo "$init_resp" | grep -q '"result"'; then
-                    echo "  ✅ MCP is READY (initialize succeeded)"
-                    echo
-                    echo "🎉 Working MCP endpoint: $url"
-                    exit 0
-                else
-                    echo "  ⚠ MCP detected but initialize failed"
-                    echo "  Response: $init_resp"
-                fi
+            if echo "$init_resp" | grep -q '"result"'; then
+                echo "  ✅ MCP is READY (initialize succeeded)"
+                echo
+                echo "🎉 Working MCP endpoint: $url"
+                exit 0
+            else
+                echo "  ⚠ MCP detected but initialize failed"
+                echo "  Response: $init_resp"
             fi
         fi
         echo

--- a/plugins/idea/scripts/start-idea.sh
+++ b/plugins/idea/scripts/start-idea.sh
@@ -83,11 +83,16 @@ else
     echo ">>> Launching IDEA with open-project AppStarter (project: ${PROJECT})"
 fi
 
+# -Dmcp.steroid.review.mode=NEVER: run mcp-steroid's steroid_execute_code without the manual
+# code-review gate. Its default (ALWAYS) opens a review.kts and waits for a human to approve every
+# execution; headless there is no reviewer, so each call hangs until mcp.steroid.review.timeout (600s).
+# NEVER auto-approves all executions — required for autonomous use (harmless when mcp-steroid absent).
 "${IDE_DIR}/bin/idea.sh" \
     -Djava.awt.headless=true \
     -Didea.platform.prefix=Idea \
     -Didea.trust.all.projects=true \
     -Dide.no.platform.update=true \
+    -Dmcp.steroid.review.mode=NEVER \
     -Didea.system.path="${IDE_SYSTEM_PATH}" \
     -Didea.config.path="${IDE_CONFIG_PATH}" \
     -Didea.plugins.path="${IDE_DIR}/plugins" \

--- a/plugins/pycharm/scripts/check-mcp.sh
+++ b/plugins/pycharm/scripts/check-mcp.sh
@@ -35,14 +35,11 @@ check_mcp_endpoint() {
         fi
         return 1
     else
-        # For /stream and /mcp endpoints, try JSON-RPC initialize
-
-        # Fast probe - check for jsonrpc response
-        if ! curl -s --max-time 3 "${url}" 2>/dev/null | grep -q '"jsonrpc"'; then
-            return 1
-        fi
-
-        # Try proper MCP initialize
+        # For /stream and /mcp endpoints, the authoritative readiness signal is a JSON-RPC
+        # `initialize` that returns a result. Do NOT gate on a GET "fast probe": some mcp-steroid
+        # builds answer a plain GET with a bare server-info object (e.g.
+        # {"name":"mcp-steroid","status":"available"}) that has no "jsonrpc" field, so the old probe
+        # reported not-ready forever — start-idea.sh then hit its WAIT_SECONDS timeout and killed the IDE.
         local init_resp=$(curl -s --max-time 3 "${url}" \
             -H "Content-Type: application/json" \
             -H "Accept: application/json, text/event-stream" \
@@ -91,38 +88,34 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
                 echo "  ✖ SSE endpoint not ready (HTTP ${http_code:-000})"
             fi
         else
-            # JSON-RPC endpoint - try initialize
-            if ! curl -s --max-time 3 "$url" 2>/dev/null | grep -q '"jsonrpc"'; then
-                echo "  ✖ Not an MCP endpoint"
-            else
-                echo "  ✔ MCP-like response detected"
-
-                init_resp=$(curl -s --max-time 3 "$url" \
-                    -H "Content-Type: application/json" \
-                    -H "Accept: application/json, text/event-stream" \
-                    -d '{
-                        "jsonrpc": "2.0",
-                        "id": 1,
-                        "method": "initialize",
-                        "params": {
-                            "protocolVersion": "2025-03-26",
-                            "capabilities": {},
-                            "clientInfo": {
-                                "name": "idegym-check",
-                                "version": "0.1.0"
-                            }
+            # JSON-RPC endpoint - the real check is an `initialize` that returns a result. (No GET
+            # "fast probe": mcp-steroid answers GET with a bare server-info object that lacks
+            # "jsonrpc", which would make the probe wrongly declare it not an MCP endpoint.)
+            init_resp=$(curl -s --max-time 3 "$url" \
+                -H "Content-Type: application/json" \
+                -H "Accept: application/json, text/event-stream" \
+                -d '{
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "clientInfo": {
+                            "name": "idegym-check",
+                            "version": "0.1.0"
                         }
-                    }' 2>/dev/null)
+                    }
+                }' 2>/dev/null)
 
-                if echo "$init_resp" | grep -q '"result"'; then
-                    echo "  ✅ MCP is READY (initialize succeeded)"
-                    echo
-                    echo "🎉 Working MCP endpoint: $url"
-                    exit 0
-                else
-                    echo "  ⚠ MCP detected but initialize failed"
-                    echo "  Response: $init_resp"
-                fi
+            if echo "$init_resp" | grep -q '"result"'; then
+                echo "  ✅ MCP is READY (initialize succeeded)"
+                echo
+                echo "🎉 Working MCP endpoint: $url"
+                exit 0
+            else
+                echo "  ⚠ MCP detected but initialize failed"
+                echo "  Response: $init_resp"
             fi
         fi
         echo

--- a/plugins/pycharm/scripts/start-pycharm.sh
+++ b/plugins/pycharm/scripts/start-pycharm.sh
@@ -93,12 +93,18 @@ else
     echo ">>> Launching PyCharm with open-project AppStarter (project: ${PROJECT})"
 fi
 
+# -Dmcp.steroid.review.mode=NEVER: run mcp-steroid's steroid_execute_code without the manual
+# code-review gate. Its default (ALWAYS) opens a review.kts and waits for a human to approve every
+# execution; in this automated run there is no reviewer, so each call hangs until
+# mcp.steroid.review.timeout (600s). NEVER auto-approves all executions — required for autonomous
+# use (harmless when mcp-steroid is absent, e.g. the default MCP_STEROID=false mode).
 "${PYCHARM_DIR}/bin/pycharm.sh" \
     -Didea.trust.all.projects=true \
     -Didea.system.path="${IDE_SYSTEM_PATH}" \
     -Didea.config.path="${IDE_CONFIG_PATH}" \
     -Didea.plugins.path="${PYCHARM_DIR}/plugins" \
     -Dide.no.platform.update=true \
+    -Dmcp.steroid.review.mode=NEVER \
     -Dide.show.tips.on.startup.default.value=false \
     -Djb.consents.confirmation.enabled=false \
     "${OPEN_ARGS[@]+"${OPEN_ARGS[@]}"}" > "${LOG_FILE}" 2>&1 &

--- a/website/docs/architecture/image-builder.md
+++ b/website/docs/architecture/image-builder.md
@@ -1,6 +1,6 @@
 ---
 title: Image builder
-description: The fluent Image API → BuildContext → plugin pipeline → ImageBuildSpec → Kaniko.
+description: The fluent Image API → BuildContext → plugin pipeline → ImageBuildSpec → a pluggable build backend (Kaniko or GKE Cloud Build).
 ---
 
 # Image builder
@@ -9,7 +9,7 @@ The image builder turns a **declarative description** of an environment into a r
 container image. Instead of hand-writing Dockerfiles, you compose an `Image` from
 **plugins**; each plugin updates a shared build context and emits a Dockerfile fragment.
 The result is compiled to an `ImageBuildSpec` and built — locally with Docker, or
-in-cluster with Kaniko.
+in-cluster through a **pluggable build backend** (Kaniko by default, or GKE Cloud Build).
 
 ## The build pipeline (click a node for source)
 
@@ -19,13 +19,17 @@ flowchart TB
     ctx["<b>BuildContext</b>"]:::infra
     plugins[/"<b>Plugin pipeline</b><br/>apply → render"/]:::build
     spec[/"<b>ImageBuildSpec</b>"/]:::build
-    kaniko[/"<b>Kaniko</b>"/]:::build
     docker["<b>Local Docker</b>"]:::infra
+    backend{{"<b>Build backend</b><br/>ImageBuildService"}}:::build
+    kaniko[/"<b>Kaniko Job</b><br/>in-cluster"/]:::build
+    cloud[/"<b>GKE Cloud Build</b>"/]:::build
     reg[("<b>📦 Registry</b>")]:::store
 
     img --> ctx --> plugins --> spec
-    spec --> kaniko --> reg
     spec --> docker --> reg
+    spec -->|"in-cluster"| backend
+    backend --> kaniko --> reg
+    backend --> cloud --> reg
 
     classDef build fill:#c026d3,stroke:#a21caf,color:#fff;
     classDef infra fill:#475569,stroke:#334155,color:#fff;
@@ -36,7 +40,9 @@ flowchart TB
     click ctx "https://github.com/JetBrains-Research/idegym/blob/main/api/src/idegym/api/plugin.py" "View the BuildContext source on GitHub."
     click spec "https://github.com/JetBrains-Research/idegym/blob/main/api/src/idegym/api/image_build.py" "View the ImageBuildSpec model on GitHub."
     click docker "https://github.com/JetBrains-Research/idegym/blob/main/image-builder/src/idegym/image/docker_api.py" "View the local Docker build source on GitHub."
-    click kaniko "https://github.com/JetBrains-Research/idegym/blob/main/backend-utils/src/idegym/backend/utils/kubernetes_client.py" "View the Kaniko submit source on GitHub."
+    click backend "https://github.com/JetBrains-Research/idegym/blob/main/backend-utils/src/idegym/backend/utils/image_builder/factory.py" "View the build-backend factory on GitHub."
+    click kaniko "https://github.com/JetBrains-Research/idegym/blob/main/backend-utils/src/idegym/backend/utils/image_builder/kaniko.py" "View the Kaniko backend on GitHub."
+    click cloud "https://github.com/JetBrains-Research/idegym/blob/main/backend-utils/src/idegym/backend/utils/image_builder/cloudbuild_gke.py" "View the GKE Cloud Build backend on GitHub."
 ```
 
 ## How it works
@@ -93,18 +99,51 @@ so YAML deserialization always sees a populated registry. See
 ## Building: local vs. in-cluster
 
 - **Local Docker** — `image.build()` uses the local Docker daemon; handy for development
-  and loading into Minikube.
-- **Kaniko (in-cluster)** — serialize to YAML, submit to the orchestrator, which runs a
-  Kaniko Job that builds from `dockerfile_content` and pushes to the configured registry.
-  Download ARGs (project URL, auth token) are passed as `--build-arg` values.
+  and loading into Minikube. Defaults to a **native single-platform build** (your host's
+  architecture); pass `--multiplatform` only when you deliberately want `linux/amd64` +
+  `linux/arm64`.
+- **In-cluster** — serialize to YAML and submit to the orchestrator, which runs the build
+  through a **pluggable backend** (below) and pushes the result to the configured registry.
+
+### Shipping files a plugin `COPY`s
+
+A plugin whose `render()` emits a `COPY` needs its source to exist in the build context.
+Rather than assume the caller builds from a checkout of the idegym repo, a plugin ships the
+file inside its own package and declares it from `get_context_files()` (`dest → packaged
+file`); `to_spec()` folds these onto `ImageBuildSpec.context_files` and into the image tag,
+so an asset change yields a new tag. The local Docker build **stages any missing declared
+files in place** into the caller's context (cleaning up only what it created), so `COPY`
+resolves from any working directory. See [Plugin system](/architecture/plugins) and the
+[reference](/reference/plugins#shipping-files-your-copy-needs-get_context_files).
+
+### Build backends
+
+The in-cluster path is **backend-agnostic**: the orchestrator picks an `ImageBuilder` at
+request time and a shared `ImageBuildService` drives it — build the tag, persist status to
+the `job_statuses` table, and poll to completion. The backend is selected via config
+(`IDEGYM_BUILD_BACKEND`), **defaulting to `kaniko`** so existing deployments are unchanged.
+
+- **Kaniko** (default) — an in-cluster Job that builds from `dockerfile_content` (mounted
+  as a ConfigMap) and pushes to the registry; download ARGs (project URL, auth token) are
+  passed as `--build-arg` values. When a spec carries `context_files` (the `idea`/`pycharm`
+  plugins), the Job's context is a **git checkout of the idegym repo** at the orchestrator's
+  version instead of the ConfigMap, so those `COPY` paths resolve.
+- **GKE Cloud Build** — builds with [GCP Cloud Build](https://cloud.google.com/build)
+  (BuildKit) instead of an in-cluster Job, pushing to Artifact Registry. The project auth
+  token is passed as a BuildKit **build secret** (never a `--build-arg`), so it never lands
+  in the Build request, its logs, or the image history.
 
 > **Kaniko + `set -u` gotcha:** ARGs without a `--build-arg` value are **unset** (not
 > empty). IdeGYM's `RUN set -eux;` uses `set -u`, so optional ARGs are referenced as
 > `${VAR:-}`. The built-in plugins handle this for you.
+
+→ Full backend configuration (env vars, GCP IAM) is in the
+[reference — build backends](/reference/image_builder#build-backends).
 
 ## View source
 
 - Fluent API → [`image-builder/src/idegym/image/builder.py`](https://github.com/JetBrains-Research/idegym/blob/main/image-builder/src/idegym/image/builder.py)
 - Built-in plugins → [`plugins/defaults/src/idegym/plugins/defaults/image.py`](https://github.com/JetBrains-Research/idegym/blob/main/plugins/defaults/src/idegym/plugins/defaults/image.py)
 - Spec model → [`api/src/idegym/api/image_build.py`](https://github.com/JetBrains-Research/idegym/blob/main/api/src/idegym/api/image_build.py)
+- Build backends → [`backend-utils/src/idegym/backend/utils/image_builder/`](https://github.com/JetBrains-Research/idegym/tree/main/backend-utils/src/idegym/backend/utils/image_builder)
 - Full reference → [Image Builder docs](/reference/image_builder)

--- a/website/docs/architecture/orchestrator.md
+++ b/website/docs/architecture/orchestrator.md
@@ -1,6 +1,6 @@
 ---
 title: Orchestrator
-description: The FastAPI control plane — lifecycle management, async operations, PostgreSQL, request forwarding, and Kaniko build submission.
+description: The FastAPI control plane — lifecycle management, async operations, PostgreSQL, request forwarding, and pluggable image-build submission.
 ---
 
 # Orchestrator
@@ -32,7 +32,7 @@ flowchart TB
     pods[["<b>Server pods</b>"]]:::pod
 
     routers --> pg
-    rb -->|"Kaniko Job"| kapi
+    rb -->|"build backend"| kapi
     rs -->|"Deployment"| kapi --> pods
     rf -->|"forward"| pods
     mcp -.->|"same handlers as REST"| routers
@@ -58,8 +58,9 @@ flowchart TB
   heartbeats, and on stop/finish tear down or release its servers.
 - **Server lifecycle** — start (or **reuse** a matching finished server), stop, finish
   (release for reuse), and restart environment pods, waiting for readiness.
-- **Image builds** — accept image-builder YAML, compile each `Image` to a spec, and
-  submit Kaniko jobs to the cluster (see [image builder](/architecture/image-builder)).
+- **Image builds** — accept image-builder YAML, compile each `Image` to a spec, and submit
+  it through a **pluggable build backend** (Kaniko by default, or GKE Cloud Build) driven by
+  a shared `ImageBuildService` (see [image builder](/architecture/image-builder#build-backends)).
 - **Forwarding** — proxy HTTP, MCP, and WebSocket requests from clients into the right
   server pod, and **persist** every request/response for offline reward computation.
 - **Async operations** — long-running calls return an operation ID the client polls to
@@ -74,7 +75,8 @@ flowchart TB
 | MCP server | [`mcp.py`](https://github.com/JetBrains-Research/idegym/blob/main/orchestrator/src/idegym/orchestrator/mcp.py) | A thin FastMCP layer over the **same** handlers as REST — no separate state |
 | Routers | [`router/`](https://github.com/JetBrains-Research/idegym/tree/main/orchestrator/src/idegym/orchestrator/router) | One module per concern: `client`, `server`, `build_images`, `forwarding`, `async_operation`, `snapshot`, `dashboard`, `diagnostics` |
 | State | [`database/`](https://github.com/JetBrains-Research/idegym/tree/main/orchestrator/src/idegym/orchestrator/database) | Async SQLAlchemy + asyncpg; Alembic migrations run on startup |
-| Kaniko submit | [`kubernetes_client.py`](https://github.com/JetBrains-Research/idegym/blob/main/backend-utils/src/idegym/backend/utils/kubernetes_client.py) | Creates Kaniko Jobs and server Deployments via the K8s API |
+| Image build | [`image_build_service.py`](https://github.com/JetBrains-Research/idegym/blob/main/orchestrator/src/idegym/orchestrator/image_build_service.py) | Backend-agnostic `ImageBuildService` drives a pluggable [`ImageBuilder`](https://github.com/JetBrains-Research/idegym/tree/main/backend-utils/src/idegym/backend/utils/image_builder) (Kaniko / GKE Cloud Build) |
+| K8s resources | [`kubernetes_client.py`](https://github.com/JetBrains-Research/idegym/blob/main/backend-utils/src/idegym/backend/utils/kubernetes_client.py) | Creates Kaniko Jobs (Kaniko backend) and server Deployments via the K8s API |
 
 ## Persistence model
 

--- a/website/docs/architecture/plugins.md
+++ b/website/docs/architecture/plugins.md
@@ -56,10 +56,21 @@ flowchart LR
 |---|---|---|---|
 | **Image** | `@image_plugin("name")` + `apply()` / `render()` | `Image.to_spec()` ([image builder](/architecture/image-builder)) | A Dockerfile fragment |
 | **MCP upstream** | `get_mcp_upstream()` on the image plugin | `Image.to_spec()` (auto-writes config) | `/etc/idegym/mcp-upstreams.d/<name>.json` |
+| **Build context files** | `get_context_files()` on the image plugin | `Image.to_spec()` → the build backend | Bundled files staged so your `COPY` sources resolve |
+| **Build secrets** | `get_build_secrets()` on the image plugin | `Image.to_spec()` → the build backend | Build-arg names forwarded as secrets (kept out of image layers) |
 | **Server** | `@server_plugin` + `get_server_router()` | `server/main.py` at startup | An `APIRouter` at `/api/<plugin>/*` |
 | **Client** | `idegym.plugins.client` entry point | `IdeGYMServer.__init__` | `server.<plugin>.<method>()` |
 
-Every method has a no-op default, so a plugin implements only the points it needs.
+Every method has a no-op default, so a plugin implements only the points it needs. The
+MCP-upstream, build-context-files, and build-secrets hooks refine the **image** hook — they
+run at `to_spec()` time alongside `render()`, feeding the build rather than the runtime.
+
+> **Shipping files your `COPY` needs.** A plugin whose `render()` emits a `COPY` should ship
+> that file inside its own package and declare it from `get_context_files()`, instead of
+> assuming the caller builds from a checkout of the idegym repo. The build backend stages the
+> declared files so `COPY` resolves from any working directory — see
+> [image builder → shipping COPY files](/architecture/image-builder#shipping-files-a-plugin-copys)
+> and the [reference](/reference/plugins#shipping-files-your-copy-needs-get_context_files).
 
 The shared base lives in [`api/src/idegym/api/plugin.py`](https://github.com/JetBrains-Research/idegym/blob/main/api/src/idegym/api/plugin.py)
 — `PluginBase`, `BuildContext`, and both registries (`@image_plugin`, `@server_plugin`).
@@ -92,9 +103,32 @@ upstream under its stem as a namespace — that's how an IDE's MCP tools surface
 | `idegym-plugins[pycharm]` | `PyCharm` (image) + `PyCharmPlugin` (server) + `PycharmClientOperations` (client) |
 | `idegym-plugins[idea]` | `Idea` (image) + `IdeaPlugin` (server) + `IdeaClientOperations` (client) |
 
+## Baking external IDE plugins
+
+The `Idea` and `PyCharm` image plugins take an ordered `external_plugins` list to bake extra
+IntelliJ-platform plugins into the IDE at build time. Each `PluginSource` names a `.zip` URL
+that is downloaded and unzipped into the IDE's bundled plugins directory — the same mechanism
+that installs mcp-steroid:
+
+```python
+from idegym.plugins.plugin_utils import PluginSource
+from idegym.plugins.idea.image import Idea
+
+Idea(external_plugins=(
+    PluginSource(url="https://example.com/my-plugin.zip"),
+    PluginSource(url="https://registry.example.com/private.zip", auth_env="MY_TOKEN"),
+))
+```
+
+For a download behind authentication, set `auth_env` to the name of a build-time environment
+variable holding the credential. It is consumed as a build **secret** (surfaced via
+`get_build_secrets()` and sent as an `Authorization` header), never promoted to an `ENV` or
+echoed to the build log, so it does not persist in an image layer.
+
 ## View source
 
 - Plugin base & registries → [`api/src/idegym/api/plugin.py`](https://github.com/JetBrains-Research/idegym/blob/main/api/src/idegym/api/plugin.py)
 - Built-in defaults → [`plugins/defaults/`](https://github.com/JetBrains-Research/idegym/tree/main/plugins/defaults)
 - PyCharm / IDEA extras → [`plugins/pycharm/`](https://github.com/JetBrains-Research/idegym/tree/main/plugins/pycharm) · [`plugins/idea/`](https://github.com/JetBrains-Research/idegym/tree/main/plugins/idea)
+- Shared helpers (external plugins, packaged assets) → [`plugins/plugin-utils/`](https://github.com/JetBrains-Research/idegym/tree/main/plugins/plugin-utils)
 - Authoring guide → [Plugin Architecture docs](/reference/plugins)

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -23,7 +23,7 @@ flowchart TB
             graf["Grafana"]
             tempo["Tempo (traces)"]
         end
-        builds["Kaniko build Jobs"]
+        builds["Image build<br/>(Kaniko Job, default)"]
         pods["Sandboxed server pods<br/>(gVisor runtime class)"]
     end
     reg[("Container registry<br/>(GHCR / in-cluster / yours)")]
@@ -79,6 +79,23 @@ Built images need somewhere to live. Three common setups:
   (`registry.kube-system.svc.cluster.local`), used by the e2e suite and local builds.
 - **Your registry** — set `DOCKER_REGISTRY` (and `KANIKO_INSECURE_REGISTRY=true` for HTTP)
   on the orchestrator; mount Kaniko push credentials as a secret.
+- **Artifact Registry** — for the GKE Cloud Build backend, point `DOCKER_REGISTRY` at an
+  Artifact Registry repo (`<region>-docker.pkg.dev/<project>/<repo>`).
+
+## Image build backends
+
+Image builds go through a **pluggable backend**, selected with `IDEGYM_BUILD_BACKEND` and
+**defaulting to `kaniko`** so existing clusters are unchanged:
+
+- **`kaniko`** (default) — an in-cluster Job builds from the generated Dockerfile and pushes
+  to the registry. No Docker daemon on the nodes; works on any Kubernetes cluster.
+- **`cloudbuild_gke`** — offloads the build to [GCP Cloud Build](https://cloud.google.com/build)
+  and pushes to Artifact Registry, authenticating with the orchestrator pod's Workload
+  Identity service account. Requires `IDEGYM_CLOUDBUILD_PROJECT_ID`, `IDEGYM_CLOUDBUILD_REGION`,
+  and `IDEGYM_CLOUDBUILD_STAGING_BUCKET`.
+
+See the [image-builder reference — build backends](/reference/image_builder#build-backends)
+for the full configuration and required GCP IAM roles.
 
 ## Observability
 
@@ -107,5 +124,5 @@ the `Mcp-Session-Id` header and run one worker per pod.
 | Guide | For |
 |---|---|
 | [Getting Started](/reference/getting_started) | Local dev setup + running tests |
-| [Local Deployment](/reference/local_deployment) | Full stack on Minikube (GHCR or local builds) |
+| [Local Deployment](/reference/local_deployment) | Full stack on Minikube — macOS or Linux (GHCR or local builds) |
 | [Remote Deployment](/reference/remote_deployment) | Production Kubernetes, secrets, node pools, snapshots |

--- a/website/docs/overview/concepts.md
+++ b/website/docs/overview/concepts.md
@@ -76,9 +76,12 @@ live cluster and reclaims anything stale — finished clients, crashed pods, orp
 resources — so capacity never silently leaks. See the [watcher](/architecture/watcher).
 
 ### Kaniko
-The **in-cluster image builder**. Building images inside Kubernetes (rather than needing
-a Docker daemon on every node) is done with [Kaniko](https://github.com/GoogleContainerTools/kaniko)
-jobs that build from the generated Dockerfile and push to a registry.
+The **default in-cluster image builder**. Building images inside Kubernetes (rather than
+needing a Docker daemon on every node) is done with
+[Kaniko](https://github.com/GoogleContainerTools/kaniko) jobs that build from the generated
+Dockerfile and push to a registry. Image builds go through a pluggable backend, so on GKE
+you can swap Kaniko for [Cloud Build](https://cloud.google.com/build) — see
+[build backends](/architecture/image-builder#build-backends).
 
 ## How they fit together
 

--- a/website/docs/overview/data-flow.md
+++ b/website/docs/overview/data-flow.md
@@ -66,16 +66,18 @@ Dockerfile fragment. Calling `image.to_spec()` compiles the whole thing into an
 ## 2 · Build the image
 
 The image definition is serialized to YAML and submitted to the orchestrator, which runs
-a **Kaniko** build job inside the cluster and pushes the result to a registry — no Docker
-daemon required on the nodes.
+the build through a **pluggable backend** — Kaniko in-cluster by default (no Docker daemon
+on the nodes), or GKE Cloud Build — and pushes the result to a registry.
 
 ```python
 summary = await client.jobs.build_and_push_images(path=yaml_path, namespace="idegym", timeout=600)
 image_tag = summary.jobs_results[0].tag
 ```
 
-The orchestrator passes download credentials (for private project repos) as Kaniko
-`--build-arg` values and polls the job to completion. → [Image builder](/architecture/image-builder)
+A shared `ImageBuildService` forwards download credentials (for private project repos) to
+the backend and polls the build to completion. Plugins that `COPY` bundled files (e.g. the
+IDE plugins) ship those assets themselves, so a build needs no checkout of the idegym repo.
+→ [Image builder](/architecture/image-builder)
 
 ## 3 · Provision a sandboxed environment
 


### PR DESCRIPTION
## What & why

Two independent chunks of work extracted from the exploratory `vpoliakov/eval-integration` branch, now that its base (PRs #204, #205, #206) has merged.

### 1. mcp-steroid headless fixes (IDEA **and** PyCharm)

The only genuinely-new fixes on `eval-integration` that never made it into `main` (the rest of that branch is already merged, and `main` is actually *ahead* on some files). Both the `idea` and `pycharm` plugins use mcp-steroid the same way and carried the same bugs — `pycharm/check-mcp.sh` was byte-identical to idea's pre-fix version — so the fixes are applied to both:

- **`check-mcp`: detect readiness via `initialize`, not a GET probe.** mcp-steroid answers a plain `GET` with a bare server-info object (e.g. `{"name":"mcp-steroid","status":"available"}`) that has no `"jsonrpc"` field. The old "fast probe" gated on that field, so it reported *not ready* forever — the `start-*` script then hit its `WAIT_SECONDS` timeout and killed the IDE. The JSON-RPC `initialize` that returns a `result` is now the sole authoritative readiness signal. (The two scripts are kept identical.)
- **`start-idea` / `start-pycharm`: disable the mcp-steroid review gate.** mcp-steroid's `steroid_execute_code` defaults to `review.mode=ALWAYS`, which opens a `review.kts` and waits for a human to approve every execution. In an automated run there is no reviewer, so each call hangs until `review.timeout` (600s). Pass `-Dmcp.steroid.review.mode=NEVER` to auto-approve (harmless when mcp-steroid is absent).

### 2. Reflect recent features in the website presentation docs

PRs #181, #204, #205 and #206 documented their features **only** under `website/docs/reference/`. This propagates them into the *presentation* side of the site (`architecture/`, `overview/`, `deployment`) so the narrative stays in sync — rather than leaving `reference/` as the only place these features are described.

| Page | Update |
|---|---|
| `architecture/image-builder` | Pluggable build backends (Kaniko default / GKE Cloud Build) in the pipeline diagram + a new **Build backends** section; build-context staging via `get_context_files` (no idegym-repo checkout); single-platform local builds |
| `architecture/plugins` | New `get_context_files` / `get_build_secrets` hook points in the integration table; **Baking external IDE plugins** section for the `external_plugins` knob |
| `architecture/orchestrator` | Build submission is now a backend-agnostic `ImageBuildService` (was described as Kaniko-only) |
| `deployment` | **Image build backends** section, Artifact Registry note; local deploy works on macOS **or Linux** |
| `overview/concepts`, `overview/data-flow` | Generalized the build stage and the "Kaniko" glossary entry to the pluggable backend |

Features covered: #204 plugin build-context, #206 `external_plugins` knob, #205 Linux + local single-platform builds, #181 Kaniko/GKE Cloud Build backend abstraction.

## Testing

- `bash -n` on all four edited scripts — OK.
- `npm run build` in `website/` — **SUCCESS**. `docusaurus.config.ts` sets both `onBrokenLinks: 'throw'` and `onBrokenAnchors: 'throw'`, so a green build confirms every new internal link and anchor resolves.