### PR TITLE
[JBRes-9953] Curated CHANGELOG.md + release automation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,139 @@
+name: Changelog
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version to generate (without the leading v, e.g. 0.11.0). The vX.Y.Z tag must exist."
+        required: true
+      previous:
+        description: "Previous version to diff against (optional; auto-detected from tags when omitted)."
+        required: false
+
+# contents: write   -> push the changelog branch and edit/create the GitHub Release
+# pull-requests: write -> open the CHANGELOG.md pull request
+# models: read      -> draft the Highlights via GitHub Models (built-in GITHUB_TOKEN, no secret)
+permissions:
+  contents: write
+  pull-requests: write
+  models: read
+
+jobs:
+  changelog:
+    name: Generate changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7.0.0
+        with:
+          ref: main
+          # Full history + tags are required to diff the release range.
+          fetch-depth: 0
+
+      - name: Resolve version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="${GITHUB_REF_NAME}"
+          fi
+          echo "VERSION=${VERSION#v}" >> "$GITHUB_ENV"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Build Highlights prompt
+        id: prep
+        env:
+          PREVIOUS: ${{ inputs.previous }}
+        run: |
+          ARGS=("$VERSION" --emit-highlights-prompt highlights-input.md)
+          if [ -n "$PREVIOUS" ]; then
+            ARGS+=(--previous "$PREVIOUS")
+          fi
+          uv run scripts/generate_changelog.py "${ARGS[@]}"
+          # Non-empty prompt -> there are substantive changes worth summarising.
+          if [ -s highlights-input.md ]; then echo "draft=true" >> "$GITHUB_OUTPUT"; fi
+
+      - name: Draft Highlights (GitHub Models)
+        id: highlights
+        if: steps.prep.outputs.draft == 'true'
+        uses: actions/ai-inference@v1
+        with:
+          # Runs on GitHub Models via the built-in GITHUB_TOKEN (models: read). No secret.
+          model: openai/gpt-4o
+          max-completion-tokens: 400
+          system-prompt: |
+            You write the 'Highlights' paragraph for a software release changelog.
+            Given the merged changes, write 2-4 sentences of plain prose summarising the
+            most meaningful, user-facing features and changes. Synthesise themes rather
+            than listing every change. Do not mention routine dependency bumps; mention a
+            dependency only if a major runtime dependency changed. No headings, no bullet
+            points, no marketing language — just factual prose a maintainer would write.
+          prompt-file: highlights-input.md
+
+      - name: Save drafted Highlights
+        if: steps.prep.outputs.draft == 'true'
+        env:
+          RESPONSE: ${{ steps.highlights.outputs.response }}
+        run: printf '%s\n' "$RESPONSE" > highlights.md
+
+      - name: Generate CHANGELOG and release notes
+        env:
+          PREVIOUS: ${{ inputs.previous }}
+        run: |
+          ARGS=("$VERSION" --force --release-notes-out release-notes.md)
+          if [ -n "$PREVIOUS" ]; then
+            ARGS+=(--previous "$PREVIOUS")
+          fi
+          if [ -f highlights.md ]; then
+            ARGS+=(--highlights-file highlights.md)
+          fi
+          uv run scripts/generate_changelog.py "${ARGS[@]}"
+
+      - name: Sync GitHub Release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${VERSION}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Updating notes for existing release $TAG."
+            gh release edit "$TAG" --notes-file release-notes.md
+          else
+            echo "Creating release $TAG."
+            gh release create "$TAG" --title "$TAG" --notes-file release-notes.md
+          fi
+
+      - name: Open CHANGELOG pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # --porcelain catches both modified and not-yet-tracked CHANGELOG.md.
+          if [ -z "$(git status --porcelain -- CHANGELOG.md)" ]; then
+            echo "CHANGELOG.md unchanged; nothing to open a PR for."
+            exit 0
+          fi
+          BRANCH="changelog/v${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Make an existing remote branch (from a previous run) visible so
+          # --force-with-lease can verify the lease on this fresh checkout.
+          git fetch origin "$BRANCH" 2>/dev/null || true
+          git switch -c "$BRANCH"
+          git add CHANGELOG.md
+          git commit -m "[changelog] add ${VERSION} section"
+          git push --force-with-lease -u origin "$BRANCH"
+          if gh pr view "$BRANCH" >/dev/null 2>&1; then
+            echo "PR for $BRANCH already exists; branch updated."
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "[changelog] Update CHANGELOG.md for ${VERSION}" \
+              --body "Automated changelog for \`v${VERSION}\`, generated by \`scripts/generate_changelog.py\`. Review the \`### Highlights\` paragraph and edit if needed before merging."
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,272 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Sections are generated from merged pull requests by
+[`scripts/generate_changelog.py`](scripts/generate_changelog.py); the `Highlights`
+paragraph is drafted by an LLM (via GitHub Models) and may be edited by hand.
+
+## [0.10.0] - 2026-06-18
+
+### Highlights
+
+This release brings MCP (Model Context Protocol) support across the stack: IdeGYM servers now
+expose their MCP tools through the orchestrator's MCP server, and the `mcp-steroid` plugin can be
+used from the IntelliJ IDEA and PyCharm plugins. GKE-based server checkpoint/restore matures with a
+snapshot-preparation pipeline, asynchronous trigger cleanup, and a `snapshot()` method on
+`IdeGYMServer`. The cleanup watcher becomes a standalone service, and the Helm chart gains UX
+improvements and pod-snapshot documentation.
+
+### Features
+
+- extract cleanup watcher into a standalone service (JBRes-9093, [#141](https://github.com/JetBrains-Research/idegym/pull/141))
+- make configure_logging idempotent to stop duplicate log lines ([#144](https://github.com/JetBrains-Research/idegym/pull/144))
+- ClusterRole + ClusterBindings for orchestrator SA (JBRes-9587, [#143](https://github.com/JetBrains-Research/idegym/pull/143))
+- add mcp session hash, sticky sessions and reduce amount of workers ([#129](https://github.com/JetBrains-Research/idegym/pull/129))
+- add documentation for pod-snapshot, update Chart (JBRes-9477, [#130](https://github.com/JetBrains-Research/idegym/pull/130))
+- add snapshot method to IdeGYMServer (JBRes-9577, [#131](https://github.com/JetBrains-Research/idegym/pull/131))
+- initial implementation for checkpoint preparation pipeline (JBRes-9180, [#119](https://github.com/JetBrains-Research/idegym/pull/119))
+- Updated README.md (JBRes-9505, [#120](https://github.com/JetBrains-Research/idegym/pull/120))
+- Clean Trigger's CRD after snapshotting, wait for snapshot being taken as async operation (JBRes-9303, [#118](https://github.com/JetBrains-Research/idegym/pull/118))
+- Snapshot/restore functionality various improvements ([#117](https://github.com/JetBrains-Research/idegym/pull/117))
+- Documentation for MCP tools ([#110](https://github.com/JetBrains-Research/idegym/pull/110))
+- Helm UX improvements (JBRes-9364, [#108](https://github.com/JetBrains-Research/idegym/pull/108))
+- Showing MCP tools from IdeGYM servers through orchestrator's mcp server (JBRes-9332, [#102](https://github.com/JetBrains-Research/idegym/pull/102))
+- Helm chart (JBRes-8916, [#97](https://github.com/JetBrains-Research/idegym/pull/97))
+- allow to use mcp-steroid plugin in idea and pycharm plugins (JBRes-9207, [#99](https://github.com/JetBrains-Research/idegym/pull/99))
+
+### Bug Fixes
+
+- Pre-release fixes (JBRes-9587, [#132](https://github.com/JetBrains-Research/idegym/pull/132))
+- Checkpoint / Restore API tweaks, snapshot-id propagation to the client fix (JBRes-9479, [#116](https://github.com/JetBrains-Research/idegym/pull/116))
+
+### Documentation
+
+- add some architectural diagrams ([#142](https://github.com/JetBrains-Research/idegym/pull/142))
+
+### Dependencies
+
+Notable upgrades:
+
+- `cryptography`: 46.0.7 → 48.0.1 ([#180](https://github.com/JetBrains-Research/idegym/pull/180))
+- `cryptography`: 47.0.0 → 48.0.1 ([#174](https://github.com/JetBrains-Research/idegym/pull/174))
+- `structlog`: 25.5.0 → 26.1.0 ([#166](https://github.com/JetBrains-Research/idegym/pull/166))
+- `kubernetes-asyncio`: 35.0.1 → 36.1.0 ([#165](https://github.com/JetBrains-Research/idegym/pull/165))
+- `kubernetes`: 35.0.0 → 36.0.1 ([#156](https://github.com/JetBrains-Research/idegym/pull/156))
+
+<details>
+<summary>50 routine dependency updates</summary>
+
+- `python-multipart`: 0.0.27 → 0.0.31 ([#178](https://github.com/JetBrains-Research/idegym/pull/178))
+- `starlette`: 1.0.1 → 1.3.1 ([#179](https://github.com/JetBrains-Research/idegym/pull/179))
+- `python-multipart`: 0.0.27 → 0.0.31 ([#173](https://github.com/JetBrains-Research/idegym/pull/173))
+- `starlette`: 1.2.1 → 1.3.1 ([#175](https://github.com/JetBrains-Research/idegym/pull/175))
+- `aiohttp`: 3.14.0 → 3.14.1 ([#176](https://github.com/JetBrains-Research/idegym/pull/176))
+- `pyjwt`: 2.12.1 → 2.13.0 ([#172](https://github.com/JetBrains-Research/idegym/pull/172))
+- `pyjwt`: 2.12.1 → 2.13.0 ([#171](https://github.com/JetBrains-Research/idegym/pull/171))
+- `astral-sh/setup-uv`: 8.1.0 → 8.2.0 ([#163](https://github.com/JetBrains-Research/idegym/pull/163))
+- `ruff`: 0.15.15 → 0.15.16 ([#164](https://github.com/JetBrains-Research/idegym/pull/164))
+- Update fastapi[standard] requirement ([#167](https://github.com/JetBrains-Research/idegym/pull/167))
+- `uvicorn`: 0.48.0 → 0.49.0 ([#168](https://github.com/JetBrains-Research/idegym/pull/168))
+- `postgresql`: 18.7.2 → 18.7.3 ([#169](https://github.com/JetBrains-Research/idegym/pull/169))
+- Bump python in /orchestrator in the python group ([#152](https://github.com/JetBrains-Research/idegym/pull/152))
+- Bump actions/checkout in the core group across 1 directory ([#148](https://github.com/JetBrains-Research/idegym/pull/148))
+- Bump the observability group across 1 directory with 3 updates ([#158](https://github.com/JetBrains-Research/idegym/pull/158))
+- `starlette`: 1.0.0 → 1.0.1 ([#146](https://github.com/JetBrains-Research/idegym/pull/146))
+- `postgresql`: 18.7.0 → 18.7.2 ([#150](https://github.com/JetBrains-Research/idegym/pull/150))
+- Bump docker/setup-docker-action in the docker group ([#151](https://github.com/JetBrains-Research/idegym/pull/151))
+- Bump pytest-asyncio in the testing group ([#153](https://github.com/JetBrains-Research/idegym/pull/153))
+- `starlette`: 1.0.0 → 1.2.1 ([#154](https://github.com/JetBrains-Research/idegym/pull/154))
+- Update fastapi[standard] requirement ([#155](https://github.com/JetBrains-Research/idegym/pull/155))
+- `ruff`: 0.15.13 → 0.15.15 ([#157](https://github.com/JetBrains-Research/idegym/pull/157))
+- `aiohttp`: 3.13.5 → 3.14.0 ([#145](https://github.com/JetBrains-Research/idegym/pull/145))
+- `greenlet`: 3.5.0 → 3.5.1 ([#135](https://github.com/JetBrains-Research/idegym/pull/135))
+- Bump the opentelemetry group across 1 directory with 13 updates ([#134](https://github.com/JetBrains-Research/idegym/pull/134))
+- Bump the observability group across 1 directory with 2 updates ([#139](https://github.com/JetBrains-Research/idegym/pull/139))
+- `sqlalchemy`: 2.0.49 → 2.0.50 ([#136](https://github.com/JetBrains-Research/idegym/pull/136))
+- Bump the docker group with 3 updates ([#133](https://github.com/JetBrains-Research/idegym/pull/133))
+- `uvicorn`: 0.47.0 → 0.48.0 ([#137](https://github.com/JetBrains-Research/idegym/pull/137))
+- Update fastapi[standard] requirement ([#138](https://github.com/JetBrains-Research/idegym/pull/138))
+- `postgresql`: 18.6.7 → 18.7.0 ([#140](https://github.com/JetBrains-Research/idegym/pull/140))
+- `fastmcp`: 3.2.4 → 3.3.1 ([#123](https://github.com/JetBrains-Research/idegym/pull/123))
+- `requests`: 2.33.1 → 2.34.2 ([#125](https://github.com/JetBrains-Research/idegym/pull/125))
+- Bump python in /orchestrator in the python group ([#127](https://github.com/JetBrains-Research/idegym/pull/127))
+- Bump the observability group in /charts/idegym with 3 updates ([#128](https://github.com/JetBrains-Research/idegym/pull/128))
+- Update fastapi[standard] requirement ([#126](https://github.com/JetBrains-Research/idegym/pull/126))
+- `uvicorn`: 0.46.0 → 0.47.0 ([#124](https://github.com/JetBrains-Research/idegym/pull/124))
+- `ruff`: 0.15.12 → 0.15.13 ([#122](https://github.com/JetBrains-Research/idegym/pull/122))
+- Bump the docker group with 2 updates ([#121](https://github.com/JetBrains-Research/idegym/pull/121))
+- `idna`: 3.13 → 3.15 ([#115](https://github.com/JetBrains-Research/idegym/pull/115))
+- `idna`: 3.11 → 3.15 ([#114](https://github.com/JetBrains-Research/idegym/pull/114))
+- `postgresql`: 18.6.4 → 18.6.7 ([#113](https://github.com/JetBrains-Research/idegym/pull/113))
+- `tomlkit`: 0.14.0 → 0.15.0 ([#112](https://github.com/JetBrains-Research/idegym/pull/112))
+- `pydantic`: 2.13.3 → 2.13.4 ([#111](https://github.com/JetBrains-Research/idegym/pull/111))
+- `authlib`: 1.6.11 → 1.6.12 ([#109](https://github.com/JetBrains-Research/idegym/pull/109))
+- Update fastapi[standard] requirement ([#107](https://github.com/JetBrains-Research/idegym/pull/107))
+- `urllib3`: 2.6.3 → 2.7.0 ([#103](https://github.com/JetBrains-Research/idegym/pull/103))
+- `urllib3`: 2.6.3 → 2.7.0 ([#104](https://github.com/JetBrains-Research/idegym/pull/104))
+- `python-multipart`: 0.0.26 → 0.0.27 ([#100](https://github.com/JetBrains-Research/idegym/pull/100))
+- Update fastapi[standard] requirement ([#101](https://github.com/JetBrains-Research/idegym/pull/101))
+
+</details>
+
+## [0.9.0] - 2026-05-08
+
+### Highlights
+
+This release introduces the plugin system — plugins for tools and rewards, plus full PyCharm and
+IntelliJ IDEA plugins — along with the initial MCP server implementation and an API for GKE pod
+checkpointing. It adds support for dedicated Kubernetes node pools and an `examples/` folder with
+OpenEnv and agentic RL-training (VERL) integrations.
+
+### Features
+
+- introduce full pycharm and idea plugins (JBRes-9072, [#93](https://github.com/JetBrains-Research/idegym/pull/93))
+- Introducing plugins for tools and rewards (JBRes-9069, [#91](https://github.com/JetBrains-Research/idegym/pull/91))
+- Introduce API for GKE pod checkpoint (JBRes-9089, [#92](https://github.com/JetBrains-Research/idegym/pull/92))
+- Initial MCP server implementation (JBRes-9071, [#90](https://github.com/JetBrains-Research/idegym/pull/90))
+- Enhance configuration model classes for resource specifications (JBRes-6033, [#87](https://github.com/JetBrains-Research/idegym/pull/87))
+- Example of the agentic RL training using IDEGYM and VERL. ([#89](https://github.com/JetBrains-Research/idegym/pull/89))
+- github issue templates (JBRes-9108, [#86](https://github.com/JetBrains-Research/idegym/pull/86))
+- move hydra and alembic config and other files inside the module (JBRes-5360, [#82](https://github.com/JetBrains-Research/idegym/pull/82))
+- Support for dedicated node pools (JBRes-8920, [#69](https://github.com/JetBrains-Research/idegym/pull/69))
+- Introduce examples folder and add OpenEnv integration examples there (JBRes-9011, [#66](https://github.com/JetBrains-Research/idegym/pull/66))
+
+### Bug Fixes
+
+- Added bug report and feature request templates ([#85](https://github.com/JetBrains-Research/idegym/pull/85))
+- Fix incomplete logging on orchestrator (JBRes-8864, [#80](https://github.com/JetBrains-Research/idegym/pull/80))
+
+### Documentation
+
+- fix pre-commit issue in docs ([#73](https://github.com/JetBrains-Research/idegym/pull/73))
+
+### Infrastructure
+
+- fix pg container clean up ([#98](https://github.com/JetBrains-Research/idegym/pull/98))
+- CI changes (JBRes-9012, [#74](https://github.com/JetBrains-Research/idegym/pull/74))
+- fix push pull registry urls and fix web socket connection closing ([#72](https://github.com/JetBrains-Research/idegym/pull/72))
+- add database client tests ([#67](https://github.com/JetBrains-Research/idegym/pull/67))
+
+### Dependencies
+
+<details>
+<summary>13 routine dependency updates</summary>
+
+- `ruff`: 0.15.11 → 0.15.12 ([#96](https://github.com/JetBrains-Research/idegym/pull/96))
+- Bump pytest-randomly in the testing group ([#94](https://github.com/JetBrains-Research/idegym/pull/94))
+- `pre-commit`: 4.5.1 → 4.6.0 ([#95](https://github.com/JetBrains-Research/idegym/pull/95))
+- `astral-sh/setup-uv`: 8.0.0 → 8.1.0 ([#88](https://github.com/JetBrains-Research/idegym/pull/88))
+- `astral-sh/setup-uv`: 7 → 8.0.0 ([#81](https://github.com/JetBrains-Research/idegym/pull/81))
+- Update testcontainers[postgres] requirement ([#79](https://github.com/JetBrains-Research/idegym/pull/79))
+- Bump prom/prometheus ([#76](https://github.com/JetBrains-Research/idegym/pull/76))
+- Bump grafana/tempo in /orchestrator/kubernetes/tempo ([#77](https://github.com/JetBrains-Research/idegym/pull/77))
+- `ruff`: 0.15.10 → 0.15.11 ([#78](https://github.com/JetBrains-Research/idegym/pull/78))
+- Bump grafana/grafana in /orchestrator/kubernetes/grafana ([#75](https://github.com/JetBrains-Research/idegym/pull/75))
+- `authlib`: 1.6.10 → 1.6.11 ([#71](https://github.com/JetBrains-Research/idegym/pull/71))
+- `mako`: 1.3.10 → 1.3.11 ([#70](https://github.com/JetBrains-Research/idegym/pull/70))
+- `python-multipart`: 0.0.22 → 0.0.26 ([#68](https://github.com/JetBrains-Research/idegym/pull/68))
+
+</details>
+
+## [0.8.0] - 2026-04-14
+
+### Highlights
+
+The first tagged release of IdeGYM. Highlights include building images from arbitrary base images
+via Kaniko, FIFO reuse of finished servers, owner-reference-based Kubernetes resource cleanup,
+OpenEnv server compatibility, and a consistent SQL table naming scheme. It establishes the testing
+foundation with full integration and end-to-end suites running in minikube.
+
+### Features
+
+- clean and update docstrings, descriptors and comments throughout the whole codebase (JBRes-9010, [#64](https://github.com/JetBrains-Research/idegym/pull/64))
+- Support arbitrary base image building (JBRes-5153, [#39](https://github.com/JetBrains-Research/idegym/pull/39))
+- introduce kaniko minikube tests ([#50](https://github.com/JetBrains-Research/idegym/pull/50))
+- Add compatibility with OpenEnv servers ([#47](https://github.com/JetBrains-Research/idegym/pull/47))
+- Add full integration tests in minikube (JBRes-8782, [#33](https://github.com/JetBrains-Research/idegym/pull/33))
+- Use owner references for easier resource cleanup (JBRes-8762, [#35](https://github.com/JetBrains-Research/idegym/pull/35))
+- return finished server in fifo order for new requests (JBRes-8318, [#32](https://github.com/JetBrains-Research/idegym/pull/32))
+- Cleanup (JBRes-4758, JBRes-4975, [#22](https://github.com/JetBrains-Research/idegym/pull/22))
+- Use secret reference for tracing credentials (JBRes-6154, [#14](https://github.com/JetBrains-Research/idegym/pull/14))
+- add run_as_root parameter as a column in database and use it when reusing finished servers (JBRes-4758, [#13](https://github.com/JetBrains-Research/idegym/pull/13))
+- update `uv` to the latest version (JBRes-4975, [#10](https://github.com/JetBrains-Research/idegym/pull/10))
+- clean up orphaned kaniko jobs; better error handling during status monitoring (JBRes-6036, [#12](https://github.com/JetBrains-Research/idegym/pull/12))
+- Consistent SQL table naming scheme (JBRes-5355, [#11](https://github.com/JetBrains-Research/idegym/pull/11))
+- Initial commit
+
+### Bug Fixes
+
+- Fix handling of database migration locks (JBRes-8664, [#9](https://github.com/JetBrains-Research/idegym/pull/9))
+
+### Documentation
+
+- review http error codes, document them and fix some issues related to it ([#63](https://github.com/JetBrains-Research/idegym/pull/63))
+- add proper documentation ([#55](https://github.com/JetBrains-Research/idegym/pull/55))
+
+### Infrastructure
+
+- disable e2e ci for now because runners are not available ([#65](https://github.com/JetBrains-Research/idegym/pull/65))
+- E2E tests in CI (JBRes-8914, [#49](https://github.com/JetBrains-Research/idegym/pull/49))
+
+### Dependencies
+
+Notable upgrades:
+
+- `kubernetes-asyncio`: 32.3.2 → 35.0.1 ([#58](https://github.com/JetBrains-Research/idegym/pull/58))
+- `pytest-randomly`: 3.16.0 → 4.0.1 ([#43](https://github.com/JetBrains-Research/idegym/pull/43))
+- `pytest`: 8.4.1 → 9.0.2 ([#31](https://github.com/JetBrains-Research/idegym/pull/31))
+
+<details>
+<summary>42 routine dependency updates</summary>
+
+- Bump python in /orchestrator ([#56](https://github.com/JetBrains-Research/idegym/pull/56))
+- Bump prom/prometheus ([#57](https://github.com/JetBrains-Research/idegym/pull/57))
+- `ruff`: 0.15.9 → 0.15.10 ([#59](https://github.com/JetBrains-Research/idegym/pull/59))
+- `pyyaml`: 6.0.2 → 6.0.3 ([#60](https://github.com/JetBrains-Research/idegym/pull/60))
+- `pytest`: 9.0.2 → 9.0.3 ([#61](https://github.com/JetBrains-Research/idegym/pull/61))
+- `pytest`: 9.0.2 → 9.0.3 ([#62](https://github.com/JetBrains-Research/idegym/pull/62))
+- `requests`: 2.33.0 → 2.33.1 ([#53](https://github.com/JetBrains-Research/idegym/pull/53))
+- `ruff`: 0.15.8 → 0.15.9 ([#52](https://github.com/JetBrains-Research/idegym/pull/52))
+- Bump prom/prometheus ([#51](https://github.com/JetBrains-Research/idegym/pull/51))
+- `aiohttp`: 3.13.3 → 3.13.4 ([#48](https://github.com/JetBrains-Research/idegym/pull/48))
+- `pygments`: 2.19.1 → 2.20.0 ([#46](https://github.com/JetBrains-Research/idegym/pull/46))
+- `pre-commit`: 4.3.0 → 4.5.1 ([#44](https://github.com/JetBrains-Research/idegym/pull/44))
+- `ruff`: 0.15.7 → 0.15.8 ([#45](https://github.com/JetBrains-Research/idegym/pull/45))
+- `grafana/grafana`: 12.4.1 → 12.4.2 ([#40](https://github.com/JetBrains-Research/idegym/pull/40))
+- `python-on-whales`: 0.78.0 → 0.81.0 ([#41](https://github.com/JetBrains-Research/idegym/pull/41))
+- `tqdm`: 4.67.1 → 4.67.3 ([#42](https://github.com/JetBrains-Research/idegym/pull/42))
+- `jinja2`: 3.1.5 → 3.1.6 ([#38](https://github.com/JetBrains-Research/idegym/pull/38))
+- `h11`: 0.14.0 → 0.16.0 ([#37](https://github.com/JetBrains-Research/idegym/pull/37))
+- `starlette`: 0.45.3 → 0.49.1 ([#36](https://github.com/JetBrains-Research/idegym/pull/36))
+- `virtualenv`: 20.29.2 → 20.36.1 ([#20](https://github.com/JetBrains-Research/idegym/pull/20))
+- `aiohttp`: 3.12.15 → 3.13.3 ([#21](https://github.com/JetBrains-Research/idegym/pull/21))
+- `urllib3`: 2.3.0 → 2.6.3 ([#19](https://github.com/JetBrains-Research/idegym/pull/19))
+- `protobuf`: 6.31.1 → 6.33.5 ([#18](https://github.com/JetBrains-Research/idegym/pull/18))
+- `python-multipart`: 0.0.20 → 0.0.22 ([#17](https://github.com/JetBrains-Research/idegym/pull/17))
+- `filelock`: 3.17.0 → 3.20.3 ([#16](https://github.com/JetBrains-Research/idegym/pull/16))
+- Bump grafana/tempo in /orchestrator/kubernetes/tempo ([#15](https://github.com/JetBrains-Research/idegym/pull/15))
+- `docker/login-action`: 3 → 4 ([#7](https://github.com/JetBrains-Research/idegym/pull/7))
+- Bump grafana/grafana in /orchestrator/kubernetes/grafana ([#6](https://github.com/JetBrains-Research/idegym/pull/6))
+- `docker/build-push-action`: 6 → 7 ([#5](https://github.com/JetBrains-Research/idegym/pull/5))
+- Bump python in /orchestrator ([#4](https://github.com/JetBrains-Research/idegym/pull/4))
+- `docker/setup-buildx-action`: 3 → 4 ([#3](https://github.com/JetBrains-Research/idegym/pull/3))
+- `docker/setup-docker-action`: 4 → 5 ([#2](https://github.com/JetBrains-Research/idegym/pull/2))
+- `astral-sh/setup-uv`: 6 → 7 ([#1](https://github.com/JetBrains-Research/idegym/pull/1))
+- `docker/build-push-action`: 6 → 7 ([#23](https://github.com/JetBrains-Research/idegym/pull/23))
+- `docker/login-action`: 3 → 4 ([#24](https://github.com/JetBrains-Research/idegym/pull/24))
+- `docker/setup-docker-action`: 4 → 5 ([#25](https://github.com/JetBrains-Research/idegym/pull/25))
+- `docker/setup-buildx-action`: 3 → 4 ([#26](https://github.com/JetBrains-Research/idegym/pull/26))
+- `supervisor`: 4.2.5 → 4.3.0 ([#27](https://github.com/JetBrains-Research/idegym/pull/27))
+- `pytest-mock`: 3.14.1 → 3.15.1 ([#28](https://github.com/JetBrains-Research/idegym/pull/28))
+- `tomlkit`: 0.13.3 → 0.14.0 ([#29](https://github.com/JetBrains-Research/idegym/pull/29))
+- `pytest-asyncio`: 1.1.0 → 1.3.0 ([#30](https://github.com/JetBrains-Research/idegym/pull/30))
+- `requests`: 2.32.5 → 2.33.0 ([#34](https://github.com/JetBrains-Research/idegym/pull/34))
+
+</details>
+
+[0.10.0]: https://github.com/JetBrains-Research/idegym/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/JetBrains-Research/idegym/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/JetBrains-Research/idegym/releases/tag/v0.8.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,82 @@
+# Releasing
+
+IdeGYM releases are cut by pushing a `vX.Y.Z` tag. Two workflows react to that tag:
+
+- **`.github/workflows/publish.yml`** builds and publishes the server/orchestrator/watcher
+  images, the example image, the Helm chart, and the Python packages.
+- **`.github/workflows/changelog.yml`** generates a curated [`CHANGELOG.md`](CHANGELOG.md)
+  section for the version, syncs the GitHub Release notes, and opens a pull request with the
+  changelog change for review.
+
+## Changelog automation
+
+GitHub's own "auto-generated release notes" list every merged pull request — including dozens of
+dependency bumps — which is hard to read. [`scripts/generate_changelog.py`](scripts/generate_changelog.py)
+turns the merged history between two tags into a readable [Keep a Changelog][keepachangelog] entry:
+
+- pull requests are grouped into **Features / Bug Fixes / Documentation / Infrastructure /
+  Dependencies** from their title prefixes (`[docs]`, `[ci]`, `[e2e]`, …) and author;
+- issue tickets (`JBRes-XXXX`) are referenced as plain IDs and pull requests are linked;
+- dependency bumps are collapsed into a `<details>` block, and only **significant** upgrades are
+  surfaced above the fold;
+- a short **Highlights** paragraph is drafted by an LLM (see below).
+
+Categorisation is heuristic — it reads pull-request titles, so an occasional entry lands in a
+neighbouring section. Fix those by editing the generated section before merging the changelog PR.
+
+### "Significant" dependencies
+
+A dependency upgrade is surfaced as *notable* only when a library's **major version increases**
+(e.g. `kubernetes 35 → 36`). GitHub Actions and container images (slash-named entries such as
+`docker/build-push-action` or `grafana/grafana`) are treated as routine infrastructure pins and
+kept in the collapsed block even when their major version changes. Everything else is collapsed
+too. Tweak `is_significant_dependency` in the script to change this.
+
+### Highlights (GitHub Models)
+
+The `Highlights` paragraph is drafted in the workflow, **not** by the script. `changelog.yml`
+runs the generator with `--emit-highlights-prompt` to produce the prompt, hands it to
+[`actions/ai-inference`](https://github.com/marketplace/actions/ai-inference) which calls
+[GitHub Models](https://docs.github.com/en/github-models) using the built-in `GITHUB_TOKEN`
+(`permissions: models: read`, no secret required), then feeds the draft back with
+`--highlights-file`. The model is `openai/gpt-4o` by default — change the `model:` input (or set
+`provider: copilot` with e.g. `claude-sonnet-4.5` to route through the org's Copilot subscription).
+If there are no substantive changes (dependency-only release) or the draft step is skipped, the
+script writes a `_TODO_` placeholder and generation still succeeds. Always review the paragraph; it
+is meant to be edited by hand when needed.
+
+## Running the generator locally
+
+```bash
+# Auto-detect the previous tag from the range vPREV..vX.Y.Z (writes a Highlights placeholder):
+uv run scripts/generate_changelog.py 0.11.0
+
+# Preview to stdout without touching the file:
+uv run scripts/generate_changelog.py 0.11.0 --print
+
+# Explicit range / regenerate an existing section:
+uv run scripts/generate_changelog.py 0.11.0 --previous 0.10.0 --force
+
+# Supply your own Highlights text instead of the placeholder:
+uv run scripts/generate_changelog.py 0.11.0 --highlights-file my-highlights.txt
+```
+
+The script has no third-party dependencies, so `uv run` needs no project sync. The `vX.Y.Z` tag
+must exist locally (`git fetch --tags`) because the range is read from `git log`.
+
+To **backfill** older releases, run the generator once per version (oldest first keeps the newest
+section on top); edit the `_TODO_` Highlights afterwards:
+
+```bash
+for v in 0.8.0 0.9.0 0.10.0; do
+  uv run scripts/generate_changelog.py "$v" --force
+done
+```
+
+## Manual / re-runs in CI
+
+The changelog workflow also accepts a `workflow_dispatch` with a `version` (and optional
+`previous`) input, so a release can be regenerated or backfilled from the Actions tab without
+re-tagging.
+
+[keepachangelog]: https://keepachangelog.com/en/1.1.0/

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -1,0 +1,622 @@
+#!/usr/bin/env -S uv run --script --quiet
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+"""Generate a meaningful, human-readable ``CHANGELOG.md`` entry for a release.
+
+The GitHub "auto-generated release notes" are a flat dump of every merged pull
+request (including dozens of dependency bumps). This script turns the merged
+history between two tags into a curated `Keep a Changelog`_ section:
+
+* pull requests are grouped into ``Features`` / ``Bug Fixes`` / ``Documentation``
+  / ``Infrastructure`` / ``Dependencies`` from their title prefixes and author,
+* issue tickets (``JBRes-XXXX``) are referenced as plain IDs and pull requests are linked,
+* dependency bumps are collapsed into a ``<details>`` block, with only the
+  *significant* (major-version) upgrades surfaced above the fold,
+* an optional ``Highlights`` paragraph summarises the meaningful changes. This
+  script does **not** call an LLM itself: ``--emit-highlights-prompt`` writes the
+  prompt for an external model (the workflow drafts it via GitHub Models), and
+  ``--highlights-file`` reads the drafted text back. Without it a manual-fill
+  placeholder is written, so generation always succeeds.
+
+The whole script is deterministic and I/O-free apart from git and the local
+filesystem, so its logic can be unit tested without a network.
+
+.. _Keep a Changelog: https://keepachangelog.com/en/1.1.0/
+
+Usage::
+
+    scripts/generate_changelog.py 0.11.0                     # auto-detect previous tag
+    scripts/generate_changelog.py 0.11.0 --previous 0.10.0   # explicit range
+    scripts/generate_changelog.py 0.11.0 --print             # stdout, don't touch the file
+    scripts/generate_changelog.py 0.11.0 --highlights-file hl.txt  # use a pre-drafted Highlights
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from argparse import ArgumentParser, Namespace
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_REPO = "JetBrains-Research/idegym"
+DEFAULT_CHANGELOG = "CHANGELOG.md"
+HIGHLIGHTS_PLACEHOLDER = "_TODO: summarise the headline changes of this release._"
+
+# Plain bullet-list categories, in render order. Highlights (always emitted) and
+# Dependencies (collapsed <details> block) are rendered separately and are not keys here.
+CATEGORY_TITLES: dict[str, str] = {
+    "features": "Features",
+    "fixes": "Bug Fixes",
+    "documentation": "Documentation",
+    "infrastructure": "Infrastructure",
+}
+
+# Leading ``[tag]`` prefixes that route a PR into the Infrastructure section.
+INFRA_TAGS = {
+    "ci",
+    "helm",
+    "e2e",
+    "integration-tests",
+    "integration",
+    "tests",
+    "test",
+    "build",
+    "workflow",
+    "actions",
+    "chart",
+    "deploy",
+    "deployment",
+    "docker",
+}
+DOC_TAGS = {"docs", "doc", "documentation"}
+
+_INFRA_KEYWORDS = re.compile(r"\b(ci|workflow|github actions|pre-commit|dependabot)\b", re.IGNORECASE)
+_FIX_KEYWORDS = re.compile(r"\b(fix|fixes|fixed|fixing|bug|bugfix|hotfix)\b", re.IGNORECASE)
+_TICKET_RE = re.compile(r"JBRes-(\d+)", re.IGNORECASE)
+_LEADING_TAGS_RE = re.compile(r"^\s*(\[[^\]]*\]\s*)+")
+_PR_SUFFIX_RE = re.compile(r"\s*\(#(\d+)\)\s*$")
+_VERSION_TAG_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+
+# Dependabot title shapes:
+#   Bump X from A to B [in /path] [in the <group> group]
+#   Update X requirement from >=A to >=B
+_DEP_BUMP_RE = re.compile(r"^Bump\s+(?P<name>.+?)\s+from\s+(?P<frm>\S+)\s+to\s+(?P<to>\S+)", re.IGNORECASE)
+_DEP_REQ_RE = re.compile(r"^Update\s+(?P<name>.+?)\s+requirement\s+from\s+\S+\s+to\s+(?P<to>\S+)", re.IGNORECASE)
+_DEP_GROUP_RE = re.compile(r"^Bump\s+the\s+.+\bgroup\b", re.IGNORECASE)
+
+GIT_LOG_SEP = "\x1f"
+GIT_LOG_FORMAT = f"%H{GIT_LOG_SEP}%an{GIT_LOG_SEP}%s"
+
+
+@dataclass(frozen=True)
+class PullRequest:
+    """A merged pull request derived from a squash-merge commit."""
+
+    title: str
+    number: Optional[int] = None
+    author: str = ""
+    is_dependency: bool = False
+    tickets: tuple[str, ...] = ()
+    # Parsed dependency-bump fields (only for dependency PRs when parseable).
+    dep_name: Optional[str] = None
+    dep_from: Optional[str] = None
+    dep_to: Optional[str] = None
+
+    @property
+    def display_title(self) -> str:
+        """The PR title with leading ``[tag]`` prefixes and the ``(#N)`` suffix removed."""
+        stripped = _LEADING_TAGS_RE.sub("", self.title)
+        stripped = _PR_SUFFIX_RE.sub("", stripped)
+        return stripped.strip()
+
+
+@dataclass
+class ReleaseChanges:
+    """The categorised set of changes for a single release."""
+
+    version: str
+    date: str
+    features: list[PullRequest] = field(default_factory=list)
+    fixes: list[PullRequest] = field(default_factory=list)
+    documentation: list[PullRequest] = field(default_factory=list)
+    infrastructure: list[PullRequest] = field(default_factory=list)
+    dependencies: list[PullRequest] = field(default_factory=list)
+
+    def bucket(self, key: str) -> list[PullRequest]:
+        return getattr(self, key)
+
+    @property
+    def substantive(self) -> list[PullRequest]:
+        """Non-dependency changes, used to prompt the highlights draft."""
+        return self.features + self.fixes + self.documentation + self.infrastructure
+
+
+# --------------------------------------------------------------------------- #
+# Parsing & categorisation (pure)
+# --------------------------------------------------------------------------- #
+def _looks_like_dependency(title: str) -> bool:
+    # Also match grouped bumps ("Bump the <group> group ..."), which carry no
+    # "from ... to ..." and would otherwise only be caught by the bot author.
+    return bool(_DEP_BUMP_RE.match(title) or _DEP_REQ_RE.match(title) or _DEP_GROUP_RE.match(title))
+
+
+def _leading_tags(title: str) -> list[str]:
+    """Return the lowercased words inside the leading ``[...]`` groups of a title."""
+    match = _LEADING_TAGS_RE.match(title)
+    if not match:
+        return []
+    return [tag.lower() for tag in re.findall(r"\[([^\]]+)\]", match.group(0))]
+
+
+def _parse_dependency(title: str) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Extract ``(name, from, to)`` from a dependabot title, where parseable."""
+    if _DEP_GROUP_RE.match(title):
+        return None, None, None
+    bump = _DEP_BUMP_RE.match(title)
+    if bump:
+        return bump.group("name"), bump.group("frm"), bump.group("to")
+    req = _DEP_REQ_RE.match(title)
+    if req:
+        return req.group("name"), None, req.group("to")
+    return None, None, None
+
+
+def parse_pull_request(subject: str, author: str = "") -> PullRequest:
+    """Build a :class:`PullRequest` from a (squash-merge) commit subject."""
+    number: Optional[int] = None
+    suffix = _PR_SUFFIX_RE.search(subject)
+    if suffix:
+        number = int(suffix.group(1))
+
+    # Normalise to the canonical ``JBRes-<n>`` form regardless of input casing.
+    tickets = tuple(dict.fromkeys(f"JBRes-{num}" for num in _TICKET_RE.findall(subject)))
+
+    # Strip a leading ``[tag]`` and the ``(#N)`` suffix before matching the "Bump ..."
+    # shape, so a bracket-prefixed dependabot PR is detected even without the bot author.
+    core = _LEADING_TAGS_RE.sub("", _PR_SUFFIX_RE.sub("", subject)).strip()
+    is_dep = author == "dependabot[bot]" or _looks_like_dependency(core)
+
+    dep_name = dep_from = dep_to = None
+    if is_dep:
+        dep_name, dep_from, dep_to = _parse_dependency(core)
+
+    return PullRequest(
+        title=subject,
+        number=number,
+        author=author,
+        is_dependency=is_dep,
+        tickets=tickets,
+        dep_name=dep_name,
+        dep_from=dep_from,
+        dep_to=dep_to,
+    )
+
+
+def categorize(pr: PullRequest) -> str:
+    """Return the category key for a pull request."""
+    if pr.is_dependency:
+        return "dependencies"
+
+    tags = set(_leading_tags(pr.title))
+    if tags & DOC_TAGS:
+        return "documentation"
+    if tags & INFRA_TAGS:
+        return "infrastructure"
+
+    low = pr.title.lower()
+    if _INFRA_KEYWORDS.search(low):
+        return "infrastructure"
+    if _FIX_KEYWORDS.search(low):
+        return "fixes"
+    return "features"
+
+
+def build_release_changes(version: str, date: str, subjects: list[tuple[str, str]]) -> ReleaseChanges:
+    """Group ``(subject, author)`` pairs into a :class:`ReleaseChanges`.
+
+    Duplicate pull requests (same number) are collapsed, keeping the first
+    occurrence; commits without a ``(#N)`` suffix (e.g. direct pushes) are kept.
+    """
+    changes = ReleaseChanges(version=version, date=date)
+    seen_numbers: set[int] = set()
+    for subject, author in subjects:
+        subject = subject.strip()
+        if not subject:
+            continue
+        pr = parse_pull_request(subject, author)
+        if pr.number is not None:
+            if pr.number in seen_numbers:
+                continue
+            seen_numbers.add(pr.number)
+        changes.bucket(categorize(pr)).append(pr)
+    return changes
+
+
+# --------------------------------------------------------------------------- #
+# Dependency significance
+# --------------------------------------------------------------------------- #
+def _major(version: Optional[str]) -> Optional[int]:
+    """Return the first integer found in a version string as its major component.
+
+    Uses the first digit run anywhere in the string, so a leading ``v`` or a
+    comparator (``>=0.136.1``) is tolerated (``v3.11.1`` → 3, ``>=0.136.1`` → 0).
+    """
+    if not version:
+        return None
+    match = re.search(r"\d+", version)
+    return int(match.group(0)) if match else None
+
+
+def is_significant_dependency(pr: PullRequest) -> bool:
+    """A dependency upgrade is *significant* when a library's major version increases.
+
+    Major bumps are where breaking changes live, so surfacing only these keeps
+    the changelog readable while still flagging the upgrades worth reviewing.
+    Slash-named entries (GitHub Actions like ``docker/build-push-action`` and
+    container images like ``grafana/grafana``) are excluded: their major bumps
+    are routine infrastructure pins rather than meaningful runtime upgrades.
+    """
+    if not pr.dep_name or "/" in pr.dep_name:
+        return False
+    frm, to = _major(pr.dep_from), _major(pr.dep_to)
+    if frm is None or to is None:
+        return False
+    return to > frm
+
+
+# --------------------------------------------------------------------------- #
+# Rendering (pure)
+# --------------------------------------------------------------------------- #
+def _pr_link(repo: str, number: int) -> str:
+    return f"[#{number}](https://github.com/{repo}/pull/{number})"
+
+
+def _ticket_ref(ticket: str) -> str:
+    # Plain-text reference: the issue tracker is internal, so no hyperlink is emitted.
+    return ticket
+
+
+def _refs(pr: PullRequest, repo: str) -> str:
+    parts = [_ticket_ref(t) for t in pr.tickets]
+    if pr.number is not None:
+        parts.append(_pr_link(repo, pr.number))
+    return f" ({', '.join(parts)})" if parts else ""
+
+
+def _render_entry(pr: PullRequest, repo: str) -> str:
+    return f"- {pr.display_title}{_refs(pr, repo)}"
+
+
+def _render_dependency_entry(pr: PullRequest, repo: str) -> str:
+    if pr.dep_name and pr.dep_from and pr.dep_to:
+        label = f"`{pr.dep_name}`: {pr.dep_from} → {pr.dep_to}"
+    elif pr.dep_name and pr.dep_to:
+        label = f"`{pr.dep_name}` → {pr.dep_to}"
+    else:
+        label = pr.display_title
+    return f"- {label}{_refs(pr, repo)}"
+
+
+def render_dependencies(deps: list[PullRequest], repo: str) -> list[str]:
+    """Render the Dependencies section: significant upgrades above a collapsed list."""
+    if not deps:
+        return []
+
+    significant: list[PullRequest] = []
+    routine: list[PullRequest] = []
+    for pr in deps:
+        (significant if is_significant_dependency(pr) else routine).append(pr)
+
+    lines = ["### Dependencies", ""]
+    if significant:
+        lines.append("Notable upgrades:")
+        lines.append("")
+        lines.extend(_render_dependency_entry(pr, repo) for pr in significant)
+        lines.append("")
+    if routine:
+        noun = "update" if len(routine) == 1 else "updates"
+        lines.append("<details>")
+        lines.append(f"<summary>{len(routine)} routine dependency {noun}</summary>")
+        lines.append("")
+        lines.extend(_render_dependency_entry(pr, repo) for pr in routine)
+        lines.append("")
+        lines.append("</details>")
+    return lines
+
+
+def render_section(changes: ReleaseChanges, repo: str, highlights: Optional[str]) -> str:
+    """Render a single ``## [version] - date`` changelog section (no trailing links)."""
+    lines: list[str] = [f"## [{changes.version}] - {changes.date}", ""]
+
+    lines.append("### Highlights")
+    lines.append("")
+    lines.append(highlights.strip() if highlights and highlights.strip() else HIGHLIGHTS_PLACEHOLDER)
+    lines.append("")
+
+    for key, title in CATEGORY_TITLES.items():
+        bucket = changes.bucket(key)
+        if not bucket:
+            continue
+        lines.append(f"### {title}")
+        lines.append("")
+        lines.extend(_render_entry(pr, repo) for pr in bucket)
+        lines.append("")
+
+    dep_lines = render_dependencies(changes.dependencies, repo)
+    if dep_lines:
+        lines.extend(dep_lines)
+        lines.append("")
+
+    # Collapse the trailing blank line; the caller controls spacing between sections.
+    while lines and lines[-1] == "":
+        lines.pop()
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------- #
+# CHANGELOG.md file editing (pure)
+# --------------------------------------------------------------------------- #
+CHANGELOG_HEADER = """# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Sections are generated from merged pull requests by
+[`scripts/generate_changelog.py`](scripts/generate_changelog.py); the `Highlights`
+paragraph is drafted by an LLM (via GitHub Models) and may be edited by hand.
+"""
+
+_SECTION_RE = re.compile(r"^## \[(?P<version>[^\]]+)\]", re.MULTILINE)
+_LINK_LINE_RE = re.compile(r"^\[[^\]]+\]:\s", re.MULTILINE)
+
+
+def _version_key(version: str) -> tuple[int, ...]:
+    return tuple(int(p) for p in re.findall(r"\d+", version)) or (0,)
+
+
+def _split_body_and_links(document: str) -> tuple[str, list[str]]:
+    """Split a changelog into its body and the trailing reference-link lines."""
+    lines = document.splitlines()
+    # Trailing block of ``[x]: url`` lines (with optional blank separators).
+    link_lines: list[str] = []
+    while lines:
+        last = lines[-1]
+        if last.strip() == "":
+            lines.pop()
+            continue
+        if _LINK_LINE_RE.match(last):
+            link_lines.insert(0, lines.pop())
+            continue
+        break
+    return "\n".join(lines), link_lines
+
+
+def _render_link_footer(repo: str, versions: list[str]) -> list[str]:
+    """Build ``[x]: compare-url`` reference links, newest first."""
+    ordered = sorted(set(versions), key=_version_key, reverse=True)
+    footer: list[str] = []
+    for idx, version in enumerate(ordered):
+        older = ordered[idx + 1] if idx + 1 < len(ordered) else None
+        if older is not None:
+            url = f"https://github.com/{repo}/compare/v{older}...v{version}"
+        else:
+            url = f"https://github.com/{repo}/releases/tag/v{version}"
+        footer.append(f"[{version}]: {url}")
+    return footer
+
+
+def upsert_section(document: Optional[str], section: str, version: str, repo: str, *, force: bool = False) -> str:
+    """Insert (or, with ``force``, replace) a version section into a changelog document.
+
+    New versions are inserted directly below the header, above older sections
+    (newest first). Reference links are rebuilt from every version present.
+    """
+    if not document or not document.strip():
+        document = CHANGELOG_HEADER
+
+    body, _ = _split_body_and_links(document)
+
+    matches = list(_SECTION_RE.finditer(body))
+    existing = next((m for m in matches if m.group("version") == version), None)
+
+    if existing is not None and not force:
+        raise ValueError(f"CHANGELOG already contains a section for {version}; pass --force to regenerate it.")
+
+    section = section.rstrip("\n") + "\n"
+
+    if existing is not None:
+        # Replace the existing section (up to the next ``## [`` heading or EOF).
+        after = [m for m in matches if m.start() > existing.start()]
+        end = after[0].start() if after else len(body)
+        new_body = body[: existing.start()].rstrip("\n") + "\n\n" + section + "\n" + body[end:].lstrip("\n")
+    elif matches:
+        # Insert before the first existing section that is older (lower version),
+        # so versions stay newest-first even when backfilled out of order.
+        target = _version_key(version)
+        older = next((m for m in matches if _version_key(m.group("version")) < target), None)
+        if older is not None:
+            insert_at = older.start()
+            new_body = body[:insert_at].rstrip("\n") + "\n\n" + section + "\n" + body[insert_at:].lstrip("\n")
+        else:
+            # New version is the oldest — append after the last existing section.
+            new_body = body.rstrip("\n") + "\n\n" + section
+    else:
+        # No sections yet: append after the header.
+        new_body = body.rstrip("\n") + "\n\n" + section
+
+    versions = [m.group("version") for m in _SECTION_RE.finditer(new_body)]
+    footer = _render_link_footer(repo, versions)
+
+    result = new_body.rstrip("\n") + "\n"
+    if footer:
+        result += "\n" + "\n".join(footer) + "\n"
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Highlights prompt (drafted externally, e.g. by GitHub Models in the workflow)
+# --------------------------------------------------------------------------- #
+def highlights_prompt(changes: ReleaseChanges) -> str:
+    """Render the LLM prompt describing the release's meaningful changes.
+
+    Returns ``""`` when there is nothing worth summarising (dependency-only
+    releases), so the caller can skip the draft and fall back to a placeholder.
+    """
+    if not changes.substantive:
+        return ""
+    lines = [f"Release: v{changes.version}", ""]
+    for key, title in CATEGORY_TITLES.items():
+        bucket = changes.bucket(key)
+        if not bucket:
+            continue
+        lines.append(f"{title}:")
+        lines.extend(f"- {pr.display_title}" for pr in bucket)
+        lines.append("")
+    significant = [pr for pr in changes.dependencies if is_significant_dependency(pr)]
+    if significant:
+        lines.append("Major dependency upgrades:")
+        lines.extend(f"- {pr.dep_name}: {pr.dep_from} → {pr.dep_to}" for pr in significant)
+    return "\n".join(lines).strip()
+
+
+# --------------------------------------------------------------------------- #
+# git / version helpers (isolated I/O)
+# --------------------------------------------------------------------------- #
+def _run_git(args: list[str]) -> str:
+    return subprocess.run(["git", *args], check=True, capture_output=True, text=True).stdout
+
+
+def list_version_tags() -> list[str]:
+    """Return existing ``vX.Y.Z`` tags as bare ``X.Y.Z`` versions, newest first."""
+    out = _run_git(["tag", "--list", "v*.*.*"])
+    versions = [tag[1:] for tag in out.split() if _VERSION_TAG_RE.match(tag)]
+    return sorted(versions, key=_version_key, reverse=True)
+
+
+def previous_version(version: str, tags: list[str]) -> Optional[str]:
+    """Return the highest tagged version strictly below ``version``."""
+    target = _version_key(version)
+    lower = [t for t in tags if _version_key(t) < target]
+    return max(lower, key=_version_key) if lower else None
+
+
+def tag_date(version: str) -> str:
+    """Return the committer date (``YYYY-MM-DD``) of a version tag."""
+    return _run_git(["log", "-1", "--format=%cs", f"v{version}"]).strip()
+
+
+def collect_subjects(previous: Optional[str], version: str) -> list[tuple[str, str]]:
+    """Collect ``(subject, author)`` pairs for commits in the release range."""
+    rev_range = f"v{previous}..v{version}" if previous else f"v{version}"
+    out = _run_git(["log", rev_range, f"--format={GIT_LOG_FORMAT}", "--no-merges"])
+    subjects: list[tuple[str, str]] = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split(GIT_LOG_SEP)
+        # parts: [hash, author, subject]
+        author = parts[1] if len(parts) > 1 else ""
+        subject = parts[2] if len(parts) > 2 else ""
+        subjects.append((subject, author))
+    return subjects
+
+
+# --------------------------------------------------------------------------- #
+# Entry point
+# --------------------------------------------------------------------------- #
+def _parse_args(argv: Optional[list[str]] = None) -> Namespace:
+    parser = ArgumentParser(
+        prog="generate-changelog",
+        description="Generate a curated CHANGELOG.md section for a release from merged pull requests.",
+    )
+    parser.add_argument("version", help="Release version without the leading 'v' (e.g. 0.11.0).")
+    parser.add_argument(
+        "--previous",
+        help="Previous release version to diff against (e.g. 0.10.0). Auto-detected from tags if omitted.",
+    )
+    parser.add_argument("--date", help="Release date (YYYY-MM-DD). Defaults to the tag's committer date.")
+    parser.add_argument("--repo", default=DEFAULT_REPO, help=f"owner/name of the repository (default: {DEFAULT_REPO}).")
+    parser.add_argument(
+        "--changelog", default=DEFAULT_CHANGELOG, help=f"Path to the changelog file (default: {DEFAULT_CHANGELOG})."
+    )
+    parser.add_argument(
+        "--highlights-file",
+        help="Read the Highlights paragraph from this file (drafted externally). A placeholder is used if omitted or empty.",
+    )
+    parser.add_argument(
+        "--emit-highlights-prompt",
+        metavar="PATH",
+        help="Write the LLM prompt describing the release's changes to PATH and exit (for external Highlights drafting).",
+    )
+    parser.add_argument("--force", action="store_true", help="Regenerate the section if it already exists.")
+    parser.add_argument("--print", dest="to_stdout", action="store_true", help="Print the section instead of writing.")
+    parser.add_argument("--release-notes-out", help="Also write the rendered section to this file (for release sync).")
+    return parser.parse_args(argv)
+
+
+def _read_highlights(path: Optional[str]) -> Optional[str]:
+    """Return the drafted Highlights text from ``path``, or ``None`` to use a placeholder."""
+    if not path:
+        return None
+    file = Path(path)
+    if not file.exists():
+        return None
+    text = file.read_text(encoding="utf-8").strip()
+    return text or None
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _parse_args(argv)
+    version = args.version.lstrip("v")
+
+    tags = list_version_tags()
+    previous = args.previous.lstrip("v") if args.previous else previous_version(version, tags)
+    date = args.date or tag_date(version)
+
+    subjects = collect_subjects(previous, version)
+    changes = build_release_changes(version, date, subjects)
+
+    if args.emit_highlights_prompt:
+        # First pass: hand the change list to an external model (e.g. GitHub Models
+        # in CI). An empty file signals "nothing worth summarising" — skip the draft.
+        Path(args.emit_highlights_prompt).write_text(highlights_prompt(changes), encoding="utf-8")
+        return 0
+
+    highlights = _read_highlights(args.highlights_file)
+    section = render_section(changes, args.repo, highlights)
+
+    if args.release_notes_out:
+        # A GitHub Release title already carries the version, so drop the leading
+        # ``## [version] - date`` heading from the release-notes body.
+        notes = re.sub(r"^## \[[^\]]+\][^\n]*\n\n?", "", section, count=1)
+        Path(args.release_notes_out).write_text(notes, encoding="utf-8")
+
+    if args.to_stdout:
+        sys.stdout.write(section)
+        return 0
+
+    path = Path(args.changelog)
+    document = path.read_text(encoding="utf-8") if path.exists() else None
+    updated = upsert_section(document, section, version, args.repo, force=args.force)
+    path.write_text(updated, encoding="utf-8")
+
+    counts = {
+        "features": len(changes.features),
+        "fixes": len(changes.fixes),
+        "docs": len(changes.documentation),
+        "infra": len(changes.infrastructure),
+        "deps": len(changes.dependencies),
+    }
+    summary = ", ".join(f"{v} {k}" for k, v in counts.items())
+    print(f"Wrote {path} section for {version} ({previous or 'initial'}..{version}): {summary}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/unit-tests/test_generate_changelog.py
+++ b/unit-tests/test_generate_changelog.py
@@ -1,0 +1,370 @@
+"""Unit tests for the deterministic parts of ``scripts/generate_changelog.py``.
+
+Everything that touches git or the filesystem is isolated in the script's thin
+collectors; these tests exercise the pure parsing, categorisation,
+dependency-significance, rendering, prompt-building, and file-editing logic with
+fabricated pull-request data (no network, no subprocess).
+"""
+
+import pytest
+
+from scripts.generate_changelog import (
+    CATEGORY_TITLES,
+    HIGHLIGHTS_PLACEHOLDER,
+    ReleaseChanges,
+    build_release_changes,
+    categorize,
+    highlights_prompt,
+    is_significant_dependency,
+    parse_pull_request,
+    previous_version,
+    render_dependencies,
+    render_section,
+    upsert_section,
+)
+
+pytestmark = pytest.mark.unit
+
+REPO = "JetBrains-Research/idegym"
+
+
+# --------------------------------------------------------------------------- #
+# parse_pull_request
+# --------------------------------------------------------------------------- #
+def test_parse_extracts_pr_number_and_ticket():
+    pr = parse_pull_request("[JBRes-9332] Showing MCP tools through orchestrator (#102)", "vpoliakov-pixel")
+    assert pr.number == 102
+    assert pr.tickets == ("JBRes-9332",)
+    assert pr.is_dependency is False
+    assert pr.display_title == "Showing MCP tools through orchestrator"
+
+
+def test_parse_handles_multiple_tickets_and_strips_all_leading_tags():
+    pr = parse_pull_request("[JBRes-9179] [JBRes-9184] Snapshot/restore improvements (#117)")
+    assert pr.tickets == ("JBRes-9179", "JBRes-9184")
+    assert pr.display_title == "Snapshot/restore improvements"
+
+
+def test_parse_handles_comma_separated_tickets():
+    pr = parse_pull_request("[JBRes-4758, JBRes-4975] Cleanup (#22)")
+    assert pr.tickets == ("JBRes-4758", "JBRes-4975")
+    assert pr.display_title == "Cleanup"
+
+
+def test_parse_without_pr_number():
+    pr = parse_pull_request("Example of agentic RL training using IDEGYM and VERL.")
+    assert pr.number is None
+    assert pr.is_dependency is False
+
+
+def test_parse_dependabot_author_is_dependency():
+    pr = parse_pull_request("[dependencies] Bump pydantic from 2.13.3 to 2.13.4 (#111)", "dependabot[bot]")
+    assert pr.is_dependency is True
+    assert pr.dep_name == "pydantic"
+    assert pr.dep_from == "2.13.3"
+    assert pr.dep_to == "2.13.4"
+
+
+def test_parse_dependency_detected_by_title_without_bot_author():
+    pr = parse_pull_request("Bump urllib3 from 2.6.3 to 2.7.0 (#104)", "somebody")
+    assert pr.is_dependency is True
+    assert pr.dep_name == "urllib3"
+
+
+def test_parse_bracket_prefixed_dependency_without_bot_author():
+    # Tag-prefixed dependabot title should be detected even if the author isn't the bot.
+    pr = parse_pull_request("[dependencies] Bump ruff from 0.15.12 to 0.15.13 (#122)", "human")
+    assert pr.is_dependency is True
+    assert pr.dep_name == "ruff"
+    assert pr.dep_from == "0.15.12"
+    assert pr.dep_to == "0.15.13"
+
+
+def test_parse_update_requirement_shape():
+    pr = parse_pull_request(
+        "[dependencies] Update fastapi[standard] requirement from >=0.135.2 to >=0.136.1 (#101)",
+        "dependabot[bot]",
+    )
+    assert pr.is_dependency is True
+    assert pr.dep_name == "fastapi[standard]"
+    assert pr.dep_from is None
+    assert pr.dep_to == ">=0.136.1"
+
+
+def test_parse_group_bump_has_no_parsed_versions():
+    pr = parse_pull_request(
+        "[dependencies] Bump the opentelemetry group across 1 directory with 13 updates (#134)",
+        "dependabot[bot]",
+    )
+    assert pr.is_dependency is True
+    assert pr.dep_name is None
+    assert pr.dep_from is None
+
+
+def test_parse_group_bump_detected_without_bot_author():
+    # Grouped bumps must be filed under Dependencies even when the squash-merge
+    # author isn't preserved as dependabot[bot] (title-based detection).
+    pr = parse_pull_request("[dependencies] Bump the docker group with 3 updates (#133)", "human")
+    assert pr.is_dependency is True
+    assert categorize(pr) == "dependencies"
+
+
+# --------------------------------------------------------------------------- #
+# categorize
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "subject,author,expected",
+    [
+        ("[JBRes-9069] Introducing plugins for tools and rewards (#91)", "", "features"),
+        ("[JBRes-8864] Fix incomplete logging on orchestrator (#80)", "", "fixes"),
+        ("[logging] fix logging with one worker (#144)", "", "fixes"),
+        ("[docs] Documentation for MCP tools (#110)", "", "documentation"),
+        ("[e2e] fix push pull registry urls (#72)", "", "infrastructure"),
+        ("[ci] Bump the docker group with 2 updates (#121)", "dependabot[bot]", "dependencies"),
+        ("[JBRes-9012] CI changes (#74)", "", "infrastructure"),
+        ("[helm] Bump postgresql from 18.6.4 to 18.6.7 (#113)", "dependabot[bot]", "dependencies"),
+        ("[integration-tests] add database client tests (#67)", "", "infrastructure"),
+    ],
+)
+def test_categorize(subject, author, expected):
+    assert categorize(parse_pull_request(subject, author)) == expected
+
+
+def test_docs_beats_fix_when_both_present():
+    # A documentation fix should be filed under Documentation, not Bug Fixes.
+    assert categorize(parse_pull_request("[docs] fix pre-commit issue in docs (#73)")) == "documentation"
+
+
+# --------------------------------------------------------------------------- #
+# is_significant_dependency
+# --------------------------------------------------------------------------- #
+def test_major_bump_is_significant():
+    pr = parse_pull_request("Bump kubernetes from 35.0.0 to 36.0.1 (#156)", "dependabot[bot]")
+    assert is_significant_dependency(pr) is True
+
+
+def test_minor_bump_is_not_significant():
+    pr = parse_pull_request("Bump pydantic from 2.13.3 to 2.13.4 (#111)", "dependabot[bot]")
+    assert is_significant_dependency(pr) is False
+
+
+def test_prefixed_version_major_bump_is_significant():
+    # A leading ``v`` on the version must not defeat major-bump detection.
+    pr = parse_pull_request("Bump supervisor from v4.2.5 to v5.0.0 (#27)", "dependabot[bot]")
+    assert is_significant_dependency(pr) is True
+
+
+def test_slash_named_major_bump_is_not_significant():
+    # GitHub Actions / container images (slash-named) are routine infra pins.
+    action = parse_pull_request("Bump docker/build-push-action from 6 to 7 (#23)", "dependabot[bot]")
+    image = parse_pull_request("Bump grafana/grafana from 12.4.2 to 13.0.1 (#75)", "dependabot[bot]")
+    assert is_significant_dependency(action) is False
+    assert is_significant_dependency(image) is False
+
+
+def test_group_bump_is_not_significant():
+    pr = parse_pull_request("Bump the opentelemetry group with 13 updates (#134)", "dependabot[bot]")
+    assert is_significant_dependency(pr) is False
+
+
+# --------------------------------------------------------------------------- #
+# build_release_changes
+# --------------------------------------------------------------------------- #
+def test_build_groups_and_dedupes():
+    subjects = [
+        ("[JBRes-9069] Introducing plugins (#91)", "alice"),
+        ("[JBRes-9069] Introducing plugins (#91)", "alice"),  # duplicate PR number
+        ("[JBRes-8864] Fix logging (#80)", "bob"),
+        ("[docs] MCP docs (#110)", "carol"),
+        ("[ci] CI changes (#74)", "dave"),
+        ("Bump pydantic from 2.13.3 to 2.13.4 (#111)", "dependabot[bot]"),
+    ]
+    changes = build_release_changes("0.10.0", "2026-06-18", subjects)
+    assert [pr.number for pr in changes.features] == [91]  # deduped
+    assert [pr.number for pr in changes.fixes] == [80]
+    assert [pr.number for pr in changes.documentation] == [110]
+    assert [pr.number for pr in changes.infrastructure] == [74]
+    assert [pr.number for pr in changes.dependencies] == [111]
+
+
+def test_build_skips_blank_subjects():
+    changes = build_release_changes("1.0.0", "2026-01-01", [("", ""), ("   ", "x")])
+    assert changes.substantive == []
+    assert changes.dependencies == []
+
+
+# --------------------------------------------------------------------------- #
+# rendering
+# --------------------------------------------------------------------------- #
+def test_render_dependencies_splits_significant_from_routine():
+    deps = [
+        parse_pull_request("Bump kubernetes from 35.0.0 to 36.0.1 (#156)", "dependabot[bot]"),
+        parse_pull_request("Bump pydantic from 2.13.3 to 2.13.4 (#111)", "dependabot[bot]"),
+        parse_pull_request("Bump tomlkit from 0.14.0 to 0.15.0 (#112)", "dependabot[bot]"),
+    ]
+    out = "\n".join(render_dependencies(deps, REPO))
+    assert "Notable upgrades:" in out
+    assert "`kubernetes`: 35.0.0 → 36.0.1" in out
+    assert "<details>" in out
+    assert "2 routine dependency updates" in out
+    # The significant upgrade is above the fold, not inside the collapsed block.
+    assert out.index("kubernetes") < out.index("<details>")
+    assert out.index("pydantic") > out.index("<details>")
+
+
+def test_render_dependencies_singular_noun():
+    deps = [parse_pull_request("Bump pydantic from 2.13.3 to 2.13.4 (#111)", "dependabot[bot]")]
+    out = "\n".join(render_dependencies(deps, REPO))
+    assert "1 routine dependency update</summary>" in out
+    assert "Notable upgrades:" not in out
+
+
+def test_render_dependencies_empty():
+    assert render_dependencies([], REPO) == []
+
+
+def test_render_section_includes_links_and_placeholder():
+    changes = build_release_changes(
+        "0.10.0",
+        "2026-06-18",
+        [("[JBRes-9332] Showing MCP tools (#102)", "alice")],
+    )
+    section = render_section(changes, REPO, highlights=None)
+    assert section.startswith("## [0.10.0] - 2026-06-18")
+    assert HIGHLIGHTS_PLACEHOLDER in section
+    assert "### Features" in section
+    # Tickets are plain-text references, not hyperlinks to the internal tracker.
+    assert "(JBRes-9332, [#102](https://github.com/JetBrains-Research/idegym/pull/102))" in section
+    assert "youtrack" not in section.lower()
+
+
+def test_render_section_uses_highlights_when_provided():
+    changes = build_release_changes("0.10.0", "2026-06-18", [("[JBRes-1] Thing (#1)", "a")])
+    section = render_section(changes, REPO, highlights="MCP support lands this release.")
+    assert "MCP support lands this release." in section
+    assert HIGHLIGHTS_PLACEHOLDER not in section
+
+
+def test_render_section_omits_empty_categories():
+    changes = build_release_changes("0.10.0", "2026-06-18", [("[docs] Only docs (#5)", "a")])
+    section = render_section(changes, REPO, highlights="x")
+    assert "### Documentation" in section
+    assert "### Features" not in section
+    assert "### Dependencies" not in section
+
+
+# --------------------------------------------------------------------------- #
+# upsert_section / file editing
+# --------------------------------------------------------------------------- #
+def _section(version: str) -> str:
+    changes = build_release_changes(version, "2026-06-18", [("[JBRes-1] Thing (#1)", "a")])
+    return render_section(changes, REPO, highlights="Highlights.")
+
+
+def test_upsert_into_empty_creates_header_and_footer():
+    doc = upsert_section(None, _section("0.8.0"), "0.8.0", REPO)
+    assert doc.startswith("# Changelog")
+    assert "## [0.8.0] - 2026-06-18" in doc
+    assert "[0.8.0]: https://github.com/JetBrains-Research/idegym/releases/tag/v0.8.0" in doc
+
+
+def test_upsert_inserts_newest_on_top_with_compare_links():
+    doc = upsert_section(None, _section("0.8.0"), "0.8.0", REPO)
+    doc = upsert_section(doc, _section("0.9.0"), "0.9.0", REPO)
+    doc = upsert_section(doc, _section("0.10.0"), "0.10.0", REPO)
+
+    # Newest section first in the body.
+    assert doc.index("## [0.10.0]") < doc.index("## [0.9.0]") < doc.index("## [0.8.0]")
+    # Compare links for the newer versions, tag link for the oldest.
+    assert "[0.10.0]: https://github.com/JetBrains-Research/idegym/compare/v0.9.0...v0.10.0" in doc
+    assert "[0.9.0]: https://github.com/JetBrains-Research/idegym/compare/v0.8.0...v0.9.0" in doc
+    assert "[0.8.0]: https://github.com/JetBrains-Research/idegym/releases/tag/v0.8.0" in doc
+    # Exactly one section per version, no duplicate link lines.
+    assert doc.count("## [0.9.0]") == 1
+    assert doc.count("[0.9.0]: ") == 1
+
+
+def test_upsert_orders_out_of_sequence_inserts():
+    # Backfilling an older version (e.g. via workflow_dispatch) after newer ones
+    # must keep the file newest-first, not just insert at the top.
+    doc = upsert_section(None, _section("0.10.0"), "0.10.0", REPO)
+    doc = upsert_section(doc, _section("0.8.0"), "0.8.0", REPO)  # oldest -> appended at end
+    doc = upsert_section(doc, _section("0.9.0"), "0.9.0", REPO)  # -> between 0.10.0 and 0.8.0
+    assert doc.index("## [0.10.0]") < doc.index("## [0.9.0]") < doc.index("## [0.8.0]")
+    assert "[0.9.0]: https://github.com/JetBrains-Research/idegym/compare/v0.8.0...v0.9.0" in doc
+
+
+def test_upsert_duplicate_without_force_raises():
+    doc = upsert_section(None, _section("0.8.0"), "0.8.0", REPO)
+    with pytest.raises(ValueError, match="already contains a section for 0.8.0"):
+        upsert_section(doc, _section("0.8.0"), "0.8.0", REPO)
+
+
+def test_upsert_force_replaces_existing_section():
+    doc = upsert_section(None, _section("0.8.0"), "0.8.0", REPO)
+    doc = upsert_section(doc, _section("0.9.0"), "0.9.0", REPO)
+
+    changes = build_release_changes("0.9.0", "2026-06-18", [("[JBRes-2] Replaced (#2)", "a")])
+    replacement = render_section(changes, REPO, highlights="New highlights.")
+    doc = upsert_section(doc, replacement, "0.9.0", REPO, force=True)
+
+    assert doc.count("## [0.9.0]") == 1
+    assert "New highlights." in doc
+    assert "Thing" not in doc.split("## [0.8.0]")[0].split("## [0.9.0]")[1]  # old 0.9.0 body gone
+    assert doc.index("## [0.9.0]") < doc.index("## [0.8.0]")
+
+
+# --------------------------------------------------------------------------- #
+# previous_version
+# --------------------------------------------------------------------------- #
+def test_previous_version_picks_highest_below():
+    tags = ["0.10.0", "0.9.0", "0.8.0"]
+    assert previous_version("0.10.0", tags) == "0.9.0"
+    assert previous_version("0.9.0", tags) == "0.8.0"
+
+
+def test_previous_version_none_for_first_release():
+    assert previous_version("0.8.0", ["0.8.0"]) is None
+
+
+def test_previous_version_ignores_higher_tags():
+    tags = ["0.10.0", "0.9.0", "0.8.0"]
+    assert previous_version("0.9.0", tags) == "0.8.0"
+
+
+def test_highlights_prompt_lists_changes():
+    changes = build_release_changes(
+        "0.10.0",
+        "2026-06-18",
+        [
+            ("[JBRes-9332] Showing MCP tools (#102)", "a"),
+            ("[JBRes-8864] Fix logging (#80)", "b"),
+            ("Bump kubernetes from 35.0.0 to 36.0.1 (#156)", "dependabot[bot]"),
+            ("Bump pydantic from 2.13.3 to 2.13.4 (#111)", "dependabot[bot]"),
+        ],
+    )
+    prompt = highlights_prompt(changes)
+    assert "Release: v0.10.0" in prompt
+    assert "- Showing MCP tools" in prompt
+    assert "- Fix logging" in prompt
+    # Only the major (significant) dependency upgrade is worth mentioning.
+    assert "kubernetes: 35.0.0 → 36.0.1" in prompt
+    assert "pydantic" not in prompt
+
+
+def test_highlights_prompt_empty_when_no_substantive_changes():
+    # Dependency-only release: nothing to summarise, so the prompt is empty and the
+    # workflow skips the LLM draft (placeholder is used instead).
+    changes = build_release_changes(
+        "0.10.1",
+        "2026-06-20",
+        [("Bump pydantic from 2.13.3 to 2.13.4 (#111)", "dependabot[bot]")],
+    )
+    assert highlights_prompt(changes) == ""
+
+
+def test_category_titles_match_release_changes_buckets():
+    # Every rendered category key must be a real ReleaseChanges bucket.
+    changes = ReleaseChanges(version="0.0.0", date="2026-01-01")
+    for key in CATEGORY_TITLES:
+        assert isinstance(changes.bucket(key), list)


### PR DESCRIPTION
## Summary

Replaces GitHub's raw auto-generated release notes (a flat dump of every merged PR, including ~50 dependency bumps per release, tickets shown only by title) with a curated, in-repo `CHANGELOG.md` and the tooling to keep it maintained.

Resolves **JBRes-9953**.

## What's included

- **`scripts/generate_changelog.py`** — builds a [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) section from the merged PRs in a `git log vPREV..vX.Y.Z` range:
  - groups PRs into **Features / Bug Fixes / Documentation / Infrastructure / Dependencies** (by `[tag]` prefix + author);
  - references **issue tickets (`JBRes-XXXX`) as plain-text IDs** (internal tracker, no hyperlink) and links **pull requests (`#N`)**;
  - collapses dependency bumps into a `<details>` block, surfacing only **significant** upgrades above the fold (a library's *major* version bump; GitHub Actions / container images like `docker/*`, `grafana/*` are treated as routine pins);
  - the script is fully deterministic (no LLM/SDK dependency). `--emit-highlights-prompt` writes the prompt for an external model; `--highlights-file` reads the drafted text back; without it a `_TODO_` placeholder is written, so generation never breaks.
- **`.github/workflows/changelog.yml`** — on `v*.*.*` tag push (and manual `workflow_dispatch(version, previous)` for backfill): drafts the **Highlights** paragraph via **[GitHub Models](https://docs.github.com/en/github-models)** ([`actions/ai-inference`](https://github.com/marketplace/actions/ai-inference), `openai/gpt-4o`, built-in `GITHUB_TOKEN` + `permissions: models: read` — **no secret**), generates the section, **syncs the GitHub Release body**, and opens a `changelog/vX.Y.Z` PR for review.
- **`CHANGELOG.md`** — backfilled for **v0.8.0 / v0.9.0 / v0.10.0**, newest-on-top, with a `compare/` link footer. The three historical Highlights are hand-written.
- **`RELEASING.md`** — documents the release + changelog flow, the significance heuristic, and how to switch the drafting model (e.g. `provider: copilot` + `claude-sonnet-4.5`).
- **`unit-tests/test_generate_changelog.py`** — 43 unit tests for the deterministic logic (no network / subprocess).

## Verification

- `uv run pytest unit-tests/test_generate_changelog.py -m unit` → 43 passed.
- `ruff format` + `ruff check` clean on the new files; workflow YAML validated.

## Notes

- Highlights run on GitHub Models with the built-in token — **no repository secret required**. Default model is `openai/gpt-4o`; to draft with Claude instead, set `provider: copilot` + `model: claude-sonnet-4.5` on the AI step (needs org Copilot enabled).
- PRs opened by the workflow use the default `GITHUB_TOKEN`, which does not trigger CI on the resulting changelog PR (acceptable for a markdown-only change).