### PR TITLE
Group npm security updates for /website and add auto-merge diagnostics

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ version: 2
 #   delayed by this schedule.
 # - Routine minor/patch version updates run quarterly.
 # - Routine major version updates are ignored and must be initiated manually.
+# - The /website (npm) presentation site is security-only: routine version
+#   updates are disabled (open-pull-requests-limit: 0); security updates still flow.
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -280,5 +282,41 @@ updates:
           - "version-update:semver-major"
     commit-message:
       prefix: "[examples] "
+    labels:
+      - "dependencies"
+
+  # /website is the Docusaurus presentation site (its own package-lock.json). There
+  # is no requirement for routine npm version bumps here, so this block is
+  # security-only: open-pull-requests-limit: 0 disables routine version updates
+  # while leaving Dependabot's alert-driven security updates untouched (security
+  # updates have a separate internal limit of 10 and ignore this setting). The two
+  # security groups mirror every other ecosystem so npm security PRs are grouped by
+  # SemVer risk (security-minor-patch vs security-major) instead of arriving as one
+  # ungrouped PR per package (which is why #249/#250 landed separately before this).
+  # No `ignore` block is needed: with version updates off, only security updates
+  # remain, and security majors must still surface (grouped) for manual review.
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "quarterly"
+      time: "09:00"
+      timezone: "Europe/Amsterdam"
+    open-pull-requests-limit: 0
+    groups:
+      security-minor-patch:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      security-major:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    commit-message:
+      prefix: "[website] "
     labels:
       - "dependencies"

--- a/.github/workflows/dependabot-security-automerge.yml
+++ b/.github/workflows/dependabot-security-automerge.yml
@@ -32,15 +32,66 @@ jobs:
         with:
           github-token: ${{ github.token }}
 
-      # Fail closed: only the explicitly named security group and recognized
-      # minor/patch SemVer updates are eligible. Major or unclassified security
-      # updates remain open for human review.
+      # Single source of truth for the verdict, reused by both the merge step and
+      # the job summary. Fail-closed: only the explicitly named security group and a
+      # recognized minor/patch SemVer bump qualify. Major or unclassified security
+      # updates are intentionally skipped (NOT failed) and left for manual review.
+      # This step NEVER enables auto-merge and NEVER approves the PR — the human
+      # approval required by branch protection is untouched.
+      - name: Evaluate auto-merge eligibility
+        id: evaluate
+        env:
+          DEP_GROUP: ${{ steps.dependabot-metadata.outputs.dependency-group }}
+          UPDATE_TYPE: ${{ steps.dependabot-metadata.outputs.update-type }}
+        run: |
+          eligible=false
+          if [ "$DEP_GROUP" != "security-minor-patch" ]; then
+            reason="dependency group '${DEP_GROUP:-<none>}' is not 'security-minor-patch'; only grouped minor/patch security updates auto-merge"
+          elif [ "$UPDATE_TYPE" != "version-update:semver-minor" ] && [ "$UPDATE_TYPE" != "version-update:semver-patch" ]; then
+            reason="update type '${UPDATE_TYPE:-<none>}' is not a minor or patch bump; majors stay manual"
+          else
+            eligible=true
+            reason="grouped minor/patch security update"
+          fi
+          echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
+          echo "reason=$reason" >> "$GITHUB_OUTPUT"
+
+      # Enabling GitHub auto-merge does NOT bypass required reviews: the PR still
+      # needs the mandatory human approval and all required checks before it merges.
       - name: Enable auto-merge for minor and patch security updates
-        if: >-
-          steps.dependabot-metadata.outputs.dependency-group == 'security-minor-patch' &&
-          (steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' ||
-           steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor')
+        if: steps.evaluate.outputs.eligible == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: gh pr merge --auto --squash "$PR_URL"
+
+      # Always run so the outcome is visible in the run's Summary tab even when the
+      # merge step was skipped. A skipped merge is an expected, non-failing outcome.
+      - name: Report outcome
+        if: always()
+        env:
+          DEP_GROUP: ${{ steps.dependabot-metadata.outputs.dependency-group }}
+          UPDATE_TYPE: ${{ steps.dependabot-metadata.outputs.update-type }}
+          ELIGIBLE: ${{ steps.evaluate.outputs.eligible }}
+          REASON: ${{ steps.evaluate.outputs.reason }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ "$ELIGIBLE" = "true" ]; then
+            automerge="✅ enabled"
+            note="GitHub auto-merge was enabled. This does **not** approve the PR: it still requires the mandatory human approval and all required status checks before it merges."
+          else
+            automerge="⏭️ skipped (not a failure)"
+            note="Merge step skipped — ${REASON:-not eligible}. This PR must be reviewed and merged manually."
+          fi
+          {
+            echo "## Dependabot security auto-merge"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| PR | #${PR_NUMBER} |"
+            echo "| Dependency group | \`${DEP_GROUP:-<none>}\` |"
+            echo "| Update type | \`${UPDATE_TYPE:-<none>}\` |"
+            echo "| Auto-merge | ${automerge} |"
+            echo ""
+            echo "${note}"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Tightens the Dependabot configuration and the security auto-merge workflow so that
dependency updates are grouped predictably, routine noise stays low, and the auto-merge
job explains its own decisions — without ever weakening the repository's manual-approval
requirement.

## Changes

### `.github/dependabot.yml`
- **New `npm` block for `/website`** (the Docusaurus presentation site). It is
  **security-only**: `open-pull-requests-limit: 0` disables routine version bumps, while
  Dependabot's alert-driven security updates keep flowing (security updates have a
  separate internal limit of 10 and ignore this setting). Two groups mirror every other
  ecosystem — `security-minor-patch` and `security-major` (both `applies-to:
  security-updates`) — so npm security PRs are grouped by SemVer risk instead of arriving
  as one ungrouped PR per package. No `ignore` block: with version updates off, only
  security updates remain, and security majors must still surface (grouped) for manual
  review.
- **`/examples` verified, unchanged.** It already meets the intended policy: routine
  updates run **quarterly**, are folded into a single grouped PR (`examples-routine`,
  no `update-types` filter so unclassifiable bumps still land in the group), SemVer-major
  routine updates are ignored/manual, and alert-driven security updates are preserved
  (two `security-*` groups, no `target-branch`).

### `.github/workflows/dependabot-security-automerge.yml`
- **Single eligibility verdict.** A new `Evaluate auto-merge eligibility` step computes
  eligibility and a human-readable reason once, and both the merge step and the summary
  reuse it (fail-closed: only `security-minor-patch` + a minor/patch bump qualifies).
- **Job summary diagnostics.** A `Report outcome` step (`if: always()`) writes a
  `$GITHUB_STEP_SUMMARY` table showing the **dependency group**, **update type**,
  **whether auto-merge was enabled**, and — when skipped — **why**. A skipped merge is
  labelled "skipped (not a failure)" so it is not mistaken for a broken workflow.
- **Policy preserved.** Only grouped `security-minor-patch` minor/patch updates enable
  auto-merge. The workflow still never runs `gh pr review --approve`; enabling GitHub
  auto-merge does not bypass required reviews, so every PR — including security ones —
  still needs the mandatory human approval before it can merge. Security-major and
  unclassified updates remain fully manual.

## GitHub / Dependabot limitations worth noting
- **Auto-merge cannot approve.** `gh pr merge --auto` only queues the merge behind branch
  protection; it does not satisfy the required review. This is intentional and matches the
  requested policy — a human must approve every update.
- **Grouping is not retroactive.** Security PRs already open before this change
  (`/website` npm PRs) stay ungrouped; Dependabot only groups on its next security
  evaluation, at which point it can supersede the individual PRs with a grouped one.
- **Server base images stay manual.** The debian/ubuntu server base image tags live in a
  Python dict (`scripts/build_server_images.py`) behind a Jinja Dockerfile template and
  are not Dependabot-trackable — unchanged by this PR.

## Validation (without merging anything unsafe)
- `.github/dependabot.yml` parses and **passes the SchemaStore `dependabot-2.0.json`
  schema** (`open-pull-requests-limit: 0`, the `npm` ecosystem, and the two `applies-to:
  security-updates` groups are all schema-valid).
- Both YAML files parse cleanly; structural assertions confirm the `/website` block is
  security-only with two security groups and no `ignore`, and that `/examples` keeps its
  quarterly single-group routine policy with SemVer-major ignored.
- After merge, confirm via the Dependabot logs (Insights → Dependency graph → Dependabot):
  - a future `/website` security update is tagged with the `security-minor-patch` /
    `security-major` group;
  - a future `/examples` routine run produces one grouped PR rather than separate PRs;
  - a minor/patch security PR shows auto-merge **enabled** in the workflow summary yet
    stays **blocked** until a human approval is submitted (and the summary renders the
    group / update-type / enabled / skip-reason table).
