### PR TITLE
[ci] Group Dependabot examples + Docker routine updates into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,13 +69,17 @@ updates:
           - "*"
         update-types:
           - "major"
-      docker-minor-patch:
+      # group-by: dependency-name consolidates the same image (e.g. python) across
+      # BOTH /orchestrator and /watcher into a single cross-directory PR, instead of
+      # one grouped PR per directory. Dropping update-types also catches updates that
+      # Dependabot cannot classify (e.g. prerelease tags like 3.15.0bN, which is why
+      # #235 fell out of the group). NOTE: this yields at most one PR per distinct
+      # image (python, uv) - Dependabot cannot merge different images into one PR.
+      docker-routine:
         applies-to: "version-updates"
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
+        group-by: "dependency-name"
     ignore:
       - dependency-name: "*"
         update-types:
@@ -241,6 +245,12 @@ updates:
       interval: "quarterly"
       time: "09:00"
       timezone: "Europe/Amsterdam"
+    # increase-if-necessary avoids raising lower bounds (e.g. >=1.36 -> >=1.44) when the
+    # existing constraint already permits the latest version, while still refreshing the
+    # locked version. NOTE: the uv ecosystem does not yet honor versioning-strategy
+    # (dependabot-core#12162); this is a no-op until that support lands, at which point
+    # it takes effect automatically.
+    versioning-strategy: "increase-if-necessary"
     groups:
       security-minor-patch:
         applies-to: "security-updates"
@@ -255,13 +265,15 @@ updates:
           - "*"
         update-types:
           - "major"
-      examples-minor-patch:
+      # No update-types filter: this catches minor/patch updates AND updates that
+      # Dependabot cannot classify (the OpenTelemetry bumps in #240-#242 carried no
+      # update-type), folding them all into a single quarterly PR. The semver-major
+      # ignore below still blocks classified majors (an unclassifiable major could
+      # slip through - an accepted tradeoff of dropping the filter).
+      examples-routine:
         applies-to: "version-updates"
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
     ignore:
       - dependency-name: "*"
         update-types:


### PR DESCRIPTION
## What

Follow-up to #228 (JBRes-9943) that trims routine-update PR fan-out exposed by the last Dependabot run.

### `/examples` → one grouped PR
- Renamed `examples-minor-patch` → `examples-routine` and **dropped its `update-types` filter**. Updates Dependabot can't classify — the OpenTelemetry bumps in #240/#241/#242 carried no update-type — now join the group instead of falling out to individual PRs, so all non-major version updates land in a single quarterly PR.
- Added `versioning-strategy: "increase-if-necessary"` to avoid needlessly raising lower bounds (e.g. `>=1.36.0 → >=1.44.0`).

### Docker → cross-directory grouping
- Renamed `docker-minor-patch` → `docker-routine`, **dropped `update-types`** (also catches prerelease tags like `3.15.0bN`, the #235 case), and added **`group-by: "dependency-name"`** so a shared image bump across `/orchestrator` and `/watcher` produces one cross-directory PR instead of one-per-directory.

The `semver-major` ignore still blocks classified majors in both groups. Security groups and `dependabot-security-automerge.yml` are unchanged.

## Two caveats (documented inline in the config)

1. **Docker can't be a single combined PR across *different* images.** `group-by: dependency-name` is the strongest lever Dependabot offers — it creates **one PR per distinct dependency** spanning directories. So `python` and `ghcr.io/astral-sh/uv` are separate PRs. Common case (a new python tag, uv unchanged) = exactly one cross-directory PR; two only when both images update in the same quarter.
2. **`versioning-strategy` is currently a no-op for `uv`.** The `uv` ecosystem does not yet honor it ([dependabot-core#12162](https://github.com/dependabot/dependabot-core/issues/12162)). The value is schema-valid and activates automatically once uv gains support; until then, lower-bound bumps on `/examples` still occur.

## Validation
- `uv run pre-commit run check-yaml` → Passed
- Config parsed; confirmed `group-by` inside the docker group and `versioning-strategy` at the `uv:/examples` entry level.

> Note: the group renames mean the first post-merge run opens freshly-named branches/PRs (`docker-routine`, `examples-routine`).