### PR TITLE
[JBRes-9944] Add safe database schema rollback support for IdeGYM deployments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,21 +202,36 @@ with the wrong configuration, or one that never matches and is rebuilt every tim
 ### Database migrations
 
 Read [`orchestrator/src/idegym/orchestrator/migrations/README.md`](orchestrator/src/idegym/orchestrator/migrations/README.md)
-first, but read its paths with care — they are inaccurate. `alembic.ini` and `migrations/`
-both live under `orchestrator/src/idegym/orchestrator/`. Beyond that README:
+first — `alembic.ini` and `migrations/` both live under
+`orchestrator/src/idegym/orchestrator/`. Beyond that README:
 
-- **Migrations are not exercised by the test suite.** Integration DB tests build the schema
-  with `Base.metadata.create_all`, so a broken migration passes CI green and fails at
-  orchestrator startup. Apply it against a scratch database yourself.
+- **A migration is a four-file change.** Ship `<rev>_<slug>.py`, `<rev>_up.sql`,
+  `<rev>_down.sql`, and the matching `database.schemaRevision` bump in
+  `charts/idegym/values.yaml` — plus the SQLAlchemy model in
+  `orchestrator/src/idegym/orchestrator/database/models.py`. A column that exists in only one
+  of model and migration is the classic bug; a stale `schemaRevision` makes the orchestrator
+  refuse to start, since it is the exact revision a rollback downgrades to.
+- **Downgrades are executed, not decorative.** `scripts/rollback.py` runs
+  `<rev>_down.sql` to roll a release's schema back, so a down migration that only ever
+  compiled is a deployment hazard. Never create or drop `alembic_version` in a migration:
+  Alembic updates it in the same transaction, so touching it aborts the downgrade.
 - **Verify there is exactly one head** before opening the PR:
   ```bash
   uv run alembic -c orchestrator/src/idegym/orchestrator/alembic.ini heads
   ```
   Sequential three-digit revision IDs collide easily when two branches are open at once. If
-  you see two heads, renumber yours — do not merge them.
-- Ship the three files together (`<rev>_<slug>.py`, `<rev>_up.sql`, `<rev>_down.sql`) and
-  update the SQLAlchemy model in `orchestrator/src/idegym/orchestrator/database/models.py`
-  in the same commit. A column that exists in only one of the two is the classic bug here.
+  you see two heads, renumber yours — do not merge them. Exact-revision rollback needs the
+  history linear, so a merge revision is rejected outright.
+- **Run the round-trip suite**, which drives every revision up and down against a real
+  PostgreSQL container with data seeded at each step:
+  ```bash
+  uv run pytest integration-tests/database/test_migration_roundtrip.py
+  ```
+  It also asserts the head schema matches the ORM models — the rest of the DB suite builds its
+  schema with `Base.metadata.create_all` and would not notice the drift.
+
+The rollback workflow itself is documented in
+[`website/docs/reference/database_rollback.md`](website/docs/reference/database_rollback.md).
 
 ### Adding or changing a plugin
 

--- a/api/src/idegym/api/config.py
+++ b/api/src/idegym/api/config.py
@@ -63,6 +63,13 @@ class DatabaseConfig(BaseModel):
     password: str = Field(default="postgres")
     db: str = Field(default="idegym")
     clean_database: bool = Field(description="Drop and recreate all tables on startup", default=False)
+    schema_revision: Optional[str] = Field(
+        description=(
+            "Alembic revision this release expects, as declared by the chart. Checked against the "
+            "image's migration head on startup, and read back from the release when rolling back"
+        ),
+        default=None,
+    )
 
     @property
     def url(self) -> str:

--- a/api/src/idegym/api/exceptions.py
+++ b/api/src/idegym/api/exceptions.py
@@ -13,7 +13,6 @@ class ResourceDeletionFailedException(IdeGYMException):
 class MigrationError(IdeGYMException):
     """Raised when a database migration cannot be planned or executed.
 
-    Carries an operator-facing message: it surfaces as the failure of a startup, of the
-    migration CLI, or of a rollback's downgrade step, and is what tells someone what to
-    do next.
+    The message is operator-facing: it surfaces as a failed startup, CLI run, or rollback
+    downgrade, and is what says what to do next.
     """

--- a/api/src/idegym/api/exceptions.py
+++ b/api/src/idegym/api/exceptions.py
@@ -8,3 +8,12 @@ class InspectionsNotReadyException(IdeGYMException):
 
 class ResourceDeletionFailedException(IdeGYMException):
     """Raised when one or more Kubernetes resources fail to be deleted."""
+
+
+class MigrationError(IdeGYMException):
+    """Raised when a database migration cannot be planned or executed.
+
+    Carries an operator-facing message: it surfaces as the failure of a startup, of the
+    migration CLI, or of a rollback's downgrade step, and is what tells someone what to
+    do next.
+    """

--- a/backend-utils/src/idegym/backend/utils/logging.py
+++ b/backend-utils/src/idegym/backend/utils/logging.py
@@ -3,6 +3,7 @@ from logging import getLevelNamesMapping as get_level_names_mapping
 from logging import getLogger as create_or_get_logger
 from logging.handlers import RotatingFileHandler
 from sys import stdout
+from typing import TextIO
 
 from idegym.api.config import LoggingConfig
 from idegym.api.type import LogLevel as Level
@@ -46,7 +47,13 @@ def _create_formatter(renderer: Processor, processors: list[Processor]) -> Proce
     )
 
 
-def configure_logging(config: LoggingConfig = LoggingConfig()):
+def configure_logging(config: LoggingConfig = LoggingConfig(), stream: TextIO = stdout):
+    """Route structlog and the standard library's logging to ``stream`` and to a rotating file.
+
+    Services log to stdout. A command-line entry point passes ``stderr`` instead, so that its
+    own stdout stays a clean value a caller can capture — the log lines are still emitted, and
+    a container runtime captures both streams either way.
+    """
     renderer = JSONRenderer() if config.json_format else ConsoleRenderer()
     processors = JSONProcessors if config.json_format else ConsoleProcessors
 
@@ -68,7 +75,7 @@ def configure_logging(config: LoggingConfig = LoggingConfig()):
         root_logger.removeHandler(handler)
         handler.close()
 
-    console_handler = StreamHandler(stdout)
+    console_handler = StreamHandler(stream)
     console_handler.setFormatter(_create_formatter(renderer=renderer, processors=processors))
     root_logger.addHandler(console_handler)
 

--- a/backend-utils/src/idegym/backend/utils/logging.py
+++ b/backend-utils/src/idegym/backend/utils/logging.py
@@ -48,11 +48,10 @@ def _create_formatter(renderer: Processor, processors: list[Processor]) -> Proce
 
 
 def configure_logging(config: LoggingConfig = LoggingConfig(), stream: TextIO = stdout):
-    """Route structlog and the standard library's logging to ``stream`` and to a rotating file.
+    """Route structlog and stdlib logging to ``stream`` and to a rotating file.
 
-    Services log to stdout. A command-line entry point passes ``stderr`` instead, so that its
-    own stdout stays a clean value a caller can capture — the log lines are still emitted, and
-    a container runtime captures both streams either way.
+    Services log to stdout; a command-line entry point passes ``stderr`` so its own stdout
+    stays a value a caller can capture. A container runtime captures both either way.
     """
     renderer = JSONRenderer() if config.json_format else ConsoleRenderer()
     processors = JSONProcessors if config.json_format else ConsoleProcessors

--- a/charts/idegym/templates/deployment.yaml
+++ b/charts/idegym/templates/deployment.yaml
@@ -117,6 +117,8 @@ spec:
               value: "jetbrains.com/idegym"
             - name: IDEGYM_NODE_POOL_PREFERENCE_WEIGHT
               value: "100"
+            - name: IDEGYM_DATABASE_SCHEMA_REVISION
+              value: {{ required "database.schemaRevision must name the Alembic revision this release expects" .Values.database.schemaRevision | quote }}
             {{- include "idegym.databaseEnv" . | nindent 12 }}
             {{- with .Values.deployment.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/charts/idegym/values.yaml
+++ b/charts/idegym/values.yaml
@@ -99,6 +99,12 @@ database:
   port:
   username:
   password:
+  # The exact Alembic revision this release's images migrate to. The orchestrator refuses
+  # to start when it disagrees with its own migration head, and `scripts/rollback.py` reads
+  # it back from the target release to decide what to downgrade to — so a chart release
+  # that adds a migration must bump it in the same change. See
+  # website/docs/reference/database_rollback.md.
+  schemaRevision: "003"
 
 service:
   type: ClusterIP

--- a/charts/idegym/values.yaml
+++ b/charts/idegym/values.yaml
@@ -99,11 +99,10 @@ database:
   port:
   username:
   password:
-  # The exact Alembic revision this release's images migrate to. The orchestrator refuses
-  # to start when it disagrees with its own migration head, and `scripts/rollback.py` reads
-  # it back from the target release to decide what to downgrade to — so a chart release
-  # that adds a migration must bump it in the same change. See
-  # website/docs/reference/database_rollback.md.
+  # The exact Alembic revision this release's images migrate to, so a change that adds a
+  # migration must bump it too. The orchestrator refuses to start on a mismatch, and
+  # `scripts/rollback.py` reads it back from the target release to pick the downgrade
+  # target. See website/docs/reference/database_rollback.md.
   schemaRevision: "003"
 
 service:

--- a/e2e-tests/test_db_rollback.py
+++ b/e2e-tests/test_db_rollback.py
@@ -88,14 +88,12 @@ def psql(sql: str) -> str:
 def cli_output(deployment_name: str, arguments: list[str]) -> str:
     """Run the migration CLI in a live pod and return the value it printed.
 
-    The container logs structured JSON to stdout too, and the command prints its answer
-    last, so the value is the final non-empty line of stdout.
+    The CLI keeps its log records on stderr, so stdout is the answer on its own.
     """
     code, stdout, stderr = exec_in_deployment(deployment_name, DEFAULT_NAMESPACE, [*MIGRATION_CLI, *arguments])
     assert code == 0, f"{' '.join(arguments)} failed: {stderr or stdout}"
-    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
-    assert lines, f"{' '.join(arguments)} printed nothing (stderr: {stderr})"
-    return lines[-1]
+    assert stdout, f"{' '.join(arguments)} printed nothing (stderr: {stderr})"
+    return stdout.strip()
 
 
 def run_migration_job(orchestrator: dict, target: str) -> None:

--- a/e2e-tests/test_db_rollback.py
+++ b/e2e-tests/test_db_rollback.py
@@ -1,15 +1,13 @@
 """End-to-end coverage for release rollback, schema included.
 
-Exercises the two halves of `scripts/rollback.py` against a real cluster and a real
-release: the exact-revision schema move it performs with the deployed image and every
-writer stopped, and the plain application-only rollback it falls back to when the target
-release declares the same schema.
+Exercises both halves of `scripts/rollback.py` against a real cluster: the exact-revision
+schema move, with the deployed image and every writer stopped, and the application-only
+rollback it falls back to when the target release declares the same schema.
 
-The literal N -> N+1 -> N case cannot be staged here, because a single-image cluster has
-only one set of migrations: an orchestrator always migrates to its own head on startup, so
-no release in the history can hold the schema below it. What is covered instead is every
-mechanism that case relies on — the declared revision, the downgrade Job built from the
-live Deployment, the round trip with data in place, and the Helm handover.
+The literal N -> N+1 -> N case cannot be staged here — one image means one set of
+migrations, and any running orchestrator drags the schema back to its own head. Covered
+instead is every mechanism that case relies on: the declared revision, the downgrade Job
+built from the live Deployment, the round trip with data, and the Helm handover.
 """
 
 import json
@@ -97,10 +95,10 @@ def cli_output(deployment_name: str, arguments: list[str]) -> str:
 
 
 def run_migration_job(orchestrator: dict, target: str) -> None:
-    """Run the downgrade/upgrade Job `scripts/rollback.py` would run, and require success.
+    """Run the Job `scripts/rollback.py` would run, and require success.
 
-    ``build_migration_job`` always passes ``--allow-downgrade``; the CLI only consults it
-    when the plan actually moves backwards, so the same builder serves both directions.
+    ``build_migration_job`` always passes ``--allow-downgrade``, which the CLI consults only
+    when the plan moves backwards, so one builder serves both directions.
     """
     name = migration_job_name(orchestrator["metadata"]["name"], f"migrate-{target}")
     delete_job(name, DEFAULT_NAMESPACE)
@@ -143,11 +141,8 @@ def restore_writers(replicas_by_name: dict[str, int]) -> None:
 
 
 def test_release_declares_the_schema_revision_its_image_produces():
-    """The invariant every exact rollback rests on.
-
-    The chart value is what a rollback downgrades to, so a release whose declaration drifts
-    from its image would send the next rollback to the wrong revision.
-    """
+    """The invariant every exact rollback rests on: a declaration that drifts from its image
+    sends the next rollback to the wrong revision."""
     values = release_values(HELM_RELEASE, DEFAULT_NAMESPACE)
     declared = declared_schema_revision(values)
     orchestrator, _ = release_deployments(HELM_RELEASE, DEFAULT_NAMESPACE, values)
@@ -161,9 +156,8 @@ def test_release_declares_the_schema_revision_its_image_produces():
 def test_schema_downgrades_and_comes_back_with_data_intact():
     """Walk the deployed schema back one revision and forward again, in-cluster.
 
-    Rows are seeded into the tables revision 001 creates, so they survive any incremental
-    revision's downgrade; if a future revision's downgrade drops them, that is a
-    data-destroying downgrade this test should fail on.
+    Rows go into the tables revision 001 creates, so they survive an incremental revision's
+    downgrade; one that drops them is data-destroying and should fail here.
     """
     chain = revision_chain()
     assert len(chain) >= 2, "need at least two revisions to exercise a downgrade"
@@ -196,10 +190,9 @@ def test_schema_downgrades_and_comes_back_with_data_intact():
 
 
 def test_application_only_rollback_leaves_the_schema_alone():
-    """A rollback between releases that declare the same revision is a plain Helm rollback.
+    """Same declared revision means a plain Helm rollback: no writer stopped, no Job run.
 
-    No writer is stopped and no migration Job runs — the schema is already what the target
-    release expects, which is the routine case an expand/contract migration policy aims for.
+    This is the routine case an expand/contract migration policy aims for.
     """
     deployed = current_helm_revision(HELM_RELEASE, DEFAULT_NAMESPACE)
     subprocess.run(

--- a/e2e-tests/test_db_rollback.py
+++ b/e2e-tests/test_db_rollback.py
@@ -1,0 +1,249 @@
+"""End-to-end coverage for release rollback, schema included.
+
+Exercises the two halves of `scripts/rollback.py` against a real cluster and a real
+release: the exact-revision schema move it performs with the deployed image and every
+writer stopped, and the plain application-only rollback it falls back to when the target
+release declares the same schema.
+
+The literal N -> N+1 -> N case cannot be staged here, because a single-image cluster has
+only one set of migrations: an orchestrator always migrates to its own head on startup, so
+no release in the history can hold the schema below it. What is covered instead is every
+mechanism that case relies on — the declared revision, the downgrade Job built from the
+live Deployment, the round trip with data in place, and the Helm handover.
+"""
+
+import json
+import subprocess
+
+import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from from_root import from_root
+from idegym.utils.logging import get_logger
+from utils import k8s_client
+from utils.constants import (
+    CHART_PATH,
+    DEFAULT_NAMESPACE,
+    HELM_RELEASE,
+    POSTGRESQL_APP_LABEL,
+    POSTGRESQL_DB,
+    POSTGRESQL_USER,
+    WATCHER_APP_LABEL,
+)
+from utils.k8s_setup import wait_for_pod_ready, wait_for_service
+
+from scripts.rollback import (
+    MIGRATION_CLI,
+    build_migration_job,
+    create_job,
+    current_helm_revision,
+    declared_schema_revision,
+    exec_in_deployment,
+    main,
+    release_deployments,
+    release_values,
+    replica_count,
+    scale,
+    wait_for_job,
+    wait_for_no_pods,
+)
+
+logger = get_logger(__name__)
+
+ALEMBIC_INI = from_root("orchestrator", "src", "idegym", "orchestrator", "alembic.ini")
+STEP_TIMEOUT_SECONDS = 300
+_PG_SUPERUSER_PASSWORD = "postgres"
+
+
+def revision_chain() -> list[str]:
+    """Revision ids base -> head, read from the same scripts the deployed image contains."""
+    script = ScriptDirectory.from_config(Config(str(ALEMBIC_INI)))
+    return [revision.revision for revision in script.walk_revisions()][::-1]
+
+
+def psql(sql: str) -> str:
+    pod_names = k8s_client.list_pod_names(
+        namespace=DEFAULT_NAMESPACE, label_selector=f"app.kubernetes.io/name={POSTGRESQL_APP_LABEL}"
+    )
+    if not pod_names:
+        raise RuntimeError(f"No postgresql pod found in namespace {DEFAULT_NAMESPACE}")
+    return k8s_client.exec_in_pod(
+        pod_name=pod_names[0],
+        namespace=DEFAULT_NAMESPACE,
+        command=[
+            "env",
+            f"PGPASSWORD={_PG_SUPERUSER_PASSWORD}",
+            "psql",
+            "-U",
+            POSTGRESQL_USER,
+            "-d",
+            POSTGRESQL_DB,
+            "-tAc",
+            sql,
+        ],
+    ).strip()
+
+
+def cli_output(deployment_name: str, arguments: list[str]) -> str:
+    """Run the migration CLI in a live pod and return what it printed.
+
+    The container logs structured JSON to stdout as well, so the value the command prints
+    is the last line.
+    """
+    code, output = exec_in_deployment(deployment_name, DEFAULT_NAMESPACE, [*MIGRATION_CLI, *arguments])
+    assert code == 0, f"{' '.join(arguments)} failed: {output}"
+    return output.splitlines()[-1].strip()
+
+
+def run_migration_job(orchestrator: dict, target: str) -> None:
+    """Run the downgrade/upgrade Job `scripts/rollback.py` would run, and require success.
+
+    ``build_migration_job`` always passes ``--allow-downgrade``; the CLI only consults it
+    when the plan actually moves backwards, so the same builder serves both directions.
+    """
+    name = f"{orchestrator['metadata']['name']}-migrate-{target}"
+    subprocess.run(
+        ["kubectl", "delete", "job", name, "--namespace", DEFAULT_NAMESPACE, "--ignore-not-found"], check=False
+    )
+    create_job(build_migration_job(name, DEFAULT_NAMESPACE, orchestrator, target, STEP_TIMEOUT_SECONDS))
+    assert wait_for_job(name, DEFAULT_NAMESPACE, STEP_TIMEOUT_SECONDS), f"migration Job {name} did not succeed"
+
+
+def seed_representative_rows(marker: str) -> None:
+    psql(
+        "WITH c AS ("
+        "  INSERT INTO clients (id, name, namespace, created_at, last_heartbeat_time, availability, nodes_count)"
+        f"  VALUES (gen_random_uuid(), '{marker}', '{DEFAULT_NAMESPACE}', 1, 1, 'ALIVE', 0)"
+        "  RETURNING id"
+        ") "
+        "INSERT INTO servers (client_id, client_name, server_name, generated_name, namespace, created_at,"
+        " last_heartbeat_time, availability, cpu, ram, run_as_root, server_kind, service_port) "
+        f"SELECT id, '{marker}', 'srv', '{marker}', '{DEFAULT_NAMESPACE}', 1, 1, 'ALIVE',"
+        " 0, 0, false, 'idegym', 80 FROM c;"
+    )
+
+
+def deployed_log_level() -> str:
+    """The currently deployed release's log level — the marker this test toggles."""
+    values = json.loads(
+        subprocess.run(
+            ["helm", "get", "values", HELM_RELEASE, "--namespace", DEFAULT_NAMESPACE, "--all", "--output", "json"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    )
+    return values["deployment"]["log"]["level"]
+
+
+def restore_writers(replicas_by_name: dict[str, int]) -> None:
+    for name, replicas in replicas_by_name.items():
+        scale(name, DEFAULT_NAMESPACE, replicas)
+    assert wait_for_service(), "Orchestrator did not become healthy again"
+    assert wait_for_pod_ready(WATCHER_APP_LABEL, timeout=STEP_TIMEOUT_SECONDS), "Watcher did not become ready again"
+
+
+@pytest.mark.e2e
+def test_release_declares_the_schema_revision_its_image_produces():
+    """The invariant every exact rollback rests on.
+
+    The chart value is what a rollback downgrades to, so a release whose declaration drifts
+    from its image would send the next rollback to the wrong revision.
+    """
+    declared = declared_schema_revision(release_values(HELM_RELEASE, DEFAULT_NAMESPACE))
+    orchestrator, _ = release_deployments(HELM_RELEASE, DEFAULT_NAMESPACE)
+    orchestrator_name = orchestrator["metadata"]["name"]
+
+    assert cli_output(orchestrator_name, ["schema", "head"]) == declared
+    assert cli_output(orchestrator_name, ["schema", "current"]) == declared
+    assert psql("SELECT version_num FROM alembic_version;") == declared
+
+
+@pytest.mark.e2e
+def test_schema_downgrades_and_comes_back_with_data_intact():
+    """Walk the deployed schema back one revision and forward again, in-cluster.
+
+    Rows are seeded into the tables revision 001 creates, so they survive any incremental
+    revision's downgrade; if a future revision's downgrade drops them, that is a
+    data-destroying downgrade this test should fail on.
+    """
+    chain = revision_chain()
+    assert len(chain) >= 2, "need at least two revisions to exercise a downgrade"
+    head, previous = chain[-1], chain[-2]
+
+    orchestrator, watcher = release_deployments(HELM_RELEASE, DEFAULT_NAMESPACE)
+    writers = [orchestrator, *([watcher] if watcher else [])]
+    original_replicas = {deployment["metadata"]["name"]: replica_count(deployment) for deployment in writers}
+
+    seed_representative_rows("rollback-e2e")
+    assert psql("SELECT count(*) FROM servers WHERE generated_name = 'rollback-e2e';") == "1"
+
+    try:
+        for name in original_replicas:
+            scale(name, DEFAULT_NAMESPACE, 0)
+        for deployment in writers:
+            wait_for_no_pods(deployment, DEFAULT_NAMESPACE, STEP_TIMEOUT_SECONDS)
+
+        run_migration_job(orchestrator, previous)
+        assert psql("SELECT version_num FROM alembic_version;") == previous
+        assert psql("SELECT count(*) FROM servers WHERE generated_name = 'rollback-e2e';") == "1"
+
+        run_migration_job(orchestrator, head)
+        assert psql("SELECT version_num FROM alembic_version;") == head
+        assert psql("SELECT count(*) FROM servers WHERE generated_name = 'rollback-e2e';") == "1"
+    finally:
+        restore_writers(original_replicas)
+
+
+@pytest.mark.e2e
+def test_application_only_rollback_leaves_the_schema_alone():
+    """A rollback between releases that declare the same revision is a plain Helm rollback.
+
+    No writer is stopped and no migration Job runs — the schema is already what the target
+    release expects, which is the routine case an expand/contract migration policy aims for.
+    """
+    deployed = current_helm_revision(HELM_RELEASE, DEFAULT_NAMESPACE)
+    subprocess.run(
+        [
+            "helm",
+            "upgrade",
+            HELM_RELEASE,
+            str(CHART_PATH),
+            "--namespace",
+            DEFAULT_NAMESPACE,
+            "--reuse-values",
+            "--set",
+            "deployment.log.level=debug",
+            "--wait",
+            "--timeout",
+            f"{STEP_TIMEOUT_SECONDS}s",
+        ],
+        check=True,
+    )
+    assert current_helm_revision(HELM_RELEASE, DEFAULT_NAMESPACE) == deployed + 1
+
+    try:
+        exit_code = main(
+            ["--release", HELM_RELEASE, "--namespace", DEFAULT_NAMESPACE, "--revision", str(deployed), "--yes"]
+        )
+        assert exit_code == 0
+        assert deployed_log_level() != "debug", "the rollback did not restore the target release's values"
+    finally:
+        # A Helm rollback records a new revision carrying the old values, so the values are
+        # what says whether the release is back where the session left it — not the number.
+        if deployed_log_level() == "debug":
+            subprocess.run(
+                [
+                    "helm",
+                    "rollback",
+                    HELM_RELEASE,
+                    str(deployed),
+                    "--namespace",
+                    DEFAULT_NAMESPACE,
+                    "--wait",
+                    "--timeout",
+                    f"{STEP_TIMEOUT_SECONDS}s",
+                ],
+                check=False,
+            )
+        assert wait_for_service(), "Orchestrator did not become healthy again"

--- a/e2e-tests/test_db_rollback.py
+++ b/e2e-tests/test_db_rollback.py
@@ -15,7 +15,6 @@ live Deployment, the round trip with data in place, and the Helm handover.
 import json
 import subprocess
 
-import pytest
 from alembic.config import Config
 from alembic.script import ScriptDirectory
 from from_root import from_root
@@ -38,8 +37,10 @@ from scripts.rollback import (
     create_job,
     current_helm_revision,
     declared_schema_revision,
+    delete_job,
     exec_in_deployment,
     main,
+    migration_job_name,
     release_deployments,
     release_values,
     replica_count,
@@ -85,14 +86,16 @@ def psql(sql: str) -> str:
 
 
 def cli_output(deployment_name: str, arguments: list[str]) -> str:
-    """Run the migration CLI in a live pod and return what it printed.
+    """Run the migration CLI in a live pod and return the value it printed.
 
-    The container logs structured JSON to stdout as well, so the value the command prints
-    is the last line.
+    The container logs structured JSON to stdout too, and the command prints its answer
+    last, so the value is the final non-empty line of stdout.
     """
-    code, output = exec_in_deployment(deployment_name, DEFAULT_NAMESPACE, [*MIGRATION_CLI, *arguments])
-    assert code == 0, f"{' '.join(arguments)} failed: {output}"
-    return output.splitlines()[-1].strip()
+    code, stdout, stderr = exec_in_deployment(deployment_name, DEFAULT_NAMESPACE, [*MIGRATION_CLI, *arguments])
+    assert code == 0, f"{' '.join(arguments)} failed: {stderr or stdout}"
+    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    assert lines, f"{' '.join(arguments)} printed nothing (stderr: {stderr})"
+    return lines[-1]
 
 
 def run_migration_job(orchestrator: dict, target: str) -> None:
@@ -101,10 +104,8 @@ def run_migration_job(orchestrator: dict, target: str) -> None:
     ``build_migration_job`` always passes ``--allow-downgrade``; the CLI only consults it
     when the plan actually moves backwards, so the same builder serves both directions.
     """
-    name = f"{orchestrator['metadata']['name']}-migrate-{target}"
-    subprocess.run(
-        ["kubectl", "delete", "job", name, "--namespace", DEFAULT_NAMESPACE, "--ignore-not-found"], check=False
-    )
+    name = migration_job_name(orchestrator["metadata"]["name"], f"migrate-{target}")
+    delete_job(name, DEFAULT_NAMESPACE)
     create_job(build_migration_job(name, DEFAULT_NAMESPACE, orchestrator, target, STEP_TIMEOUT_SECONDS))
     assert wait_for_job(name, DEFAULT_NAMESPACE, STEP_TIMEOUT_SECONDS), f"migration Job {name} did not succeed"
 
@@ -143,15 +144,15 @@ def restore_writers(replicas_by_name: dict[str, int]) -> None:
     assert wait_for_pod_ready(WATCHER_APP_LABEL, timeout=STEP_TIMEOUT_SECONDS), "Watcher did not become ready again"
 
 
-@pytest.mark.e2e
 def test_release_declares_the_schema_revision_its_image_produces():
     """The invariant every exact rollback rests on.
 
     The chart value is what a rollback downgrades to, so a release whose declaration drifts
     from its image would send the next rollback to the wrong revision.
     """
-    declared = declared_schema_revision(release_values(HELM_RELEASE, DEFAULT_NAMESPACE))
-    orchestrator, _ = release_deployments(HELM_RELEASE, DEFAULT_NAMESPACE)
+    values = release_values(HELM_RELEASE, DEFAULT_NAMESPACE)
+    declared = declared_schema_revision(values)
+    orchestrator, _ = release_deployments(HELM_RELEASE, DEFAULT_NAMESPACE, values)
     orchestrator_name = orchestrator["metadata"]["name"]
 
     assert cli_output(orchestrator_name, ["schema", "head"]) == declared
@@ -159,7 +160,6 @@ def test_release_declares_the_schema_revision_its_image_produces():
     assert psql("SELECT version_num FROM alembic_version;") == declared
 
 
-@pytest.mark.e2e
 def test_schema_downgrades_and_comes_back_with_data_intact():
     """Walk the deployed schema back one revision and forward again, in-cluster.
 
@@ -171,7 +171,9 @@ def test_schema_downgrades_and_comes_back_with_data_intact():
     assert len(chain) >= 2, "need at least two revisions to exercise a downgrade"
     head, previous = chain[-1], chain[-2]
 
-    orchestrator, watcher = release_deployments(HELM_RELEASE, DEFAULT_NAMESPACE)
+    orchestrator, watcher = release_deployments(
+        HELM_RELEASE, DEFAULT_NAMESPACE, release_values(HELM_RELEASE, DEFAULT_NAMESPACE)
+    )
     writers = [orchestrator, *([watcher] if watcher else [])]
     original_replicas = {deployment["metadata"]["name"]: replica_count(deployment) for deployment in writers}
 
@@ -195,7 +197,6 @@ def test_schema_downgrades_and_comes_back_with_data_intact():
         restore_writers(original_replicas)
 
 
-@pytest.mark.e2e
 def test_application_only_rollback_leaves_the_schema_alone():
     """A rollback between releases that declare the same revision is a plain Helm rollback.
 

--- a/integration-tests/database/test_migration_roundtrip.py
+++ b/integration-tests/database/test_migration_roundtrip.py
@@ -17,7 +17,12 @@ from uuid import uuid4
 import pytest
 from idegym.api.exceptions import MigrationError
 from idegym.orchestrator.database.models import Base
-from idegym.orchestrator.migration_manager import BASE_REVISION, MigrationDirection, MigrationManager
+from idegym.orchestrator.migration_manager import (
+    BASE_REVISION,
+    MIGRATION_LOCK_ID,
+    MigrationDirection,
+    MigrationManager,
+)
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
@@ -256,3 +261,47 @@ async def test_revision_this_image_does_not_contain_is_rejected(manager: Migrati
 
     with pytest.raises(MigrationError, match="use the image that introduced it"):
         await manager.migrate_to("003", allow_downgrade=True)
+
+
+async def test_a_lock_held_elsewhere_stops_the_migration(manager: MigrationManager, migration_db_url: str):
+    """Someone else migrating is a hard failure, not something to work around.
+
+    The lock is taken before the revision is read, so there is no window in which a plan is
+    resolved against a schema another process is moving — a starting orchestrator replica
+    runs `upgrade heads` whatever version it is, so that window would be reachable in a
+    plain pod restart.
+    """
+    holder = create_async_engine(migration_db_url, pool_size=1, max_overflow=0)
+    try:
+        async with holder.begin() as conn:
+            acquired = await conn.execute(text("SELECT pg_try_advisory_lock(:id)"), {"id": MIGRATION_LOCK_ID})
+            assert acquired.scalar()
+
+            with pytest.raises(MigrationError, match="Another process holds the migration lock"):
+                await manager.migrate_to("heads")
+
+            await conn.execute(text("SELECT pg_advisory_unlock(:id)"), {"id": MIGRATION_LOCK_ID})
+    finally:
+        await holder.dispose()
+
+    # Released: the same call now goes through.
+    assert (await manager.migrate_to("heads")).direction is MigrationDirection.UPGRADE
+
+
+async def test_a_no_op_migration_also_waits_for_the_lock(manager: MigrationManager, migration_db_url: str):
+    """ "Already at the target" is only true if nobody is moving the schema right now."""
+    await manager.migrate_to("heads")
+
+    holder = create_async_engine(migration_db_url, pool_size=1, max_overflow=0)
+    try:
+        async with holder.begin() as conn:
+            await conn.execute(text("SELECT pg_try_advisory_lock(:id)"), {"id": MIGRATION_LOCK_ID})
+
+            with pytest.raises(MigrationError, match="Another process holds the migration lock"):
+                await manager.migrate_to("heads")
+
+            await conn.execute(text("SELECT pg_advisory_unlock(:id)"), {"id": MIGRATION_LOCK_ID})
+    finally:
+        await holder.dispose()
+
+    assert (await manager.migrate_to("heads")).direction is MigrationDirection.NOOP

--- a/integration-tests/database/test_migration_roundtrip.py
+++ b/integration-tests/database/test_migration_roundtrip.py
@@ -1,0 +1,258 @@
+"""Up/down round-trip coverage for every Alembic revision against real PostgreSQL.
+
+The rest of this suite builds the schema with ``Base.metadata.create_all``, so the
+migrations themselves were never executed by any test. They are now the mechanism a
+release rollback depends on, which makes an untested downgrade a deployment hazard rather
+than a latent one.
+
+Each test gets a throwaway database inside the shared container: Alembic owns the whole
+schema here, including dropping it, which cannot share a database with the ORM-created one
+the other modules truncate.
+"""
+
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from idegym.api.exceptions import MigrationError
+from idegym.orchestrator.database.models import Base
+from idegym.orchestrator.migration_manager import BASE_REVISION, MigrationDirection, MigrationManager
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+CLIENT_ID = "11111111-1111-1111-1111-111111111111"
+PREPARE_REQUEST_ID = "22222222-2222-2222-2222-222222222222"
+
+# Tables each revision adds, checked as the schema is walked up and down.
+TABLES_BY_REVISION = {
+    "001": {"clients", "servers", "resource_limit_rules", "job_statuses", "async_operations"},
+    "002": {"snapshot_prepare_requests", "snapshots", "snapshot_jobs"},
+    "003": set(),
+}
+
+# Columns revision 003 adds, and whose data its downgrade deliberately discards.
+COLUMNS_ADDED_BY_003 = {
+    "servers": {"details", "max_restarts", "snapshot_id"},
+    "snapshots": {"pod_snapshot_name"},
+}
+
+
+@pytest.fixture
+def migration_db_url(db_url: str) -> Iterator[str]:
+    """Create a database only this test uses, and drop it afterwards."""
+    database = f"migrations_{uuid4().hex[:12]}"
+    admin_url = db_url.replace("postgresql+asyncpg://", "postgresql+psycopg2://", 1)
+    # CREATE/DROP DATABASE cannot run inside a transaction.
+    admin_engine = create_engine(admin_url, isolation_level="AUTOCOMMIT")
+    try:
+        with admin_engine.connect() as conn:
+            conn.execute(text(f'CREATE DATABASE "{database}"'))
+        try:
+            yield db_url.rsplit("/", 1)[0] + f"/{database}"
+        finally:
+            with admin_engine.connect() as conn:
+                conn.execute(text(f'DROP DATABASE IF EXISTS "{database}" WITH (FORCE)'))
+    finally:
+        admin_engine.dispose()
+
+
+@pytest.fixture
+async def manager(migration_db_url: str) -> AsyncIterator[MigrationManager]:
+    engine = create_async_engine(migration_db_url, pool_size=1, max_overflow=0)
+    try:
+        yield MigrationManager(engine=engine, db_url=migration_db_url)
+    finally:
+        await engine.dispose()
+
+
+async def table_names(engine: AsyncEngine) -> set[str]:
+    async with engine.connect() as conn:
+        return set(await conn.run_sync(lambda sync_conn: inspect(sync_conn).get_table_names()))
+
+
+async def column_names(engine: AsyncEngine, table: str) -> set[str]:
+    async with engine.connect() as conn:
+        columns = await conn.run_sync(lambda sync_conn: inspect(sync_conn).get_columns(table))
+    return {column["name"] for column in columns}
+
+
+async def execute(engine: AsyncEngine, statement: str, **parameters: Any) -> None:
+    async with engine.begin() as conn:
+        await conn.execute(text(statement), parameters)
+
+
+async def scalar(engine: AsyncEngine, statement: str) -> Any:
+    async with engine.connect() as conn:
+        return (await conn.execute(text(statement))).scalar()
+
+
+async def seed_revision_001(engine: AsyncEngine) -> None:
+    await execute(
+        engine,
+        "INSERT INTO clients (id, name, namespace, created_at, last_heartbeat_time, availability, nodes_count)"
+        " VALUES (:id, 'round-trip', 'idegym', 1, 1, 'AVAILABLE', 1)",
+        id=CLIENT_ID,
+    )
+    await execute(
+        engine,
+        "INSERT INTO servers (client_id, client_name, server_name, generated_name, namespace, created_at,"
+        " last_heartbeat_time, availability, image_tag, cpu, ram)"
+        " VALUES (:client_id, 'round-trip', 'srv', 'srv-abc', 'idegym', 1, 1, 'AVAILABLE', 'tag', 1.0, 2.0)",
+        client_id=CLIENT_ID,
+    )
+
+
+async def seed_revision_002(engine: AsyncEngine) -> None:
+    await execute(
+        engine,
+        "INSERT INTO snapshot_prepare_requests (id, total_requested, succeeded, failed, created_at, updated_at)"
+        " VALUES (:id, 1, 0, 0, 1, 1)",
+        id=PREPARE_REQUEST_ID,
+    )
+    await execute(
+        engine,
+        "INSERT INTO snapshots (snapshot_name, request_hash, namespace, image_tag, server_name, server_kind,"
+        " created_at, updated_at) VALUES ('snap', 'hash', 'idegym', 'tag', 'srv', 'idegym', 1, 1)",
+    )
+    await execute(
+        engine,
+        "INSERT INTO snapshot_jobs (job_id, status, request_hash, request, snapshot_id, prepare_request_id,"
+        " created_at, updated_at)"
+        " VALUES ('job', 'SUCCESS', 'hash', '{}', (SELECT id FROM snapshots LIMIT 1), :prepare_request_id, 1, 1)",
+        prepare_request_id=PREPARE_REQUEST_ID,
+    )
+
+
+async def seed_revision_003(engine: AsyncEngine) -> None:
+    await execute(
+        engine,
+        "UPDATE servers SET details = 'crashed once', max_restarts = 3, snapshot_id = 'group-1'",
+    )
+    await execute(engine, "UPDATE snapshots SET pod_snapshot_name = 'pod-snapshot-1'")
+
+
+SEEDS = {"001": seed_revision_001, "002": seed_revision_002, "003": seed_revision_003}
+
+
+async def test_round_trip_through_every_revision(manager: MigrationManager):
+    """Walk base -> head one revision at a time with data in place, then walk back down.
+
+    Seeding at each revision is what makes the downgrades meaningful: an empty schema
+    reverts cleanly even when the SQL would fail on a populated one.
+    """
+    engine = manager.engine
+    chain = manager.revision_chain()
+    assert chain == ["001", "002", "003"], "update this test's per-revision expectations"
+
+    expected_tables: set[str] = set()
+    for revision in chain:
+        plan = await manager.migrate_to(revision)
+        assert plan.direction is MigrationDirection.UPGRADE
+        assert await manager.get_current_revision() == revision
+
+        expected_tables |= TABLES_BY_REVISION[revision]
+        assert expected_tables <= await table_names(engine)
+        await SEEDS[revision](engine)
+
+    for table, columns in COLUMNS_ADDED_BY_003.items():
+        assert columns <= await column_names(engine, table)
+
+    for revision, previous in zip(reversed(chain), [*reversed(chain[:-1]), BASE_REVISION], strict=True):
+        plan = await manager.migrate_to(previous, allow_downgrade=True)
+        assert plan.direction is MigrationDirection.DOWNGRADE
+        assert plan.revisions == (revision,)
+        assert await manager.get_current_revision() == (None if previous == BASE_REVISION else previous)
+
+        expected_tables -= TABLES_BY_REVISION[revision]
+        assert expected_tables == await table_names(engine) - {"alembic_version"}
+
+    # Back up to head: the schema returns, the data does not — dropping a table is the
+    # documented cost of downgrading past the revision that created it.
+    await manager.migrate_to("heads")
+    assert await manager.get_current_revision() == chain[-1]
+    assert TABLES_BY_REVISION["001"] | TABLES_BY_REVISION["002"] <= await table_names(engine)
+
+
+async def test_downgrading_only_the_last_revision_preserves_rows(manager: MigrationManager):
+    """003 -> 002 -> 003 keeps every row, and empties exactly the columns 003 added."""
+    engine = manager.engine
+    await manager.migrate_to("heads")
+    await seed_revision_001(engine)
+    await seed_revision_002(engine)
+    await seed_revision_003(engine)
+
+    await manager.migrate_to("002", allow_downgrade=True)
+    for table, columns in COLUMNS_ADDED_BY_003.items():
+        assert not columns & await column_names(engine, table)
+    assert await scalar(engine, "SELECT count(*) FROM servers") == 1
+    assert await scalar(engine, "SELECT count(*) FROM snapshots") == 1
+
+    await manager.migrate_to("003")
+    assert await scalar(engine, "SELECT count(*) FROM servers") == 1
+    assert await scalar(engine, "SELECT generated_name FROM servers") == "srv-abc"
+    assert await scalar(engine, "SELECT details FROM servers") is None
+    assert await scalar(engine, "SELECT max_restarts FROM servers") == 0
+    assert await scalar(engine, "SELECT pod_snapshot_name FROM snapshots") is None
+
+
+async def test_downgrade_to_base_leaves_alembic_bookkeeping_intact(manager: MigrationManager):
+    """A migration must not drop ``alembic_version``.
+
+    Alembic deletes the revision row in the same transaction, so dropping the table there
+    aborts the whole downgrade — which is why this used to be impossible rather than lossy.
+    """
+    await manager.migrate_to("heads")
+    await seed_revision_001(manager.engine)
+
+    await manager.migrate_to(BASE_REVISION, allow_downgrade=True)
+
+    assert await table_names(manager.engine) == {"alembic_version"}
+    assert await manager.get_current_revision() is None
+
+
+async def test_head_schema_matches_the_orm_models(manager: MigrationManager):
+    """Every ORM table and column exists at head, in the database the migrations built.
+
+    A column added to ``models.py`` but not to a migration (or the reverse) otherwise only
+    surfaces at runtime, because the rest of the suite creates its schema from the models.
+    """
+    await manager.migrate_to("heads")
+
+    migrated = await table_names(manager.engine)
+    assert set(Base.metadata.tables) <= migrated
+
+    for name, table in Base.metadata.tables.items():
+        assert {column.name for column in table.columns} == await column_names(manager.engine, name), name
+
+
+async def test_downgrade_needs_explicit_approval(manager: MigrationManager):
+    await manager.migrate_to("heads")
+
+    with pytest.raises(MigrationError, match="downgrade"):
+        await manager.migrate_to("002")
+
+    assert await manager.get_current_revision() == "003"
+    assert COLUMNS_ADDED_BY_003["servers"] <= await column_names(manager.engine, "servers")
+
+
+async def test_unknown_target_is_rejected_before_touching_the_schema(manager: MigrationManager):
+    await manager.migrate_to("heads")
+
+    with pytest.raises(MigrationError, match="not one of the migrations in this image"):
+        await manager.migrate_to("999", allow_downgrade=True)
+
+    assert await manager.get_current_revision() == "003"
+
+
+async def test_revision_this_image_does_not_contain_is_rejected(manager: MigrationManager):
+    """The failure mode of rolling back with the wrong (older) image.
+
+    Alembic cannot traverse a revision it has no script for, so the error has to name the
+    situation rather than surface as a missing-revision KeyError.
+    """
+    await manager.migrate_to("heads")
+    await execute(manager.engine, "UPDATE alembic_version SET version_num = '004'")
+
+    with pytest.raises(MigrationError, match="use the image that introduced it"):
+        await manager.migrate_to("003", allow_downgrade=True)

--- a/integration-tests/database/test_migration_roundtrip.py
+++ b/integration-tests/database/test_migration_roundtrip.py
@@ -1,13 +1,10 @@
 """Up/down round-trip coverage for every Alembic revision against real PostgreSQL.
 
 The rest of this suite builds the schema with ``Base.metadata.create_all``, so the
-migrations themselves were never executed by any test. They are now the mechanism a
-release rollback depends on, which makes an untested downgrade a deployment hazard rather
-than a latent one.
+migrations were never executed by any test — and a release rollback now depends on them.
 
 Each test gets a throwaway database inside the shared container: Alembic owns the whole
-schema here, including dropping it, which cannot share a database with the ORM-created one
-the other modules truncate.
+schema here, including dropping it, so it cannot share the ORM-created one.
 """
 
 from collections.abc import AsyncIterator, Iterator
@@ -143,8 +140,8 @@ SEEDS = {"001": seed_revision_001, "002": seed_revision_002, "003": seed_revisio
 async def test_round_trip_through_every_revision(manager: MigrationManager):
     """Walk base -> head one revision at a time with data in place, then walk back down.
 
-    Seeding at each revision is what makes the downgrades meaningful: an empty schema
-    reverts cleanly even when the SQL would fail on a populated one.
+    Seeding at each revision is what makes it meaningful: an empty schema reverts cleanly
+    even when the SQL would fail on a populated one.
     """
     engine = manager.engine
     chain = manager.revision_chain()
@@ -204,8 +201,8 @@ async def test_downgrading_only_the_last_revision_preserves_rows(manager: Migrat
 async def test_downgrade_to_base_leaves_alembic_bookkeeping_intact(manager: MigrationManager):
     """A migration must not drop ``alembic_version``.
 
-    Alembic deletes the revision row in the same transaction, so dropping the table there
-    aborts the whole downgrade — which is why this used to be impossible rather than lossy.
+    Alembic deletes the revision row in the same transaction, so dropping the table aborts
+    the whole downgrade — which is why this used to be impossible rather than lossy.
     """
     await manager.migrate_to("heads")
     await seed_revision_001(manager.engine)
@@ -219,8 +216,8 @@ async def test_downgrade_to_base_leaves_alembic_bookkeeping_intact(manager: Migr
 async def test_head_schema_matches_the_orm_models(manager: MigrationManager):
     """Every ORM table and column exists at head, in the database the migrations built.
 
-    A column added to ``models.py`` but not to a migration (or the reverse) otherwise only
-    surfaces at runtime, because the rest of the suite creates its schema from the models.
+    A column in ``models.py`` but not in a migration (or the reverse) otherwise surfaces
+    only at runtime, since the rest of the suite builds its schema from the models.
     """
     await manager.migrate_to("heads")
 
@@ -253,8 +250,8 @@ async def test_unknown_target_is_rejected_before_touching_the_schema(manager: Mi
 async def test_revision_this_image_does_not_contain_is_rejected(manager: MigrationManager):
     """The failure mode of rolling back with the wrong (older) image.
 
-    Alembic cannot traverse a revision it has no script for, so the error has to name the
-    situation rather than surface as a missing-revision KeyError.
+    Alembic cannot traverse a revision it has no script for, so the error has to name that
+    rather than surface as a missing-revision KeyError.
     """
     await manager.migrate_to("heads")
     await execute(manager.engine, "UPDATE alembic_version SET version_num = '004'")
@@ -266,10 +263,9 @@ async def test_revision_this_image_does_not_contain_is_rejected(manager: Migrati
 async def test_a_lock_held_elsewhere_stops_the_migration(manager: MigrationManager, migration_db_url: str):
     """Someone else migrating is a hard failure, not something to work around.
 
-    The lock is taken before the revision is read, so there is no window in which a plan is
-    resolved against a schema another process is moving — a starting orchestrator replica
-    runs `upgrade heads` whatever version it is, so that window would be reachable in a
-    plain pod restart.
+    The lock is taken before the revision is read, so no plan is ever resolved against a
+    schema another process is moving — reachable in a plain pod restart, since every
+    orchestrator runs `upgrade heads` as it starts.
     """
     holder = create_async_engine(migration_db_url, pool_size=1, max_overflow=0)
     try:

--- a/orchestrator/src/idegym/orchestrator/config.py
+++ b/orchestrator/src/idegym/orchestrator/config.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from typing import Any
+
+from hydra import compose, initialize_config_dir
+from idegym.api.config import Config
+from omegaconf import OmegaConf
+
+HYDRA_CONFIG_DIR = Path(__file__).parent / "hydra_configs"
+
+
+def load_config() -> Config:
+    """Compose the orchestrator's Hydra configuration into the shared :class:`Config` model.
+
+    Lives apart from ``main`` so the migration CLI can read the same database settings as
+    the service without importing the FastAPI application and everything it pulls in.
+    """
+    with initialize_config_dir(version_base=None, config_dir=str(HYDRA_CONFIG_DIR)):
+        cfg = compose(config_name="config")
+    container: dict[str, Any] = OmegaConf.to_container(cfg=cfg, resolve=True)
+    return Config(**container)

--- a/orchestrator/src/idegym/orchestrator/config.py
+++ b/orchestrator/src/idegym/orchestrator/config.py
@@ -11,8 +11,8 @@ HYDRA_CONFIG_DIR = Path(__file__).parent / "hydra_configs"
 def load_config() -> Config:
     """Compose the orchestrator's Hydra configuration into the shared :class:`Config` model.
 
-    Lives apart from ``main`` so the migration CLI can read the same database settings as
-    the service without importing the FastAPI application and everything it pulls in.
+    Apart from ``main`` so the migration CLI can read the same database settings without
+    importing the FastAPI application and everything behind it.
     """
     with initialize_config_dir(version_base=None, config_dir=str(HYDRA_CONFIG_DIR)):
         cfg = compose(config_name="config")

--- a/orchestrator/src/idegym/orchestrator/database/database.py
+++ b/orchestrator/src/idegym/orchestrator/database/database.py
@@ -79,8 +79,8 @@ async def init_db(
     db_engine = connect_db_engine(db_url, config)
 
     migration_manager = MigrationManager(engine=db_engine, db_url=db_url)
-    # Before anything is migrated: a release whose declared revision does not match this
-    # image would send a later rollback to the wrong revision, so refuse to start instead.
+    # A declared revision that does not match this image would send a later rollback to the
+    # wrong one, so refuse to start rather than migrate.
     migration_manager.verify_declared_revision(declared_schema_revision)
 
     if clean_database:

--- a/orchestrator/src/idegym/orchestrator/database/database.py
+++ b/orchestrator/src/idegym/orchestrator/database/database.py
@@ -70,10 +70,19 @@ def connect_db_engine(db_url: str, config: SQLAlchemyConfig) -> AsyncEngine:
     return db_engine
 
 
-async def init_db(db_url: str, config: SQLAlchemyConfig, clean_database: bool = False):
+async def init_db(
+    db_url: str,
+    config: SQLAlchemyConfig,
+    clean_database: bool = False,
+    declared_schema_revision: Optional[str] = None,
+):
     db_engine = connect_db_engine(db_url, config)
 
     migration_manager = MigrationManager(engine=db_engine, db_url=db_url)
+    # Before anything is migrated: a release whose declared revision does not match this
+    # image would send a later rollback to the wrong revision, so refuse to start instead.
+    migration_manager.verify_declared_revision(declared_schema_revision)
+
     if clean_database:
         logger.warning("Database cleanup requested before migrations")
         await migration_manager.clean_database()
@@ -88,7 +97,7 @@ async def init_db(db_url: str, config: SQLAlchemyConfig, clean_database: bool = 
         max_wait_time = 300
         poll_interval = 1
 
-        expected_version = migration_manager.get_expected_version()
+        expected_version = migration_manager.head_revision()
         loop = asyncio.get_running_loop()
         start_time = loop.time()
 

--- a/orchestrator/src/idegym/orchestrator/db_cli.py
+++ b/orchestrator/src/idegym/orchestrator/db_cli.py
@@ -141,11 +141,19 @@ async def _run_schema_command(args: Namespace, manager: MigrationManager) -> int
 
 
 async def _run_migrate_command(args: Namespace, manager: MigrationManager) -> int:
+    """Print the plan — resolved only, or resolved and applied.
+
+    The plan is this command's output, not a progress note: with ``--dry-run`` it is the
+    whole point of the invocation, and afterwards it is the record of what the migration
+    did. ``scripts/rollback.py`` shows it to the operator by printing the Job's logs, which
+    is how a downgrade gets read and approved before any writer is stopped.
+    """
     if args.dry_run:
         plan = manager.plan_migration(current=await manager.get_current_revision(), target=args.target)
         print(plan.describe())
         if plan.direction is MigrationDirection.DOWNGRADE and not args.allow_downgrade:
-            print("(would refuse to run without --allow-downgrade)")
+            # Advice about a future invocation, so not part of the answer.
+            print("note: running this for real would need --allow-downgrade", file=sys.stderr)
         return EXIT_OK
 
     plan = await manager.migrate_to(args.target, allow_downgrade=args.allow_downgrade)

--- a/orchestrator/src/idegym/orchestrator/db_cli.py
+++ b/orchestrator/src/idegym/orchestrator/db_cli.py
@@ -30,6 +30,7 @@ Usage::
 import asyncio
 import sys
 from argparse import ArgumentParser, Namespace
+from enum import StrEnum
 from typing import Optional
 
 from idegym.api.config import Config
@@ -44,19 +45,32 @@ EXIT_OK = 0
 EXIT_ERROR = 1
 
 
+class Command(StrEnum):
+    """Top-level subcommands. Members double as the names argparse registers and matches."""
+
+    SCHEMA = "schema"
+    MIGRATE = "migrate"
+
+
+class SchemaCommand(StrEnum):
+    CURRENT = "current"
+    HEAD = "head"
+    VERIFY = "verify"
+
+
 def build_parser() -> ArgumentParser:
     parser = ArgumentParser(prog="idegym-db", description="Inspect and migrate the IdeGYM database schema.")
     subcommands = parser.add_subparsers(dest="command", required=True)
 
-    schema = subcommands.add_parser("schema", help="Inspect the schema revision").add_subparsers(
+    schema = subcommands.add_parser(Command.SCHEMA, help="Inspect the schema revision").add_subparsers(
         dest="schema_command", required=True
     )
-    schema.add_parser("current", help="Print the revision recorded in the database")
-    schema.add_parser("head", help="Print the newest revision this image contains")
-    verify = schema.add_parser("verify", help="Exit non-zero unless the database is at an exact revision")
+    schema.add_parser(SchemaCommand.CURRENT, help="Print the revision recorded in the database")
+    schema.add_parser(SchemaCommand.HEAD, help="Print the newest revision this image contains")
+    verify = schema.add_parser(SchemaCommand.VERIFY, help="Exit non-zero unless the database is at an exact revision")
     verify.add_argument("--expect", required=True, metavar="REVISION", help=f"Revision to require, or {BASE_REVISION}")
 
-    migrate = subcommands.add_parser("migrate", help="Migrate the schema to an exact revision")
+    migrate = subcommands.add_parser(Command.MIGRATE, help="Migrate the schema to an exact revision")
     migrate.add_argument(
         "--target",
         required=True,
@@ -104,7 +118,7 @@ async def _dispatch(args: Namespace, config: Config) -> int:
     engine = create_async_engine(database.url, pool_size=1, max_overflow=0)
     try:
         manager = MigrationManager(engine=engine, db_url=database.url)
-        if args.command == "schema":
+        if args.command == Command.SCHEMA:
             return await _run_schema_command(args, manager)
         return await _run_migrate_command(args, manager)
     finally:
@@ -112,17 +126,15 @@ async def _dispatch(args: Namespace, config: Config) -> int:
 
 
 async def _run_schema_command(args: Namespace, manager: MigrationManager) -> int:
-    if args.schema_command == "head":
+    if args.schema_command == SchemaCommand.HEAD:
         print(manager.head_revision())
         return EXIT_OK
 
+    # `current` and `verify` both report where the database is; only `verify` judges it.
     current = await manager.get_current_revision() or BASE_REVISION
-    if args.schema_command == "current":
-        print(current)
-        return EXIT_OK
-
     print(current)
-    if current != args.expect:
+
+    if args.schema_command == SchemaCommand.VERIFY and current != args.expect:
         print(f"error: database is at revision {current}, expected {args.expect}", file=sys.stderr)
         return EXIT_ERROR
     return EXIT_OK

--- a/orchestrator/src/idegym/orchestrator/db_cli.py
+++ b/orchestrator/src/idegym/orchestrator/db_cli.py
@@ -1,21 +1,18 @@
 """Command-line access to the orchestrator's database schema.
 
-The orchestrator only ever migrates forward, at startup. Rolling a release back needs the
-opposite: moving the schema to one *exact* revision, in a one-shot pod, with every IdeGYM
-writer stopped. This module is that entry point, and it reads the same Hydra/``POSTGRES_*``
-configuration as the service, so a Job that copies the orchestrator Deployment's
-environment needs no extra wiring.
+The orchestrator only migrates forward, at startup. Rolling a release back needs the
+opposite: an *exact* revision, in a one-shot pod, with every IdeGYM writer stopped. This is
+that entry point, and it reads the same Hydra/``POSTGRES_*`` configuration as the service,
+so a Job copying the orchestrator Deployment's environment needs no extra wiring.
 
-Nothing here is safe to run against a live deployment on its own —
-``scripts/rollback.py`` is what stops the writers and sequences the steps. Run this
-directly only to inspect the schema, or when following the manual procedure in
-`Database Rollback <../../../website/docs/reference/database_rollback.md>`_.
+Running it against a live deployment is not safe on its own — ``scripts/rollback.py`` stops
+the writers and sequences the steps. Use this directly to inspect the schema, or when
+following `Database Rollback <../../../website/docs/reference/database_rollback.md>`_.
 
-**Streams.** stdout carries the command's answer and nothing else, so ``schema current`` can
-be captured into a variable. Everything else goes to stderr: failures as a plain
-``error: ...`` line, and the migration's own progress — lock acquired, plan, lock released —
-as structlog records from :mod:`idegym.orchestrator.migration_manager`. A container runtime
-captures both streams, so ``kubectl logs`` on a migration Job shows the whole story.
+**Streams.** stdout is the command's answer and nothing else, so ``schema current`` can be
+captured into a variable. Everything else goes to stderr: failures as ``error: ...``, and
+the migration's progress as structlog records. A container runtime captures both, so
+``kubectl logs`` on a migration Job still shows the whole story.
 
 Usage::
 
@@ -90,8 +87,7 @@ def build_parser() -> ArgumentParser:
 def main(argv: Optional[list[str]] = None) -> int:
     args = build_parser().parse_args(argv)
     config = load_config()
-    # Logs go to stderr so stdout stays the command's answer and nothing else; both are
-    # captured by the container runtime, so a Job's logs show them together regardless.
+    # Logs to stderr so stdout stays the answer; a Job's logs still show both.
     configure_logging(config=config.logging, stream=sys.stderr)
     configure_sqlalchemy_logging(config=config.logging)
 
@@ -144,9 +140,8 @@ async def _run_migrate_command(args: Namespace, manager: MigrationManager) -> in
     """Print the plan — resolved only, or resolved and applied.
 
     The plan is this command's output, not a progress note: with ``--dry-run`` it is the
-    whole point of the invocation, and afterwards it is the record of what the migration
-    did. ``scripts/rollback.py`` shows it to the operator by printing the Job's logs, which
-    is how a downgrade gets read and approved before any writer is stopped.
+    point of the invocation, and otherwise the record of what ran. ``scripts/rollback.py``
+    shows it by printing the Job's logs, which is how a downgrade is approved.
     """
     if args.dry_run:
         plan = manager.plan_migration(current=await manager.get_current_revision(), target=args.target)

--- a/orchestrator/src/idegym/orchestrator/db_cli.py
+++ b/orchestrator/src/idegym/orchestrator/db_cli.py
@@ -1,0 +1,135 @@
+"""Command-line access to the orchestrator's database schema.
+
+The orchestrator only ever migrates forward, at startup. Rolling a release back needs the
+opposite: moving the schema to one *exact* revision, in a one-shot pod, with every IdeGYM
+writer stopped. This module is that entry point, and it reads the same Hydra/``POSTGRES_*``
+configuration as the service, so a Job that copies the orchestrator Deployment's
+environment needs no extra wiring.
+
+Nothing here is safe to run against a live deployment on its own —
+``scripts/rollback.py`` is what stops the writers and sequences the steps. Run this
+directly only to inspect the schema, or when following the manual procedure in
+`Database Rollback <../../../website/docs/reference/database_rollback.md>`_.
+
+Usage::
+
+    python -m idegym.orchestrator.db_cli schema current          # revision the database is at
+    python -m idegym.orchestrator.db_cli schema head             # revision this image can reach
+    python -m idegym.orchestrator.db_cli schema verify --expect 003
+    python -m idegym.orchestrator.db_cli migrate --target 003
+    python -m idegym.orchestrator.db_cli migrate --target 002 --allow-downgrade
+    python -m idegym.orchestrator.db_cli migrate --target 002 --dry-run
+"""
+
+import asyncio
+import sys
+from argparse import ArgumentParser, Namespace
+from typing import Optional
+
+from idegym.api.config import Config
+from idegym.api.exceptions import MigrationError
+from idegym.backend.utils.logging import configure_logging, configure_sqlalchemy_logging
+from idegym.orchestrator.config import load_config
+from idegym.orchestrator.migration_manager import BASE_REVISION, MigrationDirection, MigrationManager
+from idegym.utils.logging import get_logger
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import create_async_engine
+
+logger = get_logger(__name__)
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+
+
+def build_parser() -> ArgumentParser:
+    parser = ArgumentParser(prog="idegym-db", description="Inspect and migrate the IdeGYM database schema.")
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    schema = subcommands.add_parser("schema", help="Inspect the schema revision").add_subparsers(
+        dest="schema_command", required=True
+    )
+    schema.add_parser("current", help="Print the revision recorded in the database")
+    schema.add_parser("head", help="Print the newest revision this image contains")
+    verify = schema.add_parser("verify", help="Exit non-zero unless the database is at an exact revision")
+    verify.add_argument("--expect", required=True, metavar="REVISION", help=f"Revision to require, or {BASE_REVISION}")
+
+    migrate = subcommands.add_parser("migrate", help="Migrate the schema to an exact revision")
+    migrate.add_argument(
+        "--target",
+        required=True,
+        metavar="REVISION",
+        help=f"Exact revision to end at, or {BASE_REVISION}. Relative targets such as -1 are not accepted",
+    )
+    migrate.add_argument(
+        "--allow-downgrade",
+        action="store_true",
+        help="Approve reverting revisions. Required for any backwards move, which may discard data",
+    )
+    migrate.add_argument("--dry-run", action="store_true", help="Print the plan without touching the database")
+
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    config = load_config()
+    configure_logging(config=config.logging)
+    configure_sqlalchemy_logging(config=config.logging)
+
+    try:
+        return asyncio.run(_dispatch(args, config))
+    except MigrationError as e:
+        # The message is the operator-facing half of the failure; the traceback is noise.
+        print(f"error: {e}", file=sys.stderr)
+        return EXIT_ERROR
+    except (OSError, SQLAlchemyError) as e:
+        database = config.orchestrator.database
+        print(f"error: cannot use the database at {database.host}:{database.port}/{database.db}: {e}", file=sys.stderr)
+        return EXIT_ERROR
+
+
+async def _dispatch(args: Namespace, config: Config) -> int:
+    database = config.orchestrator.database
+    # A one-shot command needs one connection, and NullPool would reconnect per statement.
+    engine = create_async_engine(database.url, pool_size=1, max_overflow=0)
+    try:
+        manager = MigrationManager(engine=engine, db_url=database.url)
+        if args.command == "schema":
+            return await _run_schema_command(args, manager)
+        return await _run_migrate_command(args, manager)
+    finally:
+        await engine.dispose()
+
+
+async def _run_schema_command(args: Namespace, manager: MigrationManager) -> int:
+    if args.schema_command == "head":
+        print(manager.head_revision())
+        return EXIT_OK
+
+    current = await manager.get_current_revision() or BASE_REVISION
+    if args.schema_command == "current":
+        print(current)
+        return EXIT_OK
+
+    print(current)
+    if current != args.expect:
+        print(f"error: database is at revision {current}, expected {args.expect}", file=sys.stderr)
+        return EXIT_ERROR
+    return EXIT_OK
+
+
+async def _run_migrate_command(args: Namespace, manager: MigrationManager) -> int:
+    if args.dry_run:
+        plan = manager.plan_migration(current=await manager.get_current_revision(), target=args.target)
+        print(plan.describe())
+        if plan.direction is MigrationDirection.DOWNGRADE and not args.allow_downgrade:
+            print("(would refuse to run without --allow-downgrade)")
+        return EXIT_OK
+
+    plan = await manager.migrate_to(args.target, allow_downgrade=args.allow_downgrade)
+    print(plan.describe())
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/orchestrator/src/idegym/orchestrator/db_cli.py
+++ b/orchestrator/src/idegym/orchestrator/db_cli.py
@@ -11,6 +11,12 @@ Nothing here is safe to run against a live deployment on its own —
 directly only to inspect the schema, or when following the manual procedure in
 `Database Rollback <../../../website/docs/reference/database_rollback.md>`_.
 
+**Streams.** stdout carries the command's answer and nothing else, so ``schema current`` can
+be captured into a variable. Everything else goes to stderr: failures as a plain
+``error: ...`` line, and the migration's own progress — lock acquired, plan, lock released —
+as structlog records from :mod:`idegym.orchestrator.migration_manager`. A container runtime
+captures both streams, so ``kubectl logs`` on a migration Job shows the whole story.
+
 Usage::
 
     python -m idegym.orchestrator.db_cli schema current          # revision the database is at
@@ -31,11 +37,8 @@ from idegym.api.exceptions import MigrationError
 from idegym.backend.utils.logging import configure_logging, configure_sqlalchemy_logging
 from idegym.orchestrator.config import load_config
 from idegym.orchestrator.migration_manager import BASE_REVISION, MigrationDirection, MigrationManager
-from idegym.utils.logging import get_logger
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import create_async_engine
-
-logger = get_logger(__name__)
 
 EXIT_OK = 0
 EXIT_ERROR = 1
@@ -73,7 +76,9 @@ def build_parser() -> ArgumentParser:
 def main(argv: Optional[list[str]] = None) -> int:
     args = build_parser().parse_args(argv)
     config = load_config()
-    configure_logging(config=config.logging)
+    # Logs go to stderr so stdout stays the command's answer and nothing else; both are
+    # captured by the container runtime, so a Job's logs show them together regardless.
+    configure_logging(config=config.logging, stream=sys.stderr)
     configure_sqlalchemy_logging(config=config.logging)
 
     try:

--- a/orchestrator/src/idegym/orchestrator/db_cli.py
+++ b/orchestrator/src/idegym/orchestrator/db_cli.py
@@ -82,6 +82,11 @@ def main(argv: Optional[list[str]] = None) -> int:
         # The message is the operator-facing half of the failure; the traceback is noise.
         print(f"error: {e}", file=sys.stderr)
         return EXIT_ERROR
+    except TimeoutError:
+        # A migration that outran its timeout may still be applying; say so rather than
+        # reporting it as a connection problem (TimeoutError is an OSError).
+        print("error: the migration did not finish in time; check the schema before retrying", file=sys.stderr)
+        return EXIT_ERROR
     except (OSError, SQLAlchemyError) as e:
         database = config.orchestrator.database
         print(f"error: cannot use the database at {database.host}:{database.port}/{database.db}: {e}", file=sys.stderr)

--- a/orchestrator/src/idegym/orchestrator/hydra_configs/orchestrator/base.yaml
+++ b/orchestrator/src/idegym/orchestrator/hydra_configs/orchestrator/base.yaml
@@ -31,6 +31,7 @@ database:
   password: ${oc.env:POSTGRES_PASSWORD, "postgres"}
   db: ${oc.env:POSTGRES_DB, "idegym"}
   clean_database: ${oc.env:IDEGYM_CLEAN_DATABASE, "False"}
+  schema_revision: ${oc.env:IDEGYM_DATABASE_SCHEMA_REVISION, null}
 
 sqlalchemy:
   pool_size: ${oc.env:IDEGYM_SQLALCHEMY_POOL_SIZE, "20"}

--- a/orchestrator/src/idegym/orchestrator/main.py
+++ b/orchestrator/src/idegym/orchestrator/main.py
@@ -1,13 +1,11 @@
 from asyncio import create_task, gather, get_event_loop, sleep
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any
 
 import uvicorn
 from fastapi import FastAPI
 from fastmcp.utilities.lifespan import combine_lifespans
 from httpx import AsyncClient, Limits, Timeout
-from hydra import compose, initialize_config_dir
 from idegym.api.config import Config
 from idegym.backend.utils.diagnostics import dump_tasks_periodically
 from idegym.backend.utils.instrumentation.uvicorn import UvicornInstrumentor
@@ -15,6 +13,7 @@ from idegym.backend.utils.kubernetes_client import load_kubernetes_config
 from idegym.backend.utils.logging import configure_logging, configure_sqlalchemy_logging
 from idegym.backend.utils.otel import configure_telemetry, system_metrics_config
 from idegym.backend.utils.starlette.middleware import AsyncioTaskContextMiddleware, TracingMiddleware
+from idegym.orchestrator.config import load_config
 from idegym.orchestrator.database.database import init_db
 from idegym.orchestrator.mcp import create_mcp_server
 from idegym.orchestrator.router import (
@@ -29,7 +28,6 @@ from idegym.orchestrator.router import (
 )
 from idegym.utils import __version__
 from idegym.utils.logging import get_logger
-from omegaconf import OmegaConf
 from opentelemetry.instrumentation.aiohttp_client import AioHttpClientInstrumentor
 from opentelemetry.instrumentation.asyncio import AsyncioInstrumentor
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
@@ -38,13 +36,6 @@ from opentelemetry.instrumentation.jinja2 import Jinja2Instrumentor
 from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
 
 logger = get_logger("idegym.orchestrator")
-
-
-def load_config() -> Config:
-    with initialize_config_dir(version_base=None, config_dir=str(Path(__file__).parent / "hydra_configs")):
-        cfg = compose(config_name="config")
-    container: dict[str, Any] = OmegaConf.to_container(cfg=cfg, resolve=True)
-    return Config(**container)
 
 
 def configure_process(config: Config) -> None:
@@ -73,6 +64,7 @@ async def lifespan(app: FastAPI):
         db_url=config.orchestrator.database.url,
         config=config.orchestrator.sqlalchemy,
         clean_database=config.orchestrator.database.clean_database,
+        declared_schema_revision=config.orchestrator.database.schema_revision,
     )
 
     get_event_loop().set_debug(config.orchestrator.asyncio.debug)

--- a/orchestrator/src/idegym/orchestrator/migration_manager.py
+++ b/orchestrator/src/idegym/orchestrator/migration_manager.py
@@ -1,14 +1,57 @@
 import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
+from typing import Optional
 
 from alembic import command
 from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory
+from idegym.api.exceptions import MigrationError
 from idegym.utils.logging import get_logger
-from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy import Connection, text
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
 
 logger = get_logger(__name__)
+
+MIGRATION_LOCK_ID = 42239
+
+# Alembic's own name for "no revision applied"; a valid downgrade target, never a revision id.
+BASE_REVISION = "base"
+
+# Aliases Alembic accepts for the newest revision. Rollback must never use them: it targets
+# the exact revision the older release declared.
+HEAD_ALIASES = frozenset({"head", "heads"})
+
+
+class MigrationDirection(StrEnum):
+    UPGRADE = "upgrade"
+    DOWNGRADE = "downgrade"
+    NOOP = "noop"
+
+
+@dataclass(frozen=True)
+class MigrationPlan:
+    """What a migration would do, resolved before anything touches the database.
+
+    ``revisions`` lists the revisions in execution order — applied for an upgrade,
+    reverted for a downgrade — so an operator can see the blast radius of a downgrade
+    before approving it.
+    """
+
+    direction: MigrationDirection
+    current: Optional[str]
+    target: str
+    revisions: tuple[str, ...]
+
+    def describe(self) -> str:
+        current = self.current or BASE_REVISION
+        if self.direction is MigrationDirection.NOOP:
+            return f"database is already at revision {current}"
+        return f"{self.direction} {current} -> {self.target} via {', '.join(self.revisions)}"
 
 
 class MigrationManager:
@@ -53,24 +96,38 @@ class MigrationManager:
             raise eg.exceptions[0]
 
     async def _run_migrations_with_lock(self) -> bool:
-        async with self.engine.begin() as conn:
-            result = await conn.execute(text("SELECT pg_try_advisory_lock(42239)"))
-            lock_acquired = result.scalar()
-
-            if not lock_acquired:
+        async with self._advisory_lock() as lock_connection:
+            if lock_connection is None:
                 logger.info("Another process is already running migrations, skipping")
                 return False
 
             logger.info("Acquired migration lock, running migrations")
+            async with asyncio.timeout(self.timeout):
+                await self._run_alembic_migrations()
+            logger.info("Database migrations completed successfully")
+            return True
 
+    @asynccontextmanager
+    async def _advisory_lock(self) -> AsyncIterator[Optional[AsyncConnection]]:
+        """Try to take the migration lock, yielding the holding connection, or None.
+
+        The connection is handed to the caller rather than kept private because the pool
+        can be a single connection — the migration CLI runs with one — so anything the
+        lock holder needs to read has to reuse it instead of waiting for a second.
+
+        The lock only serialises IdeGYM processes against each other. It does not stop an
+        orchestrator or watcher that is already running from writing while the schema
+        changes, so a downgrade still requires those writers to be stopped first.
+        """
+        async with self.engine.begin() as conn:
+            result = await conn.execute(text("SELECT pg_try_advisory_lock(:lock_id)"), {"lock_id": MIGRATION_LOCK_ID})
+            lock_acquired = bool(result.scalar())
             try:
-                async with asyncio.timeout(self.timeout):
-                    await self._run_alembic_migrations()
-                logger.info("Database migrations completed successfully")
-                return True
+                yield conn if lock_acquired else None
             finally:
-                await conn.execute(text("SELECT pg_advisory_unlock(42239)"))
-                logger.info("Released migration lock")
+                if lock_acquired:
+                    await conn.execute(text("SELECT pg_advisory_unlock(:lock_id)"), {"lock_id": MIGRATION_LOCK_ID})
+                    logger.info("Released migration lock")
 
     async def _run_alembic_migrations(self):
         async with asyncio.TaskGroup() as tg:
@@ -83,23 +140,189 @@ class MigrationManager:
 
     def _run_alembic_upgrade(self):
         try:
-            alembic_cfg = Config(self.alembic_ini_path)
-            alembic_cfg.set_main_option("sqlalchemy.url", self.db_url)
-            command.upgrade(alembic_cfg, "heads")
+            command.upgrade(self._alembic_config(), "heads")
             logger.info("Alembic upgrade command completed successfully")
         except Exception as e:
             logger.exception("Alembic upgrade failed")
             raise RuntimeError(f"Database migration failed: {e}") from e
 
-    def get_expected_version(self) -> str:
-        """Return the latest Alembic head revision ID."""
+    async def migrate_to(self, target: str, *, allow_downgrade: bool = False) -> MigrationPlan:
+        """Move the schema to exactly ``target``, in whichever direction that requires.
+
+        This is the deployment-rollback counterpart of :meth:`run_migrations`, which only
+        ever moves forward. Unlike startup migrations, a lock held by someone else is an
+        error rather than a reason to skip: the caller asked for a specific revision and
+        must not be told it succeeded when nothing ran.
+
+        ``allow_downgrade`` has to be set explicitly for a backwards move, so a mistyped
+        target cannot silently drop columns.
+        """
+        plan = self.plan_migration(current=await self.get_current_revision(), target=target)
+        if plan.direction is MigrationDirection.DOWNGRADE and not allow_downgrade:
+            raise MigrationError(
+                f"Refusing to {plan.describe()} without an explicit downgrade approval; "
+                "a downgrade may discard data written by the reverted revisions"
+            )
+
+        if plan.direction is MigrationDirection.NOOP:
+            logger.info("No migration needed", revision=plan.target)
+            return plan
+
+        async with self._advisory_lock() as lock_connection:
+            if lock_connection is None:
+                raise MigrationError(
+                    "Another process holds the migration lock; a migration or rollback is already in progress"
+                )
+
+            # The revision may have moved between planning and taking the lock — a starting
+            # orchestrator replica migrates on its own. Re-plan rather than apply a stale plan.
+            locked_current = await self._read_current_revision(lock_connection)
+            locked_plan = self.plan_migration(current=locked_current, target=target)
+            if locked_plan != plan:
+                raise MigrationError(
+                    f"Database revision changed while acquiring the migration lock "
+                    f"({plan.current} -> {locked_plan.current}); stop all writers and retry"
+                )
+
+            logger.info("Acquired migration lock", plan=plan.describe())
+            async with asyncio.timeout(self.timeout):
+                await asyncio.to_thread(self._run_alembic, plan)
+
+        logger.info("Migration completed", plan=plan.describe())
+        return plan
+
+    def _run_alembic(self, plan: MigrationPlan) -> None:
         try:
-            alembic_cfg = Config(self.alembic_ini_path)
-            script = ScriptDirectory.from_config(alembic_cfg)
-            heads = script.get_heads()
-            if not heads:
-                raise ValueError("No migration heads found")
-            return heads[0]
+            if plan.direction is MigrationDirection.DOWNGRADE:
+                command.downgrade(self._alembic_config(), plan.target)
+            else:
+                command.upgrade(self._alembic_config(), plan.target)
         except Exception as e:
-            logger.exception("Failed to get expected migration version")
-            raise RuntimeError(f"Failed to get expected migration version: {e}") from e
+            logger.exception("Alembic migration failed", plan=plan.describe())
+            raise MigrationError(f"Failed to {plan.describe()}: {e}") from e
+
+    def plan_migration(self, current: Optional[str], target: str) -> MigrationPlan:
+        """Resolve ``current -> target`` into a direction and the revisions it traverses.
+
+        Raises rather than guesses whenever the move is not well defined: an unknown
+        target, a database sitting on a revision this image does not contain (the
+        signature of rolling back with the wrong image), or a revision being reverted
+        that ships no down migration.
+        """
+        chain = self.revision_chain()
+        resolved = self._resolve_target(target, chain)
+        current_position = self._position(current, chain, "Database")
+        target_position = self._position(resolved, chain, "Target")
+
+        if target_position == current_position:
+            return MigrationPlan(MigrationDirection.NOOP, current, resolved, ())
+
+        if target_position > current_position:
+            applied = tuple(chain[current_position + 1 : target_position + 1])
+            return MigrationPlan(MigrationDirection.UPGRADE, current, resolved, applied)
+
+        reverted = tuple(reversed(chain[target_position + 1 : current_position + 1]))
+        self._require_reversible(reverted)
+        return MigrationPlan(MigrationDirection.DOWNGRADE, current, resolved, reverted)
+
+    def revision_chain(self) -> list[str]:
+        """Revision ids ordered base -> head.
+
+        A rollback targets one exact revision, which only means something while the
+        history is a single unbranched line, so a merge point is rejected rather than
+        traversed in an arbitrary order.
+        """
+        self.head_revision()
+        chain: list[str] = []
+        for script in self._script_directory().walk_revisions():
+            down_revision = script.down_revision
+            if isinstance(down_revision, tuple) and len(down_revision) > 1:
+                raise MigrationError(
+                    f"Revision {script.revision} merges {len(down_revision)} branches; "
+                    "exact-revision migration needs a linear history"
+                )
+            chain.append(script.revision)
+        chain.reverse()
+        return chain
+
+    def head_revision(self) -> str:
+        """Return the single Alembic head revision this image can migrate to."""
+        heads = self._script_directory().get_heads()
+        if len(heads) != 1:
+            raise MigrationError(f"Expected exactly one migration head, found {len(heads)}: {sorted(heads)}")
+        return heads[0]
+
+    def verify_declared_revision(self, declared: Optional[str]) -> None:
+        """Fail fast when the release declares a schema revision this image cannot produce.
+
+        The chart's ``database.schemaRevision`` is what a rollback downgrades to, so a
+        value that does not match the image's head would send a later rollback to the
+        wrong revision. Refusing to start turns that into a failed rollout instead.
+        """
+        if not declared:
+            return
+
+        head = self.head_revision()
+        if declared != head:
+            raise MigrationError(
+                f"Release declares database schema revision {declared!r} but this image's migrations "
+                f"end at {head!r}; align database.schemaRevision in the chart with the deployed image"
+            )
+
+    async def get_current_revision(self) -> Optional[str]:
+        """Return the revision recorded in ``alembic_version``, or None if none is."""
+        async with self.engine.connect() as conn:
+            return await self._read_current_revision(conn)
+
+    async def _read_current_revision(self, conn: AsyncConnection) -> Optional[str]:
+        heads = await conn.run_sync(self._current_heads)
+        if len(heads) > 1:
+            raise MigrationError(f"Database records {len(heads)} applied heads: {sorted(heads)}")
+        return heads[0] if heads else None
+
+    def _resolve_target(self, target: str, chain: list[str]) -> str:
+        if target in HEAD_ALIASES:
+            return chain[-1]
+        return target
+
+    def _position(self, revision: Optional[str], chain: list[str], role: str) -> int:
+        """Index of ``revision`` in the chain, with ``base``/unmigrated at -1."""
+        if revision is None or revision == BASE_REVISION:
+            return -1
+        try:
+            return chain.index(revision)
+        except ValueError:
+            raise MigrationError(
+                f"{role} revision {revision!r} is not one of the migrations in this image "
+                f"({', '.join(chain)}); use the image that introduced it"
+            ) from None
+
+    def _require_reversible(self, revisions: tuple[str, ...]) -> None:
+        """Reject a downgrade whose revisions were never made reversible.
+
+        Migrations are SQL-first: every revision ships ``<rev>_down.sql`` beside its
+        module, an invariant ``unit-tests/test_migrations.py`` enforces. A missing file
+        therefore means the revision has no downgrade, not that it uses another mechanism.
+        """
+        versions = Path(self._script_directory().versions)
+        missing = [revision for revision in revisions if not (versions / f"{revision}_down.sql").is_file()]
+        if missing:
+            raise MigrationError(
+                f"Revisions {', '.join(missing)} ship no down migration and cannot be reverted; "
+                "restore a database backup instead"
+            )
+
+    def _alembic_config(self) -> Config:
+        alembic_cfg = Config(self.alembic_ini_path)
+        alembic_cfg.set_main_option("sqlalchemy.url", self.db_url)
+        return alembic_cfg
+
+    def _script_directory(self) -> ScriptDirectory:
+        try:
+            return ScriptDirectory.from_config(self._alembic_config())
+        except Exception as e:
+            raise MigrationError(f"Failed to read the migration scripts: {e}") from e
+
+    @staticmethod
+    def _current_heads(connection: Connection) -> tuple[str, ...]:
+        return MigrationContext.configure(connection).get_current_heads()

--- a/orchestrator/src/idegym/orchestrator/migration_manager.py
+++ b/orchestrator/src/idegym/orchestrator/migration_manager.py
@@ -19,11 +19,11 @@ logger = get_logger(__name__)
 
 MIGRATION_LOCK_ID = 42239
 
-# Alembic's own name for "no revision applied"; a valid downgrade target, never a revision id.
+# Alembic's name for "no revision applied": a valid downgrade target, never a revision id.
 BASE_REVISION = "base"
 
-# Aliases Alembic accepts for the newest revision. Rollback must never use them: it targets
-# the exact revision the older release declared.
+# Aliases for the newest revision. A rollback must not use them — it targets the exact
+# revision the older release declared.
 HEAD_ALIASES = frozenset({"head", "heads"})
 
 
@@ -37,9 +37,8 @@ class MigrationDirection(StrEnum):
 class MigrationPlan:
     """What a migration would do, resolved before anything touches the database.
 
-    ``revisions`` lists the revisions in execution order — applied for an upgrade,
-    reverted for a downgrade — so an operator can see the blast radius of a downgrade
-    before approving it.
+    ``revisions`` is in execution order — applied for an upgrade, reverted for a downgrade —
+    so an operator sees the blast radius before approving one.
     """
 
     direction: MigrationDirection
@@ -111,13 +110,12 @@ class MigrationManager:
     async def _advisory_lock(self) -> AsyncIterator[Optional[AsyncConnection]]:
         """Try to take the migration lock, yielding the holding connection, or None.
 
-        The connection is handed to the caller rather than kept private because the pool
-        can be a single connection — the migration CLI runs with one — so anything the
-        lock holder needs to read has to reuse it instead of waiting for a second.
+        The connection is handed to the caller because the pool can be a single connection —
+        the CLI runs with one — so a read taken under the lock has to reuse it.
 
-        The lock only serialises IdeGYM processes against each other. It does not stop an
-        orchestrator or watcher that is already running from writing while the schema
-        changes, so a downgrade still requires those writers to be stopped first.
+        The lock only serialises IdeGYM processes against each other; it does not stop a
+        running orchestrator or watcher from writing, so a downgrade still needs those
+        stopped first.
         """
         async with self.engine.begin() as conn:
             result = await conn.execute(text("SELECT pg_try_advisory_lock(:lock_id)"), {"lock_id": MIGRATION_LOCK_ID})
@@ -149,19 +147,14 @@ class MigrationManager:
     async def migrate_to(self, target: str, *, allow_downgrade: bool = False) -> MigrationPlan:
         """Move the schema to exactly ``target``, in whichever direction that requires.
 
-        This is the deployment-rollback counterpart of :meth:`run_migrations`, which only
-        ever moves forward. Unlike startup migrations, a lock held by someone else is an
-        error rather than a reason to skip: the caller asked for a specific revision and
-        must not be told it succeeded when nothing ran.
+        The rollback counterpart of :meth:`run_migrations`, which only moves forward. A lock
+        held by someone else is an error rather than a reason to skip: the caller asked for a
+        specific revision and must not be told it succeeded when nothing ran.
 
-        The lock is taken before the revision is even read, so the plan cannot be resolved
-        against a schema that then moves under it. It can move for reasons that have
-        nothing to do with a new release: *every* orchestrator pod runs ``upgrade heads``
-        as it starts, so a crash-loop restart, an eviction, a node drain or a scale-up is
-        enough — as is a second operator running this command.
-
-        ``allow_downgrade`` has to be set explicitly for a backwards move, so a mistyped
-        target cannot silently drop columns.
+        The lock comes before the read, so no plan is resolved against a schema that then
+        moves under it — no new release required, since every orchestrator pod runs
+        ``upgrade heads`` as it starts. ``allow_downgrade`` must be set explicitly, so a
+        mistyped target cannot silently drop columns.
         """
         async with self._advisory_lock() as lock_connection:
             if lock_connection is None:
@@ -200,10 +193,9 @@ class MigrationManager:
     def plan_migration(self, current: Optional[str], target: str) -> MigrationPlan:
         """Resolve ``current -> target`` into a direction and the revisions it traverses.
 
-        Raises rather than guesses whenever the move is not well defined: an unknown
-        target, a database sitting on a revision this image does not contain (the
-        signature of rolling back with the wrong image), or a revision being reverted
-        that ships no down migration.
+        Raises rather than guesses when the move is not well defined: an unknown target, a
+        database on a revision this image does not contain (the signature of rolling back
+        with the wrong image), or a reverted revision with no down migration.
         """
         chain = self.revision_chain()
         resolved = self._resolve_target(target, chain)
@@ -224,9 +216,8 @@ class MigrationManager:
     def revision_chain(self) -> list[str]:
         """Revision ids ordered base -> head.
 
-        A rollback targets one exact revision, which only means something while the
-        history is a single unbranched line, so a merge point is rejected rather than
-        traversed in an arbitrary order.
+        An exact target only means something while the history is one unbranched line, so a
+        merge point is rejected rather than traversed in an arbitrary order.
         """
         self.head_revision()
         chain: list[str] = []
@@ -251,9 +242,9 @@ class MigrationManager:
     def verify_declared_revision(self, declared: Optional[str]) -> None:
         """Fail fast when the release declares a schema revision this image cannot produce.
 
-        The chart's ``database.schemaRevision`` is what a rollback downgrades to, so a
-        value that does not match the image's head would send a later rollback to the
-        wrong revision. Refusing to start turns that into a failed rollout instead.
+        ``database.schemaRevision`` is what a rollback downgrades to, so a value that does
+        not match the image's head would send a later rollback to the wrong revision.
+        Refusing to start turns that into a failed rollout instead.
         """
         if not declared:
             return
@@ -296,9 +287,9 @@ class MigrationManager:
     def _require_reversible(self, revisions: tuple[str, ...]) -> None:
         """Reject a downgrade whose revisions were never made reversible.
 
-        Migrations are SQL-first: every revision ships ``<rev>_down.sql`` beside its
-        module, an invariant ``unit-tests/test_migrations.py`` enforces. A missing file
-        therefore means the revision has no downgrade, not that it uses another mechanism.
+        Migrations are SQL-first — every revision ships ``<rev>_down.sql``, enforced by
+        ``unit-tests/test_migrations.py`` — so a missing file means no downgrade exists,
+        not that another mechanism is in use.
         """
         versions = Path(self._script_directory().versions)
         missing = [revision for revision in revisions if not (versions / f"{revision}_down.sql").is_file()]

--- a/orchestrator/src/idegym/orchestrator/migration_manager.py
+++ b/orchestrator/src/idegym/orchestrator/migration_manager.py
@@ -154,37 +154,33 @@ class MigrationManager:
         error rather than a reason to skip: the caller asked for a specific revision and
         must not be told it succeeded when nothing ran.
 
+        The lock is taken before the revision is even read, so the plan cannot be resolved
+        against a schema that then moves under it. It can move for reasons that have
+        nothing to do with a new release: *every* orchestrator pod runs ``upgrade heads``
+        as it starts, so a crash-loop restart, an eviction, a node drain or a scale-up is
+        enough — as is a second operator running this command.
+
         ``allow_downgrade`` has to be set explicitly for a backwards move, so a mistyped
         target cannot silently drop columns.
         """
-        plan = self.plan_migration(current=await self.get_current_revision(), target=target)
-        if plan.direction is MigrationDirection.DOWNGRADE and not allow_downgrade:
-            raise MigrationError(
-                f"Refusing to {plan.describe()} without an explicit downgrade approval; "
-                "a downgrade may discard data written by the reverted revisions"
-            )
-
-        if plan.direction is MigrationDirection.NOOP:
-            logger.info("No migration needed", revision=plan.target)
-            return plan
-
         async with self._advisory_lock() as lock_connection:
             if lock_connection is None:
                 raise MigrationError(
                     "Another process holds the migration lock; a migration or rollback is already in progress"
                 )
+            logger.info("Acquired migration lock")
 
-            # The revision may have moved between planning and taking the lock — a starting
-            # orchestrator replica migrates on its own. Re-plan rather than apply a stale plan.
-            locked_current = await self._read_current_revision(lock_connection)
-            locked_plan = self.plan_migration(current=locked_current, target=target)
-            if locked_plan != plan:
+            plan = self.plan_migration(current=await self._read_current_revision(lock_connection), target=target)
+            if plan.direction is MigrationDirection.DOWNGRADE and not allow_downgrade:
                 raise MigrationError(
-                    f"Database revision changed while acquiring the migration lock "
-                    f"({plan.current} -> {locked_plan.current}); stop all writers and retry"
+                    f"Refusing to {plan.describe()} without an explicit downgrade approval; "
+                    "a downgrade may discard data written by the reverted revisions"
                 )
 
-            logger.info("Acquired migration lock", plan=plan.describe())
+            if plan.direction is MigrationDirection.NOOP:
+                logger.info("No migration needed", revision=plan.target)
+                return plan
+
             async with asyncio.timeout(self.timeout):
                 await asyncio.to_thread(self._run_alembic, plan)
 

--- a/orchestrator/src/idegym/orchestrator/migrations/README.md
+++ b/orchestrator/src/idegym/orchestrator/migrations/README.md
@@ -4,9 +4,9 @@ This document describes how database migrations are organized and operated for t
 The project uses Alembic and aims to support an SQL‑first workflow.
 
 Location of migration-related files:
-- Alembic configuration: orchestrator/alembic.ini
-- Alembic env: orchestrator/migrations/env.py
-- Migrations: orchestrator/migrations/versions/
+- Alembic configuration: orchestrator/src/idegym/orchestrator/alembic.ini
+- Alembic env: orchestrator/src/idegym/orchestrator/migrations/env.py
+- Migrations: orchestrator/src/idegym/orchestrator/migrations/versions/
 
 
 ## Overview
@@ -25,18 +25,49 @@ On service startup, the Orchestrator calls MigrationManager, which:
 - Releases the lock when done.
 
 Relevant code:
-- orchestrator/src/idegym/orchestrator/database.py (init_db)
+- orchestrator/src/idegym/orchestrator/database/database.py (init_db)
 - orchestrator/src/idegym/orchestrator/migration_manager.py (advisory lock + alembic upgrade logic)
+
+Startup also checks the revision the release declares (`database.schemaRevision` in the chart,
+`IDEGYM_DATABASE_SCHEMA_REVISION` in the pod) against the head in the image, and refuses to
+start when they disagree. A migration must therefore bump that chart value in the same change;
+a unit test enforces it.
+
+
+## How migrations are applied for a rollback
+
+Startup only ever migrates forward. Moving the schema to an exact revision — the older one a
+release being rolled back to declares — goes through the same MigrationManager under the same
+advisory lock, driven from a CLI in the orchestrator image:
+
+```
+python -m idegym.orchestrator.db_cli schema current
+python -m idegym.orchestrator.db_cli schema head
+python -m idegym.orchestrator.db_cli migrate --target 002 --allow-downgrade
+```
+
+Run it only with every writer stopped, and prefer `scripts/rollback.py`, which sequences the
+whole rollback. Both are documented in website/docs/reference/database_rollback.md.
+
+Two rules follow from downgrades being executable rather than decorative:
+- **Never touch `alembic_version`.** Alembic creates it and updates it in the same transaction
+  as the migration; a migration that drops or creates it breaks its own downgrade.
+- **Every revision ships a `<rev>_down.sql`.** The downgrade path is validated against those
+  files before anything runs, so a missing one makes the revision non-revertible — the release
+  can then only be rolled back by restoring a backup.
+
+Every up/down pair is exercised against real PostgreSQL, with data seeded at each revision, in
+integration-tests/database/test_migration_roundtrip.py.
 
 
 ## Directory structure and naming rules
 
-- All migrations live under orchestrator/migrations/versions.
+- All migrations live under orchestrator/src/idegym/orchestrator/migrations/versions.
 - Revision files must follow a strict sequential scheme:
   - Revision IDs: 001, 002, 003, …
   - Filenames: <rev>_<slug>.py, where <rev> is the 3‑digit revision id (e.g., 002_add_something.py)
   - This is enforced by:
-    - orchestrator/alembic.ini: file_template = %(rev)s_%(slug)s
+    - orchestrator/src/idegym/orchestrator/alembic.ini: file_template = %(rev)s_%(slug)s
 - SQL‑first pattern: for each revision, place two SQL files next to the Python file:
   - <rev>_up.sql — DDL/DML to apply during upgrade
   - <rev>_down.sql — DDL/DML to apply during downgrade
@@ -44,9 +75,9 @@ Relevant code:
 - Python script is generated automatically based on script.py.mako template
 
 Example files for rev 001:
-- orchestrator/migrations/versions/001_initial_schema.py
-- orchestrator/migrations/versions/001_up.sql
-- orchestrator/migrations/versions/001_down.sql
+- orchestrator/src/idegym/orchestrator/migrations/versions/001_initial_schema.py
+- orchestrator/src/idegym/orchestrator/migrations/versions/001_up.sql
+- orchestrator/src/idegym/orchestrator/migrations/versions/001_down.sql
 
 
 ## Creating a new migration
@@ -55,12 +86,12 @@ Example files for rev 001:
 
 2) Create a new, empty revision:
    - From the project root:
-     - `uv run alembic -c orchestrator/alembic.ini revision -m "my beautiful migration" --rev-id=002`
-   - This will create a new file orchestrator/migrations/versions/002_my_beautiful_migration.py
+     - `uv run alembic -c orchestrator/src/idegym/orchestrator/alembic.ini revision -m "my beautiful migration" --rev-id=002`
+   - This will create a new file orchestrator/src/idegym/orchestrator/migrations/versions/002_my_beautiful_migration.py
 
 3) Add SQL files next to the created Python file:
-   - Create orchestrator/migrations/versions/002_up.sql
-   - Create orchestrator/migrations/versions/002_down.sql
+   - Create orchestrator/src/idegym/orchestrator/migrations/versions/002_up.sql
+   - Create orchestrator/src/idegym/orchestrator/migrations/versions/002_down.sql
    - Write the necessary DDL/DML statements. Prefer idempotent operations when practical (e.g., CREATE INDEX IF NOT EXISTS) to ease replays in non‑prod.
 
 4) Update the generated Python file to execute your SQL files if needed:
@@ -90,10 +121,10 @@ Example files for rev 001:
 Create a new empty revision and wire SQL files:
 
 1) Create revision:
-   - `uv run alembic -c orchestrator/alembic.ini revision -m "add user audit table" --rev-id=002`
+   - `uv run alembic -c orchestrator/src/idegym/orchestrator/alembic.ini revision -m "add user audit table" --rev-id=002`
 
 2) Suppose Alembic created 002_add_user_audit_table.py. Add:
-   - orchestrator/migrations/versions/002_up.sql
-   - orchestrator/migrations/versions/002_down.sql
+   - orchestrator/src/idegym/orchestrator/migrations/versions/002_up.sql
+   - orchestrator/src/idegym/orchestrator/migrations/versions/002_down.sql
 
 3) Implement 002_up.sql / 002_down.sql and make the Python file call them (already autogenerated).

--- a/orchestrator/src/idegym/orchestrator/migrations/versions/001_down.sql
+++ b/orchestrator/src/idegym/orchestrator/migrations/versions/001_down.sql
@@ -15,5 +15,6 @@ DROP TABLE IF EXISTS servers;
 -- Drop clients table
 DROP TABLE IF EXISTS clients;
 
--- Drop alembic_version table
-DROP TABLE IF EXISTS alembic_version;
+-- alembic_version is deliberately left alone: Alembic owns it and issues the
+-- DELETE that unsets revision 001 in this same transaction. Dropping it here
+-- makes that statement fail and aborts the whole downgrade.

--- a/orchestrator/src/idegym/orchestrator/migrations/versions/001_up.sql
+++ b/orchestrator/src/idegym/orchestrator/migrations/versions/001_up.sql
@@ -83,8 +83,5 @@ CREATE TABLE IF NOT EXISTS async_operations (
     finished_at BIGINT
 );
 
--- Create alembic_version table if it doesn't exist
-CREATE TABLE IF NOT EXISTS alembic_version (
-    version_num VARCHAR(32) NOT NULL,
-    CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
-);
+-- alembic_version is not created here: Alembic creates and stamps its own version
+-- table before the first revision runs. See the note in 001_down.sql.

--- a/scripts/rollback.py
+++ b/scripts/rollback.py
@@ -47,6 +47,17 @@ from typing import Any, Optional
 # a sidecar someone added.
 ORCHESTRATOR_CONTAINER = "orchestrator"
 
+# The chart's own name, and how its two Deployments are told apart from the subcharts that
+# share the release. `idegym.selectorLabels` puts `nameOverride | chart name` in this label,
+# and the watcher's is that plus the suffix.
+APP_NAME_LABEL = "app.kubernetes.io/name"
+CHART_NAME = "idegym"
+WATCHER_NAME_SUFFIX = "-watcher"
+
+# Kubernetes copies a Job's name into a label on the pods it creates, so it cannot exceed the
+# 63-character label limit.
+MAX_JOB_NAME_LENGTH = 63
+
 # Pod-spec keys the migration Job inherits from the orchestrator Deployment. The Job runs the
 # orchestrator image on the same node pool with the same identity, so scheduling and access
 # stay whatever the release configured rather than being restated here.
@@ -130,13 +141,23 @@ def release_values(release: str, namespace: str, revision: Optional[int] = None)
     return run_json(command) or {}
 
 
-def release_deployments(release: str, namespace: str) -> tuple[dict[str, Any], Optional[dict[str, Any]]]:
+def deployments_named(items: list[dict[str, Any]], app_name: str) -> list[dict[str, Any]]:
+    return [item for item in items if (item["metadata"].get("labels") or {}).get(APP_NAME_LABEL) == app_name]
+
+
+def release_deployments(
+    release: str, namespace: str, values: dict[str, Any]
+) -> tuple[dict[str, Any], Optional[dict[str, Any]]]:
     """Return the release's (orchestrator, watcher) Deployments — its two database writers.
 
-    Found by the release's instance label rather than by rebuilding the chart's fullname
-    template, so ``fullnameOverride`` and ``nameOverride`` need no special handling. The
-    watcher is optional (``watcher.enabled``).
+    Matched on the chart's own selector labels rather than by rebuilding the fullname
+    template, so ``fullnameOverride`` needs no special handling. The instance label alone is
+    not enough: every enabled subchart — grafana, prometheus, postgresql — is part of the
+    same release and carries it too. ``app.kubernetes.io/name`` is what separates them, and
+    it follows ``nameOverride`` rather than the resource names. The watcher is optional
+    (``watcher.enabled``).
     """
+    app_name = values.get("nameOverride") or CHART_NAME
     listing = run_json(
         [
             "kubectl",
@@ -151,15 +172,27 @@ def release_deployments(release: str, namespace: str) -> tuple[dict[str, Any], O
         ]
     )
     deployments = listing.get("items", [])
-    watchers = [item for item in deployments if item["metadata"]["name"].endswith("-watcher")]
-    others = [item for item in deployments if item not in watchers]
+    orchestrators = deployments_named(deployments, app_name)
+    watchers = deployments_named(deployments, f"{app_name}{WATCHER_NAME_SUFFIX}")
 
-    if len(others) != 1:
+    if len(orchestrators) != 1:
         found = ", ".join(sorted(item["metadata"]["name"] for item in deployments)) or "none"
         raise RollbackError(
-            f"Expected exactly one orchestrator Deployment for release {release} in {namespace}, found: {found}"
+            f"Expected exactly one Deployment labelled {APP_NAME_LABEL}={app_name} in release {release} "
+            f"({namespace}); the release's Deployments are: {found}"
         )
-    return others[0], watchers[0] if watchers else None
+    return orchestrators[0], watchers[0] if watchers else None
+
+
+def migration_job_name(deployment_name: str, suffix: str) -> str:
+    """Fit ``<deployment>-<suffix>`` into the Job name limit by trimming the deployment part.
+
+    ``idegym.fullname`` is itself truncated to 63 characters, so a long release name would
+    otherwise produce a name the API server rejects — and the rollback would fail on its own
+    Job rather than on anything to do with the schema.
+    """
+    keep = max(1, MAX_JOB_NAME_LENGTH - len(suffix) - 1)
+    return f"{deployment_name[:keep].rstrip('-')}-{suffix}"
 
 
 def orchestrator_container(deployment: dict[str, Any]) -> dict[str, Any]:
@@ -277,12 +310,16 @@ def wait_for_job(name: str, namespace: str, timeout_seconds: int) -> bool:
     return succeeded
 
 
-def exec_in_deployment(name: str, namespace: str, command: list[str]) -> tuple[int, str]:
-    """Run a command in one of the Deployment's pods, returning its exit code and output."""
+def exec_in_deployment(name: str, namespace: str, command: list[str]) -> tuple[int, str, str]:
+    """Run a command in one of the Deployment's pods; returns its exit code, stdout, stderr.
+
+    The two streams stay apart because the container logs to stderr as well as printing its
+    answer to stdout, so a caller reading a value has to look at stdout alone.
+    """
     full = ["kubectl", "exec", f"deployment/{name}", "--namespace", namespace, "--", *command]
     print(f"$ {' '.join(full)}")
     result = subprocess.run(full, capture_output=True, text=True, check=False)
-    return result.returncode, (result.stdout + result.stderr).strip()
+    return result.returncode, result.stdout.strip(), result.stderr.strip()
 
 
 def scale(name: str, namespace: str, replicas: int) -> None:
@@ -320,7 +357,7 @@ def preflight_downgrade(deployment: dict[str, Any], namespace: str, target_revis
     a pod of the *previous* image would answer the question wrongly. The Job runs exactly
     the image the downgrade will use, resolves the plan, and prints it.
     """
-    name = f"{deployment['metadata']['name']}-migrate-check-{target_revision}"
+    name = migration_job_name(deployment["metadata"]["name"], f"migrate-check-{target_revision}")
     create_job(build_migration_job(name, namespace, deployment, target_revision, timeout_seconds, dry_run=True))
     try:
         if not wait_for_job(name, namespace, timeout_seconds):
@@ -380,12 +417,13 @@ def _rollback(args: Namespace, release: str, namespace: str, timeout: int) -> in
     history = run_json([*helm(["history"], release, namespace), "--output", "json"])
     target = find_history_entry(history, args.revision)
 
-    source_schema = declared_schema_revision(release_values(release, namespace), role="deployed")
+    deployed_values = release_values(release, namespace)
+    source_schema = declared_schema_revision(deployed_values, role="deployed")
     target_schema = args.target_schema_revision or declared_schema_revision(
         release_values(release, namespace, args.revision)
     )
 
-    orchestrator, watcher = release_deployments(release, namespace)
+    orchestrator, watcher = release_deployments(release, namespace, deployed_values)
     orchestrator_name = orchestrator["metadata"]["name"]
     writers = [orchestrator, *([watcher] if watcher else [])]
     downgrade_needed = source_schema != target_schema
@@ -432,7 +470,7 @@ def _rollback(args: Namespace, release: str, namespace: str, timeout: int) -> in
     for deployment in writers:
         wait_for_no_pods(deployment, namespace, timeout)
 
-    job_name = f"{orchestrator_name}-migrate-{target_schema}"
+    job_name = migration_job_name(orchestrator_name, f"migrate-{target_schema}")
     create_job(build_migration_job(job_name, namespace, orchestrator, target_schema, timeout))
     if not wait_for_job(job_name, namespace, timeout):
         raise RollbackError(
@@ -477,11 +515,11 @@ def _verify(orchestrator_name: str, namespace: str, expected_schema: str, writer
     ``/health`` — so this adds the two things it cannot see: the recorded schema revision,
     and that every writer came back.
     """
-    code, output = exec_in_deployment(
+    code, stdout, stderr = exec_in_deployment(
         orchestrator_name, namespace, [*MIGRATION_CLI, "schema", "verify", "--expect", expected_schema]
     )
     if code != 0:
-        raise RollbackError(f"The rolled-back release is not at schema revision {expected_schema}: {output}")
+        raise RollbackError(f"The rolled-back release is not at schema revision {expected_schema}: {stderr or stdout}")
 
     for deployment in writers:
         name = deployment["metadata"]["name"]

--- a/scripts/rollback.py
+++ b/scripts/rollback.py
@@ -107,7 +107,7 @@ def find_history_entry(history: list[dict[str, Any]], revision: int) -> dict[str
     raise RollbackError(f"Revision {revision} is not in the release history (have: {known})")
 
 
-def declared_schema_revision(values: dict[str, Any]) -> str:
+def declared_schema_revision(values: dict[str, Any], role: str = "target") -> str:
     """Read ``database.schemaRevision`` out of a release's computed values.
 
     Absent means the release predates this mechanism, and nothing recorded which revision
@@ -117,7 +117,7 @@ def declared_schema_revision(values: dict[str, Any]) -> str:
     revision = (values.get("database") or {}).get("schemaRevision")
     if not revision:
         raise RollbackError(
-            "The target release does not declare database.schemaRevision, so its expected schema "
+            f"The {role} release does not declare database.schemaRevision, so its expected schema "
             "revision is unknown. Pass --target-schema-revision to state it explicitly"
         )
     return str(revision)
@@ -171,16 +171,29 @@ def orchestrator_container(deployment: dict[str, Any]) -> dict[str, Any]:
 
 
 def build_migration_job(
-    name: str, namespace: str, deployment: dict[str, Any], target_revision: str, deadline_seconds: int
+    name: str,
+    namespace: str,
+    deployment: dict[str, Any],
+    target_revision: str,
+    deadline_seconds: int,
+    *,
+    dry_run: bool = False,
 ) -> dict[str, Any]:
-    """A one-shot Job that downgrades the schema using the currently deployed image.
+    """A one-shot Job that migrates the schema using the currently deployed image.
 
     The image and environment are copied from the live orchestrator, which is the point:
     the target release's image predates the migrations being reverted and cannot run them.
     ``backoffLimit: 0`` keeps a failed downgrade from being retried against a half-migrated
     schema.
+
+    With ``dry_run`` the Job only resolves and prints the plan, which is how the preflight
+    asks the source image whether it can make the move — the image in the Deployment spec,
+    not whichever pod happens to be up.
     """
     container = orchestrator_container(deployment)
+    arguments = [*MIGRATION_CLI, "migrate", "--target", target_revision, "--allow-downgrade"]
+    if dry_run:
+        arguments.append("--dry-run")
     pod_spec: dict[str, Any] = {
         key: value for key, value in deployment["spec"]["template"]["spec"].items() if key in INHERITED_POD_SPEC_KEYS
     }
@@ -192,7 +205,7 @@ def build_migration_job(
                 "image": container["image"],
                 "imagePullPolicy": container.get("imagePullPolicy", "IfNotPresent"),
                 "env": container.get("env", []),
-                "command": [*MIGRATION_CLI, "migrate", "--target", target_revision, "--allow-downgrade"],
+                "command": arguments,
             }
         ],
     }
@@ -226,6 +239,14 @@ def create_job(job: dict[str, Any]) -> None:
                 f"(`kubectl logs job/{name} -n {job['metadata']['namespace']}`), then delete it to retry"
             )
         raise RollbackError(f"Could not create Job {name}: {detail}")
+
+
+def delete_job(name: str, namespace: str) -> None:
+    subprocess.run(
+        ["kubectl", "delete", "job", name, "--namespace", namespace, "--ignore-not-found"],
+        capture_output=True,
+        check=False,
+    )
 
 
 def wait_for_job(name: str, namespace: str, timeout_seconds: int) -> bool:
@@ -291,6 +312,26 @@ def replica_count(deployment: dict[str, Any]) -> int:
     return int(deployment["spec"].get("replicas", 1))
 
 
+def preflight_downgrade(deployment: dict[str, Any], namespace: str, target_revision: str, timeout_seconds: int) -> None:
+    """Ask the source image whether it can reach ``target_revision``, changing nothing.
+
+    Runs as a Job rather than ``kubectl exec`` on purpose: a rollback usually follows a
+    failed rollout, when no pod of the new image may be healthy enough to exec into — and
+    a pod of the *previous* image would answer the question wrongly. The Job runs exactly
+    the image the downgrade will use, resolves the plan, and prints it.
+    """
+    name = f"{deployment['metadata']['name']}-migrate-check-{target_revision}"
+    create_job(build_migration_job(name, namespace, deployment, target_revision, timeout_seconds, dry_run=True))
+    try:
+        if not wait_for_job(name, namespace, timeout_seconds):
+            raise RollbackError(
+                f"The deployed image cannot migrate to {target_revision} (see the Job logs above). "
+                "Nothing was stopped and the release is untouched"
+            )
+    finally:
+        delete_job(name, namespace)
+
+
 def _parse_args(argv: Optional[list[str]]) -> Namespace:
     parser = ArgumentParser(description=__doc__.split("\n\n")[0])
     parser.add_argument("--release", required=True, help="Helm release name")
@@ -312,7 +353,12 @@ def _parse_args(argv: Optional[list[str]]) -> Namespace:
 
 def confirm(plan: str) -> bool:
     print(f"\n{plan}\n")
-    return input("Type 'yes' to continue: ").strip().lower() == "yes"
+    try:
+        return input("Type 'yes' to continue: ").strip().lower() == "yes"
+    except EOFError:
+        # Nothing on stdin to answer with — a pipeline has to opt in with --yes.
+        print("No terminal to confirm on; pass --yes to approve the downgrade.", file=sys.stderr)
+        return False
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -334,7 +380,7 @@ def _rollback(args: Namespace, release: str, namespace: str, timeout: int) -> in
     history = run_json([*helm(["history"], release, namespace), "--output", "json"])
     target = find_history_entry(history, args.revision)
 
-    source_schema = declared_schema_revision(release_values(release, namespace))
+    source_schema = declared_schema_revision(release_values(release, namespace), role="deployed")
     target_schema = args.target_schema_revision or declared_schema_revision(
         release_values(release, namespace, args.revision)
     )
@@ -353,17 +399,10 @@ def _rollback(args: Namespace, release: str, namespace: str, timeout: int) -> in
     )
 
     if downgrade_needed:
-        # The live image is the only one that has the migrations being reverted; ask it
-        # whether it can make the move before anything is stopped.
-        code, output = exec_in_deployment(
-            orchestrator_name, namespace, [*MIGRATION_CLI, "migrate", "--target", target_schema, "--dry-run"]
-        )
-        if code != 0:
-            raise RollbackError(f"The deployed image cannot downgrade to {target_schema}: {output}")
-        print(f"  plan reported by the deployed image: {output.splitlines()[-1]}")
+        preflight_downgrade(orchestrator, namespace, target_schema, timeout)
 
     if args.dry_run:
-        print("\n--dry-run: nothing was changed.")
+        print("\n--dry-run: the release, the schema, and both writers are untouched.")
         return 0
 
     if downgrade_needed and not args.yes:
@@ -402,6 +441,10 @@ def _rollback(args: Namespace, release: str, namespace: str, timeout: int) -> in
             f"Inspect the Job above, then either fix the cause and re-run, or restore a backup.\n"
             f"To bring the current release back up as it was:\n{restore_hint}"
         )
+
+    # Its logs are printed above, and leaving it would make the next rollback to this
+    # revision collide with a name that already exists. A *failed* Job is kept on purpose.
+    delete_job(job_name, namespace)
 
     print(f"\nSchema is at {target_schema}; handing over to Helm.")
     try:

--- a/scripts/rollback.py
+++ b/scripts/rollback.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env -S uv run --script --quiet
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+"""Roll an IdeGYM release back, including its database schema.
+
+``helm rollback`` restores Kubernetes resources and nothing else. The orchestrator migrates
+the schema forward on startup, so after a failed upgrade the database is left on the newer
+revision: the older image may not contain it, and Alembic cannot traverse a revision whose
+script it does not have. This script sequences the parts Helm cannot.
+
+Two shapes of rollback, decided from the ``database.schemaRevision`` each release declares:
+
+* **Same revision** — the upgrade did not change the schema. Plain ``helm rollback``.
+* **Older revision** — stop both database writers, downgrade to the target release's exact
+  revision *with the currently deployed image* (the only one that contains the migrations
+  being reverted), and only then hand over to ``helm rollback``. A failed downgrade never
+  reaches Helm and never restarts a writer.
+
+A downgrade discards whatever the reverted revisions stored — dropping a column drops its
+data. There is no automatic backup: take one first if the data matters, since nothing here
+can bring it back::
+
+    kubectl exec -n <namespace> <postgres-pod> -- \
+        pg_dump -U <user> -Fc <database> > idegym-pre-rollback.dump
+
+Requires ``helm`` and ``kubectl`` on PATH, pointed at the cluster, with permission to scale
+Deployments, create Jobs, and exec into pods.
+
+Usage::
+
+    scripts/rollback.py --release idegym --namespace idegym --revision 7 --dry-run
+    scripts/rollback.py --release idegym --namespace idegym --revision 7
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from argparse import ArgumentParser, Namespace
+from typing import Any, Optional
+
+# The chart names the orchestrator container this; every other container in the pod would be
+# a sidecar someone added.
+ORCHESTRATOR_CONTAINER = "orchestrator"
+
+# Pod-spec keys the migration Job inherits from the orchestrator Deployment. The Job runs the
+# orchestrator image on the same node pool with the same identity, so scheduling and access
+# stay whatever the release configured rather than being restated here.
+INHERITED_POD_SPEC_KEYS = (
+    "affinity",
+    "imagePullSecrets",
+    "nodeSelector",
+    "securityContext",
+    "serviceAccountName",
+    "tolerations",
+)
+
+MIGRATION_CLI = ["uv", "run", "python", "-m", "idegym.orchestrator.db_cli"]
+
+JOB_POLL_INTERVAL_SECONDS = 2
+
+
+class RollbackError(RuntimeError):
+    """A rollback step failed, or a precondition was not met."""
+
+
+def run(command: list[str], *, capture: bool = True) -> str:
+    """Run a command, raising :class:`RollbackError` with its stderr when it fails."""
+    printable = " ".join(command)
+    print(f"$ {printable}")
+    result = subprocess.run(command, capture_output=capture, text=True, check=False)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip() if capture else ""
+        raise RollbackError(f"`{printable}` exited {result.returncode}{f': {detail}' if detail else ''}")
+    return result.stdout if capture else ""
+
+
+def run_json(command: list[str]) -> Any:
+    output = run(command)
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError as e:
+        raise RollbackError(f"`{' '.join(command)}` did not return JSON: {e}") from e
+
+
+def helm(args: list[str], release: str, namespace: str) -> list[str]:
+    return ["helm", *args, release, "--namespace", namespace]
+
+
+def current_helm_revision(release: str, namespace: str) -> int:
+    status = run_json([*helm(["status"], release, namespace), "--output", "json"])
+    revision = status.get("version")
+    if not isinstance(revision, int):
+        raise RollbackError(f"Could not read the current revision of release {release}")
+    return revision
+
+
+def find_history_entry(history: list[dict[str, Any]], revision: int) -> dict[str, Any]:
+    for entry in history:
+        if entry.get("revision") == revision:
+            return entry
+    known = ", ".join(str(entry.get("revision")) for entry in history)
+    raise RollbackError(f"Revision {revision} is not in the release history (have: {known})")
+
+
+def declared_schema_revision(values: dict[str, Any]) -> str:
+    """Read ``database.schemaRevision`` out of a release's computed values.
+
+    Absent means the release predates this mechanism, and nothing recorded which revision
+    its images expect — the exact schema target cannot be guessed, so the operator has to
+    supply it.
+    """
+    revision = (values.get("database") or {}).get("schemaRevision")
+    if not revision:
+        raise RollbackError(
+            "The target release does not declare database.schemaRevision, so its expected schema "
+            "revision is unknown. Pass --target-schema-revision to state it explicitly"
+        )
+    return str(revision)
+
+
+def release_values(release: str, namespace: str, revision: Optional[int] = None) -> dict[str, Any]:
+    command = [*helm(["get", "values"], release, namespace), "--all", "--output", "json"]
+    if revision is not None:
+        command += ["--revision", str(revision)]
+    return run_json(command) or {}
+
+
+def release_deployments(release: str, namespace: str) -> tuple[dict[str, Any], Optional[dict[str, Any]]]:
+    """Return the release's (orchestrator, watcher) Deployments — its two database writers.
+
+    Found by the release's instance label rather than by rebuilding the chart's fullname
+    template, so ``fullnameOverride`` and ``nameOverride`` need no special handling. The
+    watcher is optional (``watcher.enabled``).
+    """
+    listing = run_json(
+        [
+            "kubectl",
+            "get",
+            "deployments",
+            "--namespace",
+            namespace,
+            "--selector",
+            f"app.kubernetes.io/instance={release}",
+            "--output",
+            "json",
+        ]
+    )
+    deployments = listing.get("items", [])
+    watchers = [item for item in deployments if item["metadata"]["name"].endswith("-watcher")]
+    others = [item for item in deployments if item not in watchers]
+
+    if len(others) != 1:
+        found = ", ".join(sorted(item["metadata"]["name"] for item in deployments)) or "none"
+        raise RollbackError(
+            f"Expected exactly one orchestrator Deployment for release {release} in {namespace}, found: {found}"
+        )
+    return others[0], watchers[0] if watchers else None
+
+
+def orchestrator_container(deployment: dict[str, Any]) -> dict[str, Any]:
+    containers = deployment["spec"]["template"]["spec"]["containers"]
+    for container in containers:
+        if container["name"] == ORCHESTRATOR_CONTAINER:
+            return container
+    raise RollbackError(f"Deployment {deployment['metadata']['name']} has no {ORCHESTRATOR_CONTAINER} container")
+
+
+def build_migration_job(
+    name: str, namespace: str, deployment: dict[str, Any], target_revision: str, deadline_seconds: int
+) -> dict[str, Any]:
+    """A one-shot Job that downgrades the schema using the currently deployed image.
+
+    The image and environment are copied from the live orchestrator, which is the point:
+    the target release's image predates the migrations being reverted and cannot run them.
+    ``backoffLimit: 0`` keeps a failed downgrade from being retried against a half-migrated
+    schema.
+    """
+    container = orchestrator_container(deployment)
+    pod_spec: dict[str, Any] = {
+        key: value for key, value in deployment["spec"]["template"]["spec"].items() if key in INHERITED_POD_SPEC_KEYS
+    }
+    pod_spec |= {
+        "restartPolicy": "Never",
+        "containers": [
+            {
+                "name": "migrate",
+                "image": container["image"],
+                "imagePullPolicy": container.get("imagePullPolicy", "IfNotPresent"),
+                "env": container.get("env", []),
+                "command": [*MIGRATION_CLI, "migrate", "--target", target_revision, "--allow-downgrade"],
+            }
+        ],
+    }
+    return {
+        "apiVersion": "batch/v1",
+        "kind": "Job",
+        "metadata": {"name": name, "namespace": namespace},
+        "spec": {
+            "backoffLimit": 0,
+            "activeDeadlineSeconds": deadline_seconds,
+            "template": {"spec": pod_spec},
+        },
+    }
+
+
+def create_job(job: dict[str, Any]) -> None:
+    name = job["metadata"]["name"]
+    print(f"$ kubectl create -f - # Job/{name}")
+    result = subprocess.run(
+        ["kubectl", "create", "--namespace", job["metadata"]["namespace"], "--filename", "-"],
+        input=json.dumps(job),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or "").strip()
+        if "already exists" in detail:
+            raise RollbackError(
+                f"Job {name} already exists — another rollback may be running. Inspect it "
+                f"(`kubectl logs job/{name} -n {job['metadata']['namespace']}`), then delete it to retry"
+            )
+        raise RollbackError(f"Could not create Job {name}: {detail}")
+
+
+def wait_for_job(name: str, namespace: str, timeout_seconds: int) -> bool:
+    """Poll until the Job succeeds or fails, then print its logs. True when it succeeded."""
+    deadline = time.monotonic() + timeout_seconds
+    succeeded = False
+    while True:
+        status = run_json(["kubectl", "get", "job", name, "--namespace", namespace, "--output", "json"]).get(
+            "status", {}
+        )
+        if status.get("succeeded"):
+            succeeded = True
+            break
+        if status.get("failed"):
+            break
+        if time.monotonic() >= deadline:
+            print(f"Job {name} did not finish within {timeout_seconds}s", file=sys.stderr)
+            break
+        time.sleep(JOB_POLL_INTERVAL_SECONDS)
+
+    logs = subprocess.run(
+        ["kubectl", "logs", f"job/{name}", "--namespace", namespace, "--tail=-1"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    print(f"--- Job/{name} logs ---\n{logs.stdout}{logs.stderr}--- end of logs ---")
+    return succeeded
+
+
+def exec_in_deployment(name: str, namespace: str, command: list[str]) -> tuple[int, str]:
+    """Run a command in one of the Deployment's pods, returning its exit code and output."""
+    full = ["kubectl", "exec", f"deployment/{name}", "--namespace", namespace, "--", *command]
+    print(f"$ {' '.join(full)}")
+    result = subprocess.run(full, capture_output=True, text=True, check=False)
+    return result.returncode, (result.stdout + result.stderr).strip()
+
+
+def scale(name: str, namespace: str, replicas: int) -> None:
+    run(["kubectl", "scale", "deployment", name, "--namespace", namespace, f"--replicas={replicas}"])
+
+
+def wait_for_no_pods(deployment: dict[str, Any], namespace: str, timeout_seconds: int) -> None:
+    """Block until the Deployment reports no running replicas.
+
+    Scaling to zero returns immediately; the downgrade must not start while a writer is
+    still finishing a request against the schema it is about to lose.
+    """
+    name = deployment["metadata"]["name"]
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        status = run_json(["kubectl", "get", "deployment", name, "--namespace", namespace, "--output", "json"]).get(
+            "status", {}
+        )
+        if not status.get("replicas"):
+            return
+        if time.monotonic() >= deadline:
+            raise RollbackError(f"Deployment {name} still has {status.get('replicas')} pods after {timeout_seconds}s")
+        time.sleep(JOB_POLL_INTERVAL_SECONDS)
+
+
+def replica_count(deployment: dict[str, Any]) -> int:
+    return int(deployment["spec"].get("replicas", 1))
+
+
+def _parse_args(argv: Optional[list[str]]) -> Namespace:
+    parser = ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--release", required=True, help="Helm release name")
+    parser.add_argument("--namespace", required=True, help="Namespace the release is installed in")
+    parser.add_argument(
+        "--revision", required=True, type=int, help="Exact Helm revision to roll back to (see `helm history`)"
+    )
+    parser.add_argument(
+        "--target-schema-revision",
+        help="Alembic revision the target release expects. Only needed when it predates database.schemaRevision",
+    )
+    parser.add_argument("--timeout", type=int, default=600, help="Seconds to allow each waiting step (default: 600)")
+    parser.add_argument("--dry-run", action="store_true", help="Print the plan and exit without changing anything")
+    parser.add_argument(
+        "--yes", action="store_true", help="Skip the confirmation prompt shown before a schema downgrade"
+    )
+    return parser.parse_args(argv)
+
+
+def confirm(plan: str) -> bool:
+    print(f"\n{plan}\n")
+    return input("Type 'yes' to continue: ").strip().lower() == "yes"
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _parse_args(argv)
+    release, namespace, timeout = args.release, args.namespace, args.timeout
+
+    try:
+        return _rollback(args, release, namespace, timeout)
+    except RollbackError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+
+def _rollback(args: Namespace, release: str, namespace: str, timeout: int) -> int:
+    source_revision = current_helm_revision(release, namespace)
+    if args.revision == source_revision:
+        raise RollbackError(f"Release {release} is already at revision {source_revision}")
+
+    history = run_json([*helm(["history"], release, namespace), "--output", "json"])
+    target = find_history_entry(history, args.revision)
+
+    source_schema = declared_schema_revision(release_values(release, namespace))
+    target_schema = args.target_schema_revision or declared_schema_revision(
+        release_values(release, namespace, args.revision)
+    )
+
+    orchestrator, watcher = release_deployments(release, namespace)
+    orchestrator_name = orchestrator["metadata"]["name"]
+    writers = [orchestrator, *([watcher] if watcher else [])]
+    downgrade_needed = source_schema != target_schema
+
+    print(
+        f"\nRelease {release} in {namespace}\n"
+        f"  from revision {source_revision} (schema {source_schema})\n"
+        f"  to   revision {args.revision} (schema {target_schema}, chart {target.get('chart')})\n"
+        f"  orchestrator image {orchestrator_container(orchestrator)['image']}\n"
+        f"  schema downgrade: {'yes' if downgrade_needed else 'not needed'}"
+    )
+
+    if downgrade_needed:
+        # The live image is the only one that has the migrations being reverted; ask it
+        # whether it can make the move before anything is stopped.
+        code, output = exec_in_deployment(
+            orchestrator_name, namespace, [*MIGRATION_CLI, "migrate", "--target", target_schema, "--dry-run"]
+        )
+        if code != 0:
+            raise RollbackError(f"The deployed image cannot downgrade to {target_schema}: {output}")
+        print(f"  plan reported by the deployed image: {output.splitlines()[-1]}")
+
+    if args.dry_run:
+        print("\n--dry-run: nothing was changed.")
+        return 0
+
+    if downgrade_needed and not args.yes:
+        plan = (
+            f"This reverts schema revisions down to {target_schema} and permanently discards the data they hold.\n"
+            f"There is no automatic backup. {len(writers)} Deployment(s) will be stopped first."
+        )
+        if not confirm(plan):
+            print("Aborted; nothing was changed.")
+            return 1
+
+    if not downgrade_needed:
+        run([*helm(["rollback"], release, namespace), str(args.revision), "--wait", "--timeout", f"{timeout}s"])
+        _verify(orchestrator_name, namespace, target_schema, writers)
+        print(f"\nRolled {release} back to revision {args.revision}; the schema was already at {target_schema}.")
+        return 0
+
+    original_replicas = {deployment["metadata"]["name"]: replica_count(deployment) for deployment in writers}
+    restore_hint = "\n".join(
+        f"  kubectl scale deployment {name} -n {namespace} --replicas={replicas}"
+        for name, replicas in original_replicas.items()
+    )
+
+    print("\nStopping database writers...")
+    for name in original_replicas:
+        scale(name, namespace, 0)
+    for deployment in writers:
+        wait_for_no_pods(deployment, namespace, timeout)
+
+    job_name = f"{orchestrator_name}-migrate-{target_schema}"
+    create_job(build_migration_job(job_name, namespace, orchestrator, target_schema, timeout))
+    if not wait_for_job(job_name, namespace, timeout):
+        raise RollbackError(
+            f"The downgrade to {target_schema} failed, so the Helm release was left at revision {source_revision} "
+            f"and every writer is still stopped — the schema may be partially reverted.\n"
+            f"Inspect the Job above, then either fix the cause and re-run, or restore a backup.\n"
+            f"To bring the current release back up as it was:\n{restore_hint}"
+        )
+
+    print(f"\nSchema is at {target_schema}; handing over to Helm.")
+    try:
+        run(
+            [
+                *helm(["rollback"], release, namespace),
+                str(args.revision),
+                "--wait",
+                "--wait-for-jobs",
+                "--timeout",
+                f"{timeout}s",
+            ]
+        )
+    except RollbackError as e:
+        raise RollbackError(
+            f"{e}\nThe schema was downgraded to {target_schema} but the release was not rolled back, so the writers "
+            f"are still stopped. Retry `helm rollback {release} {args.revision} -n {namespace} --wait`, or start the "
+            f"current release again after upgrading the schema back:\n{restore_hint}"
+        ) from e
+
+    _verify(orchestrator_name, namespace, target_schema, writers)
+    print(f"\nRolled {release} back to revision {args.revision} with the schema at {target_schema}.")
+    return 0
+
+
+def _verify(orchestrator_name: str, namespace: str, expected_schema: str, writers: list[dict[str, Any]]) -> None:
+    """Confirm the schema and the writers after Helm reports success.
+
+    ``helm rollback --wait`` already gates on the orchestrator's readiness probe, which is
+    ``/health`` — so this adds the two things it cannot see: the recorded schema revision,
+    and that every writer came back.
+    """
+    code, output = exec_in_deployment(
+        orchestrator_name, namespace, [*MIGRATION_CLI, "schema", "verify", "--expect", expected_schema]
+    )
+    if code != 0:
+        raise RollbackError(f"The rolled-back release is not at schema revision {expected_schema}: {output}")
+
+    for deployment in writers:
+        name = deployment["metadata"]["name"]
+        status = run_json(["kubectl", "get", "deployment", name, "--namespace", namespace, "--output", "json"])
+        ready = status.get("status", {}).get("readyReplicas") or 0
+        expected = replica_count(status)
+        if ready != expected:
+            raise RollbackError(f"Deployment {name} has {ready}/{expected} ready replicas after the rollback")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rollback.py
+++ b/scripts/rollback.py
@@ -5,28 +5,23 @@
 # ///
 """Roll an IdeGYM release back, including its database schema.
 
-``helm rollback`` restores Kubernetes resources and nothing else. The orchestrator migrates
-the schema forward on startup, so after a failed upgrade the database is left on the newer
-revision: the older image may not contain it, and Alembic cannot traverse a revision whose
-script it does not have. This script sequences the parts Helm cannot.
+``helm rollback`` restores Kubernetes resources only, and the orchestrator migrates forward
+at startup, so a failed upgrade leaves the database on a revision the older image may not
+contain at all. This script sequences what Helm cannot.
 
-Two shapes of rollback, decided from the ``database.schemaRevision`` each release declares:
+The shape of the rollback follows the ``database.schemaRevision`` each release declares.
+Same revision: plain ``helm rollback``. Older revision: stop both writers, downgrade with
+the *currently deployed* image — the only one holding the migrations being reverted — and
+hand over to Helm only once that has succeeded.
 
-* **Same revision** — the upgrade did not change the schema. Plain ``helm rollback``.
-* **Older revision** — stop both database writers, downgrade to the target release's exact
-  revision *with the currently deployed image* (the only one that contains the migrations
-  being reverted), and only then hand over to ``helm rollback``. A failed downgrade never
-  reaches Helm and never restarts a writer.
-
-A downgrade discards whatever the reverted revisions stored — dropping a column drops its
-data. There is no automatic backup: take one first if the data matters, since nothing here
-can bring it back::
+A downgrade discards what the reverted revisions stored, and there is no automatic backup,
+so take one first if the data matters::
 
     kubectl exec -n <namespace> <postgres-pod> -- \
         pg_dump -U <user> -Fc <database> > idegym-pre-rollback.dump
 
-Requires ``helm`` and ``kubectl`` on PATH, pointed at the cluster, with permission to scale
-Deployments, create Jobs, and exec into pods.
+Needs ``helm`` and ``kubectl`` on PATH, with permission to scale Deployments, create Jobs,
+and exec into pods.
 
 Usage::
 
@@ -43,24 +38,20 @@ import time
 from argparse import ArgumentParser, Namespace
 from typing import Any, Optional
 
-# The chart names the orchestrator container this; every other container in the pod would be
-# a sidecar someone added.
+# The chart's name for this container; anything else in the pod is a sidecar.
 ORCHESTRATOR_CONTAINER = "orchestrator"
 
-# The chart's own name, and how its two Deployments are told apart from the subcharts that
-# share the release. `idegym.selectorLabels` puts `nameOverride | chart name` in this label,
-# and the watcher's is that plus the suffix.
+# Subcharts share the release's instance label, so the chart's own Deployments are found by
+# this one: `nameOverride | chart name`, plus the suffix for the watcher.
 APP_NAME_LABEL = "app.kubernetes.io/name"
 CHART_NAME = "idegym"
 WATCHER_NAME_SUFFIX = "-watcher"
 
-# Kubernetes copies a Job's name into a label on the pods it creates, so it cannot exceed the
-# 63-character label limit.
+# A Job's name becomes a label value on its pods, so the label limit bounds it.
 MAX_JOB_NAME_LENGTH = 63
 
-# Pod-spec keys the migration Job inherits from the orchestrator Deployment. The Job runs the
-# orchestrator image on the same node pool with the same identity, so scheduling and access
-# stay whatever the release configured rather than being restated here.
+# Inherited by the migration Job so it schedules and authenticates exactly like the
+# orchestrator, instead of restating the release's configuration here.
 INHERITED_POD_SPEC_KEYS = (
     "affinity",
     "imagePullSecrets",
@@ -121,9 +112,8 @@ def find_history_entry(history: list[dict[str, Any]], revision: int) -> dict[str
 def declared_schema_revision(values: dict[str, Any], role: str = "target") -> str:
     """Read ``database.schemaRevision`` out of a release's computed values.
 
-    Absent means the release predates this mechanism, and nothing recorded which revision
-    its images expect — the exact schema target cannot be guessed, so the operator has to
-    supply it.
+    Absent means the release predates the declaration, and an exact target cannot be
+    guessed, so the operator has to supply it.
     """
     revision = (values.get("database") or {}).get("schemaRevision")
     if not revision:
@@ -150,12 +140,9 @@ def release_deployments(
 ) -> tuple[dict[str, Any], Optional[dict[str, Any]]]:
     """Return the release's (orchestrator, watcher) Deployments — its two database writers.
 
-    Matched on the chart's own selector labels rather than by rebuilding the fullname
-    template, so ``fullnameOverride`` needs no special handling. The instance label alone is
-    not enough: every enabled subchart — grafana, prometheus, postgresql — is part of the
-    same release and carries it too. ``app.kubernetes.io/name`` is what separates them, and
-    it follows ``nameOverride`` rather than the resource names. The watcher is optional
-    (``watcher.enabled``).
+    Matched on the chart's selector labels rather than by rebuilding the fullname template,
+    so ``fullnameOverride`` needs no handling. The instance label alone is not enough: every
+    enabled subchart shares it. The watcher is optional (``watcher.enabled``).
     """
     app_name = values.get("nameOverride") or CHART_NAME
     listing = run_json(
@@ -188,8 +175,7 @@ def migration_job_name(deployment_name: str, suffix: str) -> str:
     """Fit ``<deployment>-<suffix>`` into the Job name limit by trimming the deployment part.
 
     ``idegym.fullname`` is itself truncated to 63 characters, so a long release name would
-    otherwise produce a name the API server rejects — and the rollback would fail on its own
-    Job rather than on anything to do with the schema.
+    otherwise fail the rollback on its own Job rather than on anything about the schema.
     """
     keep = max(1, MAX_JOB_NAME_LENGTH - len(suffix) - 1)
     return f"{deployment_name[:keep].rstrip('-')}-{suffix}"
@@ -214,14 +200,10 @@ def build_migration_job(
 ) -> dict[str, Any]:
     """A one-shot Job that migrates the schema using the currently deployed image.
 
-    The image and environment are copied from the live orchestrator, which is the point:
-    the target release's image predates the migrations being reverted and cannot run them.
-    ``backoffLimit: 0`` keeps a failed downgrade from being retried against a half-migrated
-    schema.
-
-    With ``dry_run`` the Job only resolves and prints the plan, which is how the preflight
-    asks the source image whether it can make the move — the image in the Deployment spec,
-    not whichever pod happens to be up.
+    Copying the image and environment from the live orchestrator is the point: the target
+    release's image predates the migrations being reverted and cannot run them.
+    ``backoffLimit: 0`` stops a failed downgrade being retried against a half-reverted
+    schema. ``dry_run`` resolves and prints the plan without applying it.
     """
     container = orchestrator_container(deployment)
     arguments = [*MIGRATION_CLI, "migrate", "--target", target_revision, "--allow-downgrade"]
@@ -311,10 +293,10 @@ def wait_for_job(name: str, namespace: str, timeout_seconds: int) -> bool:
 
 
 def exec_in_deployment(name: str, namespace: str, command: list[str]) -> tuple[int, str, str]:
-    """Run a command in one of the Deployment's pods; returns its exit code, stdout, stderr.
+    """Run a command in one of the Deployment's pods; returns exit code, stdout, stderr.
 
-    The two streams stay apart because the container logs to stderr as well as printing its
-    answer to stdout, so a caller reading a value has to look at stdout alone.
+    Kept apart because the container logs to stderr, so a caller reading a value wants
+    stdout alone.
     """
     full = ["kubectl", "exec", f"deployment/{name}", "--namespace", namespace, "--", *command]
     print(f"$ {' '.join(full)}")
@@ -329,7 +311,7 @@ def scale(name: str, namespace: str, replicas: int) -> None:
 def wait_for_no_pods(deployment: dict[str, Any], namespace: str, timeout_seconds: int) -> None:
     """Block until the Deployment reports no running replicas.
 
-    Scaling to zero returns immediately; the downgrade must not start while a writer is
+    Scaling to zero returns immediately, but the downgrade must not start while a writer is
     still finishing a request against the schema it is about to lose.
     """
     name = deployment["metadata"]["name"]
@@ -352,10 +334,9 @@ def replica_count(deployment: dict[str, Any]) -> int:
 def preflight_downgrade(deployment: dict[str, Any], namespace: str, target_revision: str, timeout_seconds: int) -> None:
     """Ask the source image whether it can reach ``target_revision``, changing nothing.
 
-    Runs as a Job rather than ``kubectl exec`` on purpose: a rollback usually follows a
-    failed rollout, when no pod of the new image may be healthy enough to exec into — and
-    a pod of the *previous* image would answer the question wrongly. The Job runs exactly
-    the image the downgrade will use, resolves the plan, and prints it.
+    A Job rather than ``kubectl exec``: a rollback usually follows a failed rollout, when no
+    pod of that image may be healthy enough to exec into — and a pod of the *previous* image
+    would answer wrongly.
     """
     name = migration_job_name(deployment["metadata"]["name"], f"migrate-check-{target_revision}")
     create_job(build_migration_job(name, namespace, deployment, target_revision, timeout_seconds, dry_run=True))
@@ -480,8 +461,8 @@ def _rollback(args: Namespace, release: str, namespace: str, timeout: int) -> in
             f"To bring the current release back up as it was:\n{restore_hint}"
         )
 
-    # Its logs are printed above, and leaving it would make the next rollback to this
-    # revision collide with a name that already exists. A *failed* Job is kept on purpose.
+    # Logs are printed above, and leaving it would collide with the next rollback to this
+    # revision. A *failed* Job is kept on purpose.
     delete_job(job_name, namespace)
 
     print(f"\nSchema is at {target_schema}; handing over to Helm.")
@@ -511,9 +492,8 @@ def _rollback(args: Namespace, release: str, namespace: str, timeout: int) -> in
 def _verify(orchestrator_name: str, namespace: str, expected_schema: str, writers: list[dict[str, Any]]) -> None:
     """Confirm the schema and the writers after Helm reports success.
 
-    ``helm rollback --wait`` already gates on the orchestrator's readiness probe, which is
-    ``/health`` — so this adds the two things it cannot see: the recorded schema revision,
-    and that every writer came back.
+    ``helm rollback --wait`` already gates on the ``/health`` readiness probe, so this adds
+    only what it cannot see: the recorded revision, and that every writer came back.
     """
     code, stdout, stderr = exec_in_deployment(
         orchestrator_name, namespace, [*MIGRATION_CLI, "schema", "verify", "--expect", expected_schema]

--- a/unit-tests/test_db_cli.py
+++ b/unit-tests/test_db_cli.py
@@ -1,0 +1,113 @@
+"""Unit tests for migration planning and the ``idegym-db`` argument surface.
+
+Everything here is decided before a connection is opened, so it needs no database: the
+plan, the guards that stop a downgrade from happening by accident, and the CLI's contract.
+The round-trip against real PostgreSQL lives in
+``integration-tests/database/test_migration_roundtrip.py``.
+"""
+
+import pytest
+from idegym.api.exceptions import MigrationError
+from idegym.orchestrator.db_cli import build_parser
+from idegym.orchestrator.migration_manager import BASE_REVISION, MigrationDirection, MigrationManager
+from sqlalchemy.ext.asyncio import create_async_engine
+
+
+@pytest.fixture
+def manager() -> MigrationManager:
+    """A manager over an engine that is never connected — planning is offline."""
+    url = "postgresql+asyncpg://idegym:idegym@localhost:5432/idegym"
+    return MigrationManager(engine=create_async_engine(url), db_url=url)
+
+
+def test_revision_chain_is_ordered_base_to_head(manager: MigrationManager):
+    chain = manager.revision_chain()
+    assert chain[0] == "001"
+    assert chain[-1] == manager.head_revision()
+    assert chain == sorted(chain), "sequential revision ids should walk in order"
+
+
+def test_upgrade_plan_lists_the_revisions_it_applies(manager: MigrationManager):
+    plan = manager.plan_migration(current=None, target="heads")
+
+    assert plan.direction is MigrationDirection.UPGRADE
+    assert plan.target == manager.head_revision()
+    assert plan.revisions == tuple(manager.revision_chain())
+
+
+def test_downgrade_plan_lists_the_revisions_it_reverts_newest_first(manager: MigrationManager):
+    plan = manager.plan_migration(current="003", target="001")
+
+    assert plan.direction is MigrationDirection.DOWNGRADE
+    assert plan.revisions == ("003", "002")
+    assert "downgrade 003 -> 001" in plan.describe()
+
+
+def test_downgrade_to_base_is_a_valid_target(manager: MigrationManager):
+    plan = manager.plan_migration(current="001", target=BASE_REVISION)
+
+    assert plan.direction is MigrationDirection.DOWNGRADE
+    assert plan.revisions == ("001",)
+
+
+def test_same_revision_is_a_noop(manager: MigrationManager):
+    plan = manager.plan_migration(current="002", target="002")
+
+    assert plan.direction is MigrationDirection.NOOP
+    assert plan.revisions == ()
+    assert "already at revision 002" in plan.describe()
+
+
+def test_unknown_target_is_rejected(manager: MigrationManager):
+    with pytest.raises(MigrationError, match="Target revision '404'"):
+        manager.plan_migration(current="003", target="404")
+
+
+def test_database_on_an_unknown_revision_is_rejected(manager: MigrationManager):
+    """The signature of rolling back with an image older than the database.
+
+    Alembic cannot traverse a revision it has no script for, so this has to fail with an
+    explanation rather than a KeyError from inside Alembic.
+    """
+    with pytest.raises(MigrationError, match="use the image that introduced it"):
+        manager.plan_migration(current="099", target="003")
+
+
+def test_declared_revision_must_match_the_image_head(manager: MigrationManager):
+    manager.verify_declared_revision(None)
+    manager.verify_declared_revision(manager.head_revision())
+
+    with pytest.raises(MigrationError, match="align database.schemaRevision"):
+        manager.verify_declared_revision("002")
+
+
+def test_migrate_requires_an_exact_target():
+    parser = build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["migrate"])
+
+    args = parser.parse_args(["migrate", "--target", "002", "--allow-downgrade"])
+    assert (args.target, args.allow_downgrade, args.dry_run) == ("002", True, False)
+
+
+def test_downgrade_approval_is_off_by_default():
+    args = build_parser().parse_args(["migrate", "--target", "002"])
+
+    assert args.allow_downgrade is False
+
+
+def test_schema_verify_requires_an_expected_revision():
+    parser = build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["schema", "verify"])
+
+    assert parser.parse_args(["schema", "verify", "--expect", "003"]).expect == "003"
+
+
+def test_schema_subcommands_are_named():
+    parser = build_parser()
+
+    assert parser.parse_args(["schema", "current"]).schema_command == "current"
+    assert parser.parse_args(["schema", "head"]).schema_command == "head"

--- a/unit-tests/test_db_cli.py
+++ b/unit-tests/test_db_cli.py
@@ -8,8 +8,13 @@ The round-trip against real PostgreSQL lives in
 
 import pytest
 from idegym.api.exceptions import MigrationError
-from idegym.orchestrator.db_cli import Command, SchemaCommand, build_parser
-from idegym.orchestrator.migration_manager import BASE_REVISION, MigrationDirection, MigrationManager
+from idegym.orchestrator.db_cli import Command, SchemaCommand, _run_migrate_command, build_parser
+from idegym.orchestrator.migration_manager import (
+    BASE_REVISION,
+    MigrationDirection,
+    MigrationManager,
+    MigrationPlan,
+)
 from sqlalchemy.ext.asyncio import create_async_engine
 
 
@@ -123,3 +128,32 @@ def test_every_top_level_command_is_accepted(command: Command):
     extra = ["--target", "003"] if command is Command.MIGRATE else [SchemaCommand.HEAD]
 
     assert build_parser().parse_args([command, *extra]).command == command
+
+
+def fake_manager(mocker, plan: MigrationPlan) -> MigrationManager:
+    """A manager that resolves to ``plan`` without a database."""
+    manager = mocker.MagicMock(spec=MigrationManager)
+    manager.get_current_revision = mocker.AsyncMock(return_value=plan.current)
+    manager.plan_migration.return_value = plan
+    return manager
+
+
+async def test_dry_run_prints_the_plan_as_its_answer(mocker, capsys):
+    """The plan is the command's output — it goes to stdout, on its own."""
+    plan = MigrationPlan(MigrationDirection.DOWNGRADE, "003", "002", ("003",))
+    args = build_parser().parse_args([Command.MIGRATE, "--target", "002", "--dry-run", "--allow-downgrade"])
+
+    assert await _run_migrate_command(args, fake_manager(mocker, plan)) == 0
+    assert capsys.readouterr().out.strip() == plan.describe()
+
+
+async def test_dry_run_advice_about_approval_stays_off_stdout(mocker, capsys):
+    """Guidance about a *future* invocation is not part of this one's answer."""
+    plan = MigrationPlan(MigrationDirection.DOWNGRADE, "003", "002", ("003",))
+    args = build_parser().parse_args([Command.MIGRATE, "--target", "002", "--dry-run"])
+
+    assert await _run_migrate_command(args, fake_manager(mocker, plan)) == 0
+
+    captured = capsys.readouterr()
+    assert captured.out.strip() == plan.describe()
+    assert "--allow-downgrade" in captured.err

--- a/unit-tests/test_db_cli.py
+++ b/unit-tests/test_db_cli.py
@@ -8,7 +8,7 @@ The round-trip against real PostgreSQL lives in
 
 import pytest
 from idegym.api.exceptions import MigrationError
-from idegym.orchestrator.db_cli import build_parser
+from idegym.orchestrator.db_cli import Command, SchemaCommand, build_parser
 from idegym.orchestrator.migration_manager import BASE_REVISION, MigrationDirection, MigrationManager
 from sqlalchemy.ext.asyncio import create_async_engine
 
@@ -85,14 +85,14 @@ def test_migrate_requires_an_exact_target():
     parser = build_parser()
 
     with pytest.raises(SystemExit):
-        parser.parse_args(["migrate"])
+        parser.parse_args([Command.MIGRATE])
 
-    args = parser.parse_args(["migrate", "--target", "002", "--allow-downgrade"])
+    args = parser.parse_args([Command.MIGRATE, "--target", "002", "--allow-downgrade"])
     assert (args.target, args.allow_downgrade, args.dry_run) == ("002", True, False)
 
 
 def test_downgrade_approval_is_off_by_default():
-    args = build_parser().parse_args(["migrate", "--target", "002"])
+    args = build_parser().parse_args([Command.MIGRATE, "--target", "002"])
 
     assert args.allow_downgrade is False
 
@@ -101,13 +101,25 @@ def test_schema_verify_requires_an_expected_revision():
     parser = build_parser()
 
     with pytest.raises(SystemExit):
-        parser.parse_args(["schema", "verify"])
+        parser.parse_args([Command.SCHEMA, SchemaCommand.VERIFY])
 
-    assert parser.parse_args(["schema", "verify", "--expect", "003"]).expect == "003"
+    expect = parser.parse_args([Command.SCHEMA, SchemaCommand.VERIFY, "--expect", "003"]).expect
+    assert expect == "003"
 
 
-def test_schema_subcommands_are_named():
-    parser = build_parser()
+@pytest.mark.parametrize("subcommand", list(SchemaCommand))
+def test_every_schema_subcommand_is_accepted(subcommand: SchemaCommand):
+    """The enums name the CLI surface, so a member with no subparser is a typo, not a feature."""
+    extra = ["--expect", "003"] if subcommand is SchemaCommand.VERIFY else []
 
-    assert parser.parse_args(["schema", "current"]).schema_command == "current"
-    assert parser.parse_args(["schema", "head"]).schema_command == "head"
+    args = build_parser().parse_args([Command.SCHEMA, subcommand, *extra])
+
+    assert args.command == Command.SCHEMA
+    assert args.schema_command == subcommand
+
+
+@pytest.mark.parametrize("command", list(Command))
+def test_every_top_level_command_is_accepted(command: Command):
+    extra = ["--target", "003"] if command is Command.MIGRATE else [SchemaCommand.HEAD]
+
+    assert build_parser().parse_args([command, *extra]).command == command

--- a/unit-tests/test_db_cli.py
+++ b/unit-tests/test_db_cli.py
@@ -1,9 +1,8 @@
-"""Unit tests for migration planning and the ``idegym-db`` argument surface.
+"""Migration planning and the ``idegym-db`` argument surface.
 
-Everything here is decided before a connection is opened, so it needs no database: the
-plan, the guards that stop a downgrade from happening by accident, and the CLI's contract.
-The round-trip against real PostgreSQL lives in
-``integration-tests/database/test_migration_roundtrip.py``.
+All decided before a connection is opened, so no database is needed: the plan, the guards
+against an accidental downgrade, and the CLI's contract. The round-trip against real
+PostgreSQL lives in ``integration-tests/database/test_migration_roundtrip.py``.
 """
 
 import pytest
@@ -69,9 +68,9 @@ def test_unknown_target_is_rejected(manager: MigrationManager):
 
 
 def test_database_on_an_unknown_revision_is_rejected(manager: MigrationManager):
-    """The signature of rolling back with an image older than the database.
+    """Rolling back with an image older than the database.
 
-    Alembic cannot traverse a revision it has no script for, so this has to fail with an
+    Alembic cannot traverse a revision it has no script for, so this fails with an
     explanation rather than a KeyError from inside Alembic.
     """
     with pytest.raises(MigrationError, match="use the image that introduced it"):
@@ -114,7 +113,7 @@ def test_schema_verify_requires_an_expected_revision():
 
 @pytest.mark.parametrize("subcommand", list(SchemaCommand))
 def test_every_schema_subcommand_is_accepted(subcommand: SchemaCommand):
-    """The enums name the CLI surface, so a member with no subparser is a typo, not a feature."""
+    """A member with no subparser is a typo, not a feature."""
     extra = ["--expect", "003"] if subcommand is SchemaCommand.VERIFY else []
 
     args = build_parser().parse_args([Command.SCHEMA, subcommand, *extra])
@@ -139,7 +138,7 @@ def fake_manager(mocker, plan: MigrationPlan) -> MigrationManager:
 
 
 async def test_dry_run_prints_the_plan_as_its_answer(mocker, capsys):
-    """The plan is the command's output — it goes to stdout, on its own."""
+    """The plan is the command's output, so it goes to stdout on its own."""
     plan = MigrationPlan(MigrationDirection.DOWNGRADE, "003", "002", ("003",))
     args = build_parser().parse_args([Command.MIGRATE, "--target", "002", "--dry-run", "--allow-downgrade"])
 

--- a/unit-tests/test_logging.py
+++ b/unit-tests/test_logging.py
@@ -1,0 +1,56 @@
+"""Which stream ``configure_logging`` writes its records to.
+
+Services log to stdout, but ``idegym.orchestrator.db_cli`` prints values a caller captures
+there, so it sends its log records to stderr instead. That separation is what makes
+``REV=$(... db_cli schema current)`` return a revision rather than a revision buried in log
+lines, so it is worth a test of its own.
+"""
+
+import logging
+import sys
+from collections.abc import Iterator
+from io import StringIO
+
+import pytest
+from idegym.backend.utils.logging import configure_logging
+from idegym.utils.logging import get_logger
+
+
+@pytest.fixture(autouse=True)
+def restore_root_logger() -> Iterator[None]:
+    """Put the root logger back: ``configure_logging`` replaces its handlers globally."""
+    root = logging.getLogger()
+    handlers, level = list(root.handlers), root.level
+    try:
+        yield
+    finally:
+        for handler in list(root.handlers):
+            root.removeHandler(handler)
+        for handler in handlers:
+            root.addHandler(handler)
+        root.setLevel(level)
+
+
+def console_streams() -> list[object]:
+    """Streams of the non-file handlers — what a terminal or ``kubectl logs`` sees."""
+    return [
+        handler.stream
+        for handler in logging.getLogger().handlers
+        if isinstance(handler, logging.StreamHandler) and not isinstance(handler, logging.FileHandler)
+    ]
+
+
+def test_logging_goes_to_stdout_by_default():
+    configure_logging()
+
+    assert sys.stdout in console_streams()
+
+
+def test_a_command_line_entry_point_can_send_its_logs_elsewhere():
+    stream = StringIO()
+
+    configure_logging(stream=stream)
+    get_logger(__name__).info("migrating")
+
+    assert console_streams() == [stream]
+    assert "migrating" in stream.getvalue()

--- a/unit-tests/test_logging.py
+++ b/unit-tests/test_logging.py
@@ -1,9 +1,8 @@
 """Which stream ``configure_logging`` writes its records to.
 
-Services log to stdout, but ``idegym.orchestrator.db_cli`` prints values a caller captures
-there, so it sends its log records to stderr instead. That separation is what makes
-``REV=$(... db_cli schema current)`` return a revision rather than a revision buried in log
-lines, so it is worth a test of its own.
+Services log to stdout, but ``idegym.orchestrator.db_cli`` prints captured values there, so
+it logs to stderr instead. That separation is what makes ``REV=$(... schema current)`` a
+revision rather than a revision buried in log lines.
 """
 
 import logging

--- a/unit-tests/test_migrations.py
+++ b/unit-tests/test_migrations.py
@@ -61,9 +61,8 @@ def test_every_revision_has_up_and_down_sql():
 def test_chart_declares_the_head_schema_revision():
     """The chart's declared revision is the exact target a rollback downgrades to.
 
-    Adding a migration without bumping it would leave the next rollback aiming at the
-    wrong revision, and the orchestrator refuses to start on the mismatch — so catch it
-    here rather than in a rollout.
+    A migration that does not bump it aims the next rollback at the wrong revision, and the
+    orchestrator refuses to start on the mismatch — so catch it here, not in a rollout.
     """
     values = yaml.safe_load(CHART_VALUES.read_text())
     assert values["database"]["schemaRevision"] == script_directory().get_heads()[0]
@@ -72,9 +71,8 @@ def test_chart_declares_the_head_schema_revision():
 def test_no_migration_manages_the_alembic_version_table():
     """Alembic owns ``alembic_version``.
 
-    A migration that drops it makes Alembic's own bookkeeping statement fail in the same
-    transaction, which aborts the downgrade — the reason ``downgrade base`` used to be
-    impossible.
+    Dropping it makes Alembic's own bookkeeping fail in the same transaction and aborts the
+    downgrade — the reason ``downgrade base`` used to be impossible.
     """
     for sql_file in sorted(VERSIONS.glob("*.sql")):
         statements = [line for line in sql_file.read_text().splitlines() if not line.strip().startswith("--")]

--- a/unit-tests/test_migrations.py
+++ b/unit-tests/test_migrations.py
@@ -2,11 +2,14 @@ import re
 from collections import Counter
 from pathlib import Path
 
+import yaml
 from alembic.config import Config
 from alembic.script import ScriptDirectory
 
-ALEMBIC_INI = Path(__file__).resolve().parents[1] / "orchestrator" / "src" / "idegym" / "orchestrator" / "alembic.ini"
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ALEMBIC_INI = REPO_ROOT / "orchestrator" / "src" / "idegym" / "orchestrator" / "alembic.ini"
 VERSIONS = ALEMBIC_INI.parent / "migrations" / "versions"
+CHART_VALUES = REPO_ROOT / "charts" / "idegym" / "values.yaml"
 
 # script.py.mako emits repr(), so a freshly generated migration is single-quoted
 # until ruff format normalizes it.
@@ -53,3 +56,26 @@ def test_every_revision_has_up_and_down_sql():
     for script in script_directory().walk_revisions():
         assert (VERSIONS / f"{script.revision}_up.sql").is_file()
         assert (VERSIONS / f"{script.revision}_down.sql").is_file()
+
+
+def test_chart_declares_the_head_schema_revision():
+    """The chart's declared revision is the exact target a rollback downgrades to.
+
+    Adding a migration without bumping it would leave the next rollback aiming at the
+    wrong revision, and the orchestrator refuses to start on the mismatch — so catch it
+    here rather than in a rollout.
+    """
+    values = yaml.safe_load(CHART_VALUES.read_text())
+    assert values["database"]["schemaRevision"] == script_directory().get_heads()[0]
+
+
+def test_no_migration_manages_the_alembic_version_table():
+    """Alembic owns ``alembic_version``.
+
+    A migration that drops it makes Alembic's own bookkeeping statement fail in the same
+    transaction, which aborts the downgrade — the reason ``downgrade base`` used to be
+    impossible.
+    """
+    for sql_file in sorted(VERSIONS.glob("*.sql")):
+        statements = [line for line in sql_file.read_text().splitlines() if not line.strip().startswith("--")]
+        assert "alembic_version" not in "\n".join(statements).lower(), sql_file.name

--- a/unit-tests/test_rollback.py
+++ b/unit-tests/test_rollback.py
@@ -8,11 +8,13 @@ orchestrator, and the ordering guarantee that a failed downgrade never reaches H
 import pytest
 
 from scripts.rollback import (
+    MAX_JOB_NAME_LENGTH,
     RollbackError,
     build_migration_job,
     declared_schema_revision,
     find_history_entry,
     main,
+    migration_job_name,
     orchestrator_container,
     release_deployments,
 )
@@ -23,7 +25,7 @@ HISTORY = [
 ]
 
 ORCHESTRATOR_DEPLOYMENT = {
-    "metadata": {"name": "idegym"},
+    "metadata": {"name": "idegym", "labels": {"app.kubernetes.io/name": "idegym"}},
     "spec": {
         "replicas": 4,
         "template": {
@@ -48,9 +50,16 @@ ORCHESTRATOR_DEPLOYMENT = {
 }
 
 WATCHER_DEPLOYMENT = {
-    "metadata": {"name": "idegym-watcher"},
+    "metadata": {"name": "idegym-watcher", "labels": {"app.kubernetes.io/name": "idegym-watcher"}},
     "spec": {"replicas": 1, "template": {"spec": {"containers": [{"name": "watcher", "image": "watcher:0.11.0"}]}}},
 }
+
+# Enabled subcharts belong to the same Helm release and carry the same instance label, so they
+# come back from the same `kubectl get deployments` query.
+SUBCHART_DEPLOYMENTS = [
+    {"metadata": {"name": "grafana", "labels": {"app.kubernetes.io/name": "grafana"}}, "spec": {}},
+    {"metadata": {"name": "prometheus", "labels": {"app.kubernetes.io/name": "prometheus"}}, "spec": {}},
+]
 
 
 def test_find_history_entry_returns_the_requested_revision():
@@ -73,29 +82,48 @@ def test_a_release_without_a_declared_revision_must_be_told_the_target(values):
         declared_schema_revision(values)
 
 
-def test_release_deployments_finds_both_writers(mocker):
-    mocker.patch("scripts.rollback.run_json", return_value={"items": [WATCHER_DEPLOYMENT, ORCHESTRATOR_DEPLOYMENT]})
+def test_release_deployments_ignores_the_subcharts_in_the_same_release(mocker):
+    """grafana, prometheus and postgresql share the release's instance label.
 
-    orchestrator, watcher = release_deployments("idegym", "idegym")
+    Selecting on that label alone picked them up too and aborted every rollback of a chart
+    with observability enabled.
+    """
+    mocker.patch(
+        "scripts.rollback.run_json",
+        return_value={"items": [*SUBCHART_DEPLOYMENTS, WATCHER_DEPLOYMENT, ORCHESTRATOR_DEPLOYMENT]},
+    )
+
+    orchestrator, watcher = release_deployments("idegym", "idegym", {})
 
     assert orchestrator["metadata"]["name"] == "idegym"
     assert watcher["metadata"]["name"] == "idegym-watcher"
 
 
+def test_release_deployments_follows_name_override(mocker):
+    """The label carries `nameOverride`, not the resource name, so the match must too."""
+    renamed = {"metadata": {"name": "gym-abc", "labels": {"app.kubernetes.io/name": "gym"}}, "spec": {}}
+    mocker.patch("scripts.rollback.run_json", return_value={"items": [*SUBCHART_DEPLOYMENTS, renamed]})
+
+    orchestrator, watcher = release_deployments("idegym", "idegym", {"nameOverride": "gym"})
+
+    assert orchestrator["metadata"]["name"] == "gym-abc"
+    assert watcher is None
+
+
 def test_release_deployments_tolerates_a_disabled_watcher(mocker):
     mocker.patch("scripts.rollback.run_json", return_value={"items": [ORCHESTRATOR_DEPLOYMENT]})
 
-    orchestrator, watcher = release_deployments("idegym", "idegym")
+    orchestrator, watcher = release_deployments("idegym", "idegym", {})
 
     assert orchestrator["metadata"]["name"] == "idegym"
     assert watcher is None
 
 
 def test_release_deployments_reports_what_it_found_when_ambiguous(mocker):
-    mocker.patch("scripts.rollback.run_json", return_value={"items": []})
+    mocker.patch("scripts.rollback.run_json", return_value={"items": SUBCHART_DEPLOYMENTS})
 
-    with pytest.raises(RollbackError, match="found: none"):
-        release_deployments("idegym", "idegym")
+    with pytest.raises(RollbackError, match="grafana, prometheus"):
+        release_deployments("idegym", "idegym", {})
 
 
 def test_orchestrator_container_is_picked_by_name():
@@ -141,6 +169,27 @@ def test_migration_job_is_not_retried():
     assert job["spec"]["activeDeadlineSeconds"] == 600
 
 
+def test_job_name_keeps_the_suffix_when_the_deployment_name_is_long():
+    """A long release name must not produce a Job the API server rejects."""
+    long_name = "a" * MAX_JOB_NAME_LENGTH
+
+    name = migration_job_name(long_name, "migrate-check-002")
+
+    assert len(name) == MAX_JOB_NAME_LENGTH
+    assert name.endswith("-migrate-check-002")
+
+
+def test_job_name_is_left_alone_when_it_already_fits():
+    assert migration_job_name("idegym", "migrate-002") == "idegym-migrate-002"
+
+
+def test_job_name_does_not_end_up_with_a_double_dash():
+    """Trimming must not leave the trailing hyphen of a name like `idegym-` in place."""
+    name = migration_job_name("idegym-" + "b" * MAX_JOB_NAME_LENGTH, "migrate-002")
+
+    assert "--" not in name
+
+
 def fake_run_json(command: list[str]):
     """Answer the two read-only queries ``main`` makes: release history and Deployments."""
     if "history" in command:
@@ -165,7 +214,7 @@ def cluster(mocker):
         },
     )
     mocker.patch("scripts.rollback.release_deployments", return_value=(ORCHESTRATOR_DEPLOYMENT, WATCHER_DEPLOYMENT))
-    mocker.patch("scripts.rollback.exec_in_deployment", return_value=(0, "003"))
+    mocker.patch("scripts.rollback.exec_in_deployment", return_value=(0, "003", ""))
     mocker.patch("scripts.rollback.wait_for_no_pods")
     mocker.patch("scripts.rollback.create_job")
     mocker.patch("scripts.rollback.delete_job")

--- a/unit-tests/test_rollback.py
+++ b/unit-tests/test_rollback.py
@@ -1,8 +1,8 @@
 """Unit tests for ``scripts/rollback.py``.
 
-The cluster interaction is mocked; what is worth pinning down is the decision-making — how
-releases and Deployments are resolved, what the downgrade Job inherits from the live
-orchestrator, and the ordering guarantee that a failed downgrade never reaches Helm.
+The cluster calls are mocked; what is pinned down is the decision-making — how releases and
+Deployments are resolved, what the downgrade Job inherits, and the ordering guarantee that a
+failed downgrade never reaches Helm.
 """
 
 import pytest
@@ -54,8 +54,7 @@ WATCHER_DEPLOYMENT = {
     "spec": {"replicas": 1, "template": {"spec": {"containers": [{"name": "watcher", "image": "watcher:0.11.0"}]}}},
 }
 
-# Enabled subcharts belong to the same Helm release and carry the same instance label, so they
-# come back from the same `kubectl get deployments` query.
+# Enabled subcharts share the release's instance label, so the same query returns them too.
 SUBCHART_DEPLOYMENTS = [
     {"metadata": {"name": "grafana", "labels": {"app.kubernetes.io/name": "grafana"}}, "spec": {}},
     {"metadata": {"name": "prometheus", "labels": {"app.kubernetes.io/name": "prometheus"}}, "spec": {}},
@@ -83,11 +82,8 @@ def test_a_release_without_a_declared_revision_must_be_told_the_target(values):
 
 
 def test_release_deployments_ignores_the_subcharts_in_the_same_release(mocker):
-    """grafana, prometheus and postgresql share the release's instance label.
-
-    Selecting on that label alone picked them up too and aborted every rollback of a chart
-    with observability enabled.
-    """
+    """Selecting on the instance label alone picked these up and aborted every rollback of a
+    chart with observability enabled."""
     mocker.patch(
         "scripts.rollback.run_json",
         return_value={"items": [*SUBCHART_DEPLOYMENTS, WATCHER_DEPLOYMENT, ORCHESTRATOR_DEPLOYMENT]},
@@ -138,8 +134,7 @@ def test_orchestrator_container_missing_is_an_error():
 
 
 def test_migration_job_runs_the_live_image_and_environment():
-    """The target release's image predates the migrations being reverted, so the Job must
-    use the one currently deployed."""
+    """The target release's image cannot run the migrations being reverted."""
     job = build_migration_job("idegym-migrate-002", "idegym", ORCHESTRATOR_DEPLOYMENT, "002", 600)
 
     container = job["spec"]["template"]["spec"]["containers"][0]
@@ -222,11 +217,8 @@ def cluster(mocker):
 
 
 def test_a_failed_downgrade_never_reaches_helm(cluster, capsys):
-    """The ordering guarantee of the whole script.
-
-    Rolling the Kubernetes resources back on top of a half-reverted schema would leave the
-    old code facing a schema it cannot read, with no record of what went wrong.
-    """
+    """The ordering guarantee of the whole script: rolling the resources back onto a
+    half-reverted schema would leave the old code facing a schema it cannot read."""
     run = cluster.patch("scripts.rollback.run", return_value="")
     cluster.patch("scripts.rollback.scale")
     # The preflight Job succeeds; the downgrade that follows it does not.
@@ -260,7 +252,7 @@ def test_the_preflight_runs_before_any_writer_stops(cluster):
 
 
 def test_a_matching_schema_rolls_back_without_stopping_anything(cluster, capsys):
-    """An upgrade that did not change the schema needs no downgrade and no maintenance window."""
+    """An unchanged schema needs no downgrade and no maintenance window."""
     run = cluster.patch("scripts.rollback.run", return_value="")
     cluster.patch(
         "scripts.rollback.release_values",
@@ -275,7 +267,7 @@ def test_a_matching_schema_rolls_back_without_stopping_anything(cluster, capsys)
 
 
 def test_dry_run_touches_neither_the_release_nor_the_writers(cluster):
-    """Only the preflight runs, and the Job it uses to ask the image is cleaned up."""
+    """Only the preflight runs, and its Job is cleaned up."""
     run = cluster.patch("scripts.rollback.run", return_value="")
     scale = cluster.patch("scripts.rollback.scale")
     create_job = cluster.patch("scripts.rollback.create_job")
@@ -291,7 +283,7 @@ def test_dry_run_touches_neither_the_release_nor_the_writers(cluster):
 
 
 def test_a_source_image_that_cannot_migrate_aborts_before_anything_stops(cluster, capsys):
-    """The preflight is what makes rolling back with the wrong image a no-op, not a mess."""
+    """The preflight makes rolling back with the wrong image a no-op rather than a mess."""
     cluster.patch("scripts.rollback.wait_for_job", return_value=False)
     scale = cluster.patch("scripts.rollback.scale")
     run = cluster.patch("scripts.rollback.run", return_value="")

--- a/unit-tests/test_rollback.py
+++ b/unit-tests/test_rollback.py
@@ -1,0 +1,236 @@
+"""Unit tests for ``scripts/rollback.py``.
+
+The cluster interaction is mocked; what is worth pinning down is the decision-making — how
+releases and Deployments are resolved, what the downgrade Job inherits from the live
+orchestrator, and the ordering guarantee that a failed downgrade never reaches Helm.
+"""
+
+import pytest
+
+from scripts.rollback import (
+    RollbackError,
+    build_migration_job,
+    declared_schema_revision,
+    find_history_entry,
+    main,
+    orchestrator_container,
+    release_deployments,
+)
+
+HISTORY = [
+    {"revision": 6, "status": "superseded", "chart": "idegym-0.10.0"},
+    {"revision": 7, "status": "deployed", "chart": "idegym-0.11.0"},
+]
+
+ORCHESTRATOR_DEPLOYMENT = {
+    "metadata": {"name": "idegym"},
+    "spec": {
+        "replicas": 4,
+        "template": {
+            "spec": {
+                "serviceAccountName": "idegym",
+                "imagePullSecrets": [{"name": "ghcr"}],
+                "tolerations": [{"key": "jetbrains.com/idegym", "operator": "Exists", "effect": "NoSchedule"}],
+                "affinity": {"nodeAffinity": {}},
+                "containers": [
+                    {
+                        "name": "orchestrator",
+                        "image": "ghcr.io/jetbrains-research/idegym/orchestrator:0.11.0",
+                        "imagePullPolicy": "IfNotPresent",
+                        "env": [{"name": "POSTGRES_HOST", "value": "postgres"}],
+                        "readinessProbe": {"httpGet": {"path": "/health", "port": "http"}},
+                    },
+                    {"name": "sidecar", "image": "busybox"},
+                ],
+            }
+        },
+    },
+}
+
+WATCHER_DEPLOYMENT = {
+    "metadata": {"name": "idegym-watcher"},
+    "spec": {"replicas": 1, "template": {"spec": {"containers": [{"name": "watcher", "image": "watcher:0.11.0"}]}}},
+}
+
+
+def test_find_history_entry_returns_the_requested_revision():
+    assert find_history_entry(HISTORY, 6)["chart"] == "idegym-0.10.0"
+
+
+def test_find_history_entry_lists_what_exists_when_the_revision_does_not():
+    with pytest.raises(RollbackError, match="have: 6, 7"):
+        find_history_entry(HISTORY, 9)
+
+
+def test_declared_schema_revision_reads_the_chart_value():
+    assert declared_schema_revision({"database": {"schemaRevision": "002"}}) == "002"
+
+
+@pytest.mark.parametrize("values", [{}, {"database": {}}, {"database": {"schemaRevision": ""}}])
+def test_a_release_without_a_declared_revision_must_be_told_the_target(values):
+    """Guessing the schema of a release that predates the declaration would be a data risk."""
+    with pytest.raises(RollbackError, match="--target-schema-revision"):
+        declared_schema_revision(values)
+
+
+def test_release_deployments_finds_both_writers(mocker):
+    mocker.patch("scripts.rollback.run_json", return_value={"items": [WATCHER_DEPLOYMENT, ORCHESTRATOR_DEPLOYMENT]})
+
+    orchestrator, watcher = release_deployments("idegym", "idegym")
+
+    assert orchestrator["metadata"]["name"] == "idegym"
+    assert watcher["metadata"]["name"] == "idegym-watcher"
+
+
+def test_release_deployments_tolerates_a_disabled_watcher(mocker):
+    mocker.patch("scripts.rollback.run_json", return_value={"items": [ORCHESTRATOR_DEPLOYMENT]})
+
+    orchestrator, watcher = release_deployments("idegym", "idegym")
+
+    assert orchestrator["metadata"]["name"] == "idegym"
+    assert watcher is None
+
+
+def test_release_deployments_reports_what_it_found_when_ambiguous(mocker):
+    mocker.patch("scripts.rollback.run_json", return_value={"items": []})
+
+    with pytest.raises(RollbackError, match="found: none"):
+        release_deployments("idegym", "idegym")
+
+
+def test_orchestrator_container_is_picked_by_name():
+    assert orchestrator_container(ORCHESTRATOR_DEPLOYMENT)["image"].endswith("orchestrator:0.11.0")
+
+
+def test_orchestrator_container_missing_is_an_error():
+    deployment = {"metadata": {"name": "idegym"}, "spec": {"template": {"spec": {"containers": []}}}}
+
+    with pytest.raises(RollbackError, match="no orchestrator container"):
+        orchestrator_container(deployment)
+
+
+def test_migration_job_runs_the_live_image_and_environment():
+    """The target release's image predates the migrations being reverted, so the Job must
+    use the one currently deployed."""
+    job = build_migration_job("idegym-migrate-002", "idegym", ORCHESTRATOR_DEPLOYMENT, "002", 600)
+
+    container = job["spec"]["template"]["spec"]["containers"][0]
+    assert container["image"] == "ghcr.io/jetbrains-research/idegym/orchestrator:0.11.0"
+    assert container["env"] == [{"name": "POSTGRES_HOST", "value": "postgres"}]
+    assert container["command"][-3:] == ["--target", "002", "--allow-downgrade"]
+    assert "readinessProbe" not in container
+
+
+def test_migration_job_inherits_scheduling_and_identity():
+    job = build_migration_job("idegym-migrate-002", "idegym", ORCHESTRATOR_DEPLOYMENT, "002", 600)
+
+    pod_spec = job["spec"]["template"]["spec"]
+    assert pod_spec["serviceAccountName"] == "idegym"
+    assert pod_spec["tolerations"][0]["key"] == "jetbrains.com/idegym"
+    assert pod_spec["imagePullSecrets"] == [{"name": "ghcr"}]
+    assert pod_spec["restartPolicy"] == "Never"
+    # The sidecar is deliberately dropped: this pod only migrates.
+    assert [container["name"] for container in pod_spec["containers"]] == ["migrate"]
+
+
+def test_migration_job_is_not_retried():
+    """A retry would run the downgrade again against a half-reverted schema."""
+    job = build_migration_job("idegym-migrate-002", "idegym", ORCHESTRATOR_DEPLOYMENT, "002", 600)
+
+    assert job["spec"]["backoffLimit"] == 0
+    assert job["spec"]["activeDeadlineSeconds"] == 600
+
+
+def fake_run_json(command: list[str]):
+    """Answer the two read-only queries ``main`` makes: release history and Deployments."""
+    if "history" in command:
+        return HISTORY
+    name = command[3]
+    replicas = 1 if name.endswith("-watcher") else 4
+    return {"metadata": {"name": name}, "spec": {"replicas": replicas}, "status": {"readyReplicas": replicas}}
+
+
+@pytest.fixture
+def cluster(mocker):
+    """Patch away every cluster call so ``main`` can be driven end to end.
+
+    Deployed release is Helm revision 7 at schema 003; revision 6 declared schema 002.
+    """
+    mocker.patch("scripts.rollback.current_helm_revision", return_value=7)
+    mocker.patch("scripts.rollback.run_json", side_effect=fake_run_json)
+    mocker.patch(
+        "scripts.rollback.release_values",
+        side_effect=lambda release, namespace, revision=None: {
+            "database": {"schemaRevision": "002" if revision == 6 else "003"}
+        },
+    )
+    mocker.patch("scripts.rollback.release_deployments", return_value=(ORCHESTRATOR_DEPLOYMENT, WATCHER_DEPLOYMENT))
+    mocker.patch("scripts.rollback.exec_in_deployment", return_value=(0, "downgrade 003 -> 002 via 003"))
+    mocker.patch("scripts.rollback.wait_for_no_pods")
+    mocker.patch("scripts.rollback.create_job")
+    return mocker
+
+
+def test_a_failed_downgrade_never_reaches_helm(cluster, capsys):
+    """The ordering guarantee of the whole script.
+
+    Rolling the Kubernetes resources back on top of a half-reverted schema would leave the
+    old code facing a schema it cannot read, with no record of what went wrong.
+    """
+    run = cluster.patch("scripts.rollback.run", return_value="")
+    cluster.patch("scripts.rollback.scale")
+    cluster.patch("scripts.rollback.wait_for_job", return_value=False)
+
+    assert main(["--release", "idegym", "--namespace", "idegym", "--revision", "6", "--yes"]) == 1
+    assert not [call for call in run.call_args_list if "rollback" in call.args[0]]
+    assert "still stopped" in capsys.readouterr().err
+
+
+def test_a_successful_downgrade_stops_the_writers_first(cluster):
+    run = cluster.patch("scripts.rollback.run", return_value="")
+    scale = cluster.patch("scripts.rollback.scale")
+    cluster.patch("scripts.rollback.wait_for_job", return_value=True)
+
+    assert main(["--release", "idegym", "--namespace", "idegym", "--revision", "6", "--yes"]) == 0
+    assert [call.args for call in scale.call_args_list] == [("idegym", "idegym", 0), ("idegym-watcher", "idegym", 0)]
+    assert [call for call in run.call_args_list if "rollback" in call.args[0]]
+
+
+def test_a_matching_schema_rolls_back_without_stopping_anything(cluster, capsys):
+    """An upgrade that did not change the schema needs no downgrade and no maintenance window."""
+    run = cluster.patch("scripts.rollback.run", return_value="")
+    cluster.patch(
+        "scripts.rollback.release_values",
+        side_effect=lambda release, namespace, revision=None: {"database": {"schemaRevision": "003"}},
+    )
+    scale = cluster.patch("scripts.rollback.scale")
+
+    assert main(["--release", "idegym", "--namespace", "idegym", "--revision", "6"]) == 0
+    assert [call for call in run.call_args_list if "rollback" in call.args[0]]
+    scale.assert_not_called()
+    assert "schema was already at 003" in capsys.readouterr().out
+
+
+def test_dry_run_changes_nothing(cluster):
+    run = cluster.patch("scripts.rollback.run", return_value="")
+    scale = cluster.patch("scripts.rollback.scale")
+    create_job = cluster.patch("scripts.rollback.create_job")
+
+    assert main(["--release", "idegym", "--namespace", "idegym", "--revision", "6", "--dry-run"]) == 0
+    run.assert_not_called()
+    scale.assert_not_called()
+    create_job.assert_not_called()
+
+
+def test_a_source_image_that_cannot_downgrade_aborts_before_anything_stops(cluster, capsys):
+    cluster.patch("scripts.rollback.exec_in_deployment", return_value=(1, "error: revision '002' is not one of ..."))
+    scale = cluster.patch("scripts.rollback.scale")
+
+    assert main(["--release", "idegym", "--namespace", "idegym", "--revision", "6", "--yes"]) == 1
+    scale.assert_not_called()
+    assert "cannot downgrade to 002" in capsys.readouterr().err
+
+
+def test_rolling_back_to_the_current_revision_is_refused(cluster, capsys):
+    assert main(["--release", "idegym", "--namespace", "idegym", "--revision", "7"]) == 1
+    assert "already at revision 7" in capsys.readouterr().err

--- a/unit-tests/test_rollback.py
+++ b/unit-tests/test_rollback.py
@@ -165,9 +165,10 @@ def cluster(mocker):
         },
     )
     mocker.patch("scripts.rollback.release_deployments", return_value=(ORCHESTRATOR_DEPLOYMENT, WATCHER_DEPLOYMENT))
-    mocker.patch("scripts.rollback.exec_in_deployment", return_value=(0, "downgrade 003 -> 002 via 003"))
+    mocker.patch("scripts.rollback.exec_in_deployment", return_value=(0, "003"))
     mocker.patch("scripts.rollback.wait_for_no_pods")
     mocker.patch("scripts.rollback.create_job")
+    mocker.patch("scripts.rollback.delete_job")
     return mocker
 
 
@@ -179,7 +180,8 @@ def test_a_failed_downgrade_never_reaches_helm(cluster, capsys):
     """
     run = cluster.patch("scripts.rollback.run", return_value="")
     cluster.patch("scripts.rollback.scale")
-    cluster.patch("scripts.rollback.wait_for_job", return_value=False)
+    # The preflight Job succeeds; the downgrade that follows it does not.
+    cluster.patch("scripts.rollback.wait_for_job", side_effect=[True, False])
 
     assert main(["--release", "idegym", "--namespace", "idegym", "--revision", "6", "--yes"]) == 1
     assert not [call for call in run.call_args_list if "rollback" in call.args[0]]
@@ -194,6 +196,18 @@ def test_a_successful_downgrade_stops_the_writers_first(cluster):
     assert main(["--release", "idegym", "--namespace", "idegym", "--revision", "6", "--yes"]) == 0
     assert [call.args for call in scale.call_args_list] == [("idegym", "idegym", 0), ("idegym-watcher", "idegym", 0)]
     assert [call for call in run.call_args_list if "rollback" in call.args[0]]
+
+
+def test_the_preflight_runs_before_any_writer_stops(cluster):
+    """Ordering: the source image is asked whether it can migrate while it is still serving."""
+    calls: list[str] = []
+    cluster.patch("scripts.rollback.create_job", side_effect=lambda job: calls.append(job["metadata"]["name"]))
+    cluster.patch("scripts.rollback.scale", side_effect=lambda *_: calls.append("scale"))
+    cluster.patch("scripts.rollback.run", return_value="")
+    cluster.patch("scripts.rollback.wait_for_job", return_value=True)
+
+    assert main(["--release", "idegym", "--namespace", "idegym", "--revision", "6", "--yes"]) == 0
+    assert calls == ["idegym-migrate-check-002", "scale", "scale", "idegym-migrate-002"]
 
 
 def test_a_matching_schema_rolls_back_without_stopping_anything(cluster, capsys):
@@ -211,24 +225,32 @@ def test_a_matching_schema_rolls_back_without_stopping_anything(cluster, capsys)
     assert "schema was already at 003" in capsys.readouterr().out
 
 
-def test_dry_run_changes_nothing(cluster):
+def test_dry_run_touches_neither_the_release_nor_the_writers(cluster):
+    """Only the preflight runs, and the Job it uses to ask the image is cleaned up."""
     run = cluster.patch("scripts.rollback.run", return_value="")
     scale = cluster.patch("scripts.rollback.scale")
     create_job = cluster.patch("scripts.rollback.create_job")
+    delete_job = cluster.patch("scripts.rollback.delete_job")
+    cluster.patch("scripts.rollback.wait_for_job", return_value=True)
 
     assert main(["--release", "idegym", "--namespace", "idegym", "--revision", "6", "--dry-run"]) == 0
     run.assert_not_called()
     scale.assert_not_called()
-    create_job.assert_not_called()
+    assert create_job.call_count == 1
+    assert create_job.call_args.args[0]["spec"]["template"]["spec"]["containers"][0]["command"][-1] == "--dry-run"
+    delete_job.assert_called_once()
 
 
-def test_a_source_image_that_cannot_downgrade_aborts_before_anything_stops(cluster, capsys):
-    cluster.patch("scripts.rollback.exec_in_deployment", return_value=(1, "error: revision '002' is not one of ..."))
+def test_a_source_image_that_cannot_migrate_aborts_before_anything_stops(cluster, capsys):
+    """The preflight is what makes rolling back with the wrong image a no-op, not a mess."""
+    cluster.patch("scripts.rollback.wait_for_job", return_value=False)
     scale = cluster.patch("scripts.rollback.scale")
+    run = cluster.patch("scripts.rollback.run", return_value="")
 
     assert main(["--release", "idegym", "--namespace", "idegym", "--revision", "6", "--yes"]) == 1
     scale.assert_not_called()
-    assert "cannot downgrade to 002" in capsys.readouterr().err
+    run.assert_not_called()
+    assert "cannot migrate to 002" in capsys.readouterr().err
 
 
 def test_rolling_back_to_the_current_revision_is_refused(cluster, capsys):

--- a/watcher/src/idegym/watcher/main.py
+++ b/watcher/src/idegym/watcher/main.py
@@ -8,8 +8,9 @@ from idegym.api.config import Config
 from idegym.api.health import HealthCheckResponse
 from idegym.backend.utils.kubernetes_client import load_kubernetes_config
 from idegym.backend.utils.logging import configure_logging
+from idegym.orchestrator.config import load_config
 from idegym.orchestrator.database.database import connect_db_engine
-from idegym.orchestrator.main import configure_process, load_config
+from idegym.orchestrator.main import configure_process
 from idegym.utils.logging import get_logger
 from idegym.watcher.cleanup import cleanup_inactive_pods
 from prometheus_client import REGISTRY

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -61,6 +61,20 @@ kubectl port-forward svc/idegym 8000:80 -n idegym
 curl http://localhost:8000/health   # → {"status":"healthy"}
 ```
 
+## Upgrades and rollback
+
+The orchestrator owns the database schema: it runs Alembic migrations on startup, forward
+only. Each release therefore declares the exact revision its images expect
+(`database.schemaRevision`), and refuses to start if that disagrees with the migrations it
+actually contains.
+
+Because Helm only restores Kubernetes resources, a bare `helm rollback` leaves the schema on
+the newer revision — which the older image may not even know about. Roll back with
+[`scripts/rollback.py`](https://github.com/JetBrains-Research/idegym/blob/main/scripts/rollback.py)
+instead: it compares what the two releases declare and, when the target expects an older
+revision, stops both database writers and downgrades the schema with the *currently deployed*
+image before handing over to Helm. See [Database Rollback](/reference/database_rollback).
+
 ## Sandboxing with gVisor
 
 Environment pods run untrusted code, so they're meant to run under the
@@ -126,3 +140,4 @@ the `Mcp-Session-Id` header and run one worker per pod.
 | [Getting Started](/reference/getting_started) | Local dev setup + running tests |
 | [Local Deployment](/reference/local_deployment) | Full stack on Minikube — macOS or Linux (GHCR or local builds) |
 | [Remote Deployment](/reference/remote_deployment) | Production Kubernetes, secrets, node pools, snapshots |
+| [Database Rollback](/reference/database_rollback) | Rolling a release back, schema included; writing reversible migrations |

--- a/website/docs/reference/database_rollback.md
+++ b/website/docs/reference/database_rollback.md
@@ -1,0 +1,222 @@
+# Database Rollback
+
+`helm rollback` restores Kubernetes resources and nothing else. The orchestrator migrates the
+schema forward on startup, so after a failed upgrade the database is left on the *newer*
+revision: the older image may not contain that revision at all, and Alembic cannot traverse a
+revision whose script it does not have.
+
+Rolling a release back therefore has to decide what to do about the schema. IdeGYM supports
+three answers, and they are not interchangeable.
+
+| Kind | What it does to data | When |
+|---|---|---|
+| **Application-only** | Nothing | The target release declares the same schema revision, or the newer schema is backwards compatible |
+| **Exact schema rollback** | Discards whatever the reverted revisions store | The target release declares an older revision |
+| **Restore a backup** | Discards *every* write since the backup | The downgrade failed or is not reversible |
+
+Everything below is an explicit operator action. Nothing restores a backup automatically —
+that would silently turn a code rollback into a point-in-time data rollback.
+
+---
+
+## Every release declares its schema revision
+
+`charts/idegym/values.yaml` carries the exact Alembic revision the release's images expect:
+
+```yaml
+database:
+  schemaRevision: "003"
+```
+
+This is the value a rollback downgrades *to*, so three things keep it honest:
+
+- the orchestrator refuses to start when it does not match its own migration head, so a
+  mis-declared release fails its rollout instead of breaking a later rollback;
+- a unit test compares it with Alembic's sole head, so CI fails on a migration that lands
+  without bumping it;
+- `scripts/rollback.py` reads it back from the *target* release with
+  `helm get values --revision <n> --all`, so the target is whatever that release declared —
+  never a relative guess like `-1`.
+
+A release created before this mechanism existed declares nothing; rolling back to one requires
+`--target-schema-revision` to state its revision explicitly.
+
+---
+
+## Rolling back
+
+Always look at the history first, and ask for the plan before committing to it:
+
+```shell
+helm history idegym -n idegym
+
+uv run python scripts/rollback.py \
+  --release idegym --namespace idegym --revision 7 --dry-run
+```
+
+The dry run prints both schema revisions, the image that would run the downgrade, and — when a
+downgrade is needed — the plan the **deployed** image reports for it. It changes nothing.
+
+Then run it for real (drop `--dry-run`). A schema downgrade asks for confirmation unless you
+pass `--yes`:
+
+```shell
+uv run python scripts/rollback.py \
+  --release idegym --namespace idegym --revision 7
+```
+
+### Application-only rollback
+
+When both releases declare the same revision, there is nothing to migrate: the command runs a
+plain `helm rollback --wait`, then verifies the recorded revision and that both writers came
+back. No maintenance window, no data loss.
+
+This is also the right outcome when the newer schema is *compatible* with the older code —
+[expand/contract migrations](#writing-reversible-migrations) are what make that true. Keeping a
+compatible newer schema is preferable to downgrading it; the schema can be contracted later,
+on the way forward.
+
+### Exact schema rollback
+
+When the target release declares an older revision, ordering is what keeps the rollback safe:
+
+```mermaid
+sequenceDiagram
+    participant Op as scripts/rollback.py
+    participant K as Kubernetes
+    participant DB as PostgreSQL
+    participant H as Helm
+
+    Op->>K: ask the live image whether it can downgrade (dry run)
+    Op->>K: scale orchestrator + watcher to 0
+    K-->>Op: no IdeGYM process can write
+    Op->>K: Job: migrate --target <older> (source image)
+    K->>DB: Alembic downgrade under the advisory lock
+    DB-->>Op: schema at the target revision
+    Op->>H: helm rollback --wait --wait-for-jobs
+    H-->>Op: target release running
+    Op->>DB: verify the recorded revision
+```
+
+Three properties of that sequence matter:
+
+- **The downgrade runs with the currently deployed image.** It is the only one that contains
+  the migrations being reverted. The target release's image predates them and cannot run them.
+- **Both writers are stopped first.** The advisory lock only serialises migrations against each
+  other; it does not stop a running orchestrator or watcher from writing to a schema that is
+  being changed underneath it.
+- **Helm is never reached after a failed downgrade.** Rolling the resources back on top of a
+  half-reverted schema would leave the old code facing a schema it cannot read.
+
+### When a step fails
+
+| Failure | State it leaves | What the command tells you |
+|---|---|---|
+| Preflight (unknown revision, no downgrade path, wrong image) | Untouched | Nothing was stopped |
+| The downgrade Job | Writers stopped, schema possibly partly reverted, release unchanged | The Job's logs, and the `kubectl scale` commands that bring the current release back up |
+| `helm rollback` after a successful downgrade | Writers stopped, schema at the target revision | Retry the Helm rollback, or migrate forward again and restart the current release |
+
+A failed rollback never restarts a writer on its own: a database in an unknown state should be
+looked at before anything writes to it again.
+
+---
+
+## Back up before you downgrade
+
+A downgrade discards what the reverted revisions store — dropping a column drops its data, and
+dropping a table drops all of it. Nothing in the rollback path can bring that back, so if the
+data matters, take a logical dump first and keep it somewhere that outlives the pod:
+
+```shell
+kubectl exec -n idegym postgres-0 -- \
+  env PGPASSWORD="$(kubectl get secret postgres -n idegym -o jsonpath='{.data.password}' | base64 -d)" \
+  pg_dump -U idegym -Fc idegym > idegym-pre-rollback.dump
+```
+
+`pg_dump` is consistent while readers and writers keep running, but its recovery point is when
+the dump *started*. For a zero-loss recovery point, stop the writers first (the rollback command
+does that anyway) and dump before the downgrade Job runs.
+
+### Restoring one
+
+Restoring a dump discards every write made after it — including work created since the upgrade.
+It is a recovery action, not a rollback, and it is always deliberate:
+
+```shell
+# 1. Stop every IdeGYM writer.
+kubectl scale deployment idegym idegym-watcher -n idegym --replicas=0
+
+# 2. Restore into the empty database. --clean --if-exists overwrites what is there.
+kubectl exec -i -n idegym postgres-0 -- \
+  env PGPASSWORD=... pg_restore -U idegym -d idegym \
+      --clean --if-exists --no-owner --no-acl --single-transaction --exit-on-error \
+  < idegym-pre-rollback.dump
+
+# 3. Check the restored revision matches the release you are about to run.
+kubectl exec -n idegym postgres-0 -- \
+  env PGPASSWORD=... psql -U idegym -d idegym -tAc 'SELECT version_num FROM alembic_version;'
+
+# 4. Bring the writers back at their original replica counts.
+kubectl scale deployment idegym -n idegym --replicas=4
+kubectl scale deployment idegym-watcher -n idegym --replicas=1
+```
+
+Release-bound automatic backups (a pre-upgrade Job, retention, checksum-verified restore) are
+not implemented yet; until they are, the dump above is the recovery point and taking it is part
+of the upgrade procedure.
+
+---
+
+## The migration CLI
+
+`scripts/rollback.py` drives the schema through a CLI in the orchestrator image, which reads the
+same database configuration the service does. It is also useful on its own for inspection:
+
+```shell
+# What the database is at, and what this image can reach.
+kubectl exec deployment/idegym -n idegym -- \
+  uv run python -m idegym.orchestrator.db_cli schema current
+kubectl exec deployment/idegym -n idegym -- \
+  uv run python -m idegym.orchestrator.db_cli schema head
+
+# What a move would do, without doing it.
+kubectl exec deployment/idegym -n idegym -- \
+  uv run python -m idegym.orchestrator.db_cli migrate --target 002 --dry-run
+```
+
+`migrate` takes one exact revision (or `base`) — never a relative offset — and refuses a
+backwards move unless `--allow-downgrade` is passed, so a mistyped target cannot drop columns.
+It fails rather than guessing when the target is unknown, when the database sits on a revision
+the image does not contain, when a revision being reverted ships no down migration, or when
+another process holds the migration lock.
+
+Run `migrate` by hand only with every writer stopped. With the orchestrator running, its next
+starting replica migrates the schema straight back to its own head.
+
+---
+
+## Writing reversible migrations
+
+An exact schema rollback is only as good as the down migrations it runs, and the least
+disruptive rollback is the one that does not need them.
+
+- **Prefer expand/contract.** Add tables and nullable columns first; ship code that tolerates
+  both shapes; remove or rename in a later release. Release N's migration must be safe while
+  N-1's orchestrator and watcher are still running — a rolling update overlaps them by design.
+- **Ship `<rev>_up.sql` and `<rev>_down.sql` together.** The downgrade path is checked against
+  those files before anything runs; a revision without a down migration cannot be reverted and
+  turns an exact rollback into a backup restore.
+- **Say what a downgrade discards**, in a comment next to the SQL. `003_down.sql` drops columns;
+  `002_down.sql` drops whole tables. That difference is what an operator is approving.
+- **Keep the history linear.** Exact-revision migration is only well defined without branches;
+  a merge revision is rejected rather than traversed in an arbitrary order.
+
+Every revision's up/down pair is exercised against real PostgreSQL, with data seeded at each
+step, in
+[`integration-tests/database/test_migration_roundtrip.py`](https://github.com/JetBrains-Research/idegym/blob/main/integration-tests/database/test_migration_roundtrip.py).
+
+See also
+[`orchestrator/src/idegym/orchestrator/migrations/README.md`](https://github.com/JetBrains-Research/idegym/blob/main/orchestrator/src/idegym/orchestrator/migrations/README.md)
+for how to create a migration, and
+[Remote Deployment](/reference/remote_deployment#updating-the-orchestrator) for the upgrade
+procedure this reverses.

--- a/website/docs/reference/database_rollback.md
+++ b/website/docs/reference/database_rollback.md
@@ -6,16 +6,22 @@ revision: the older image may not contain that revision at all, and Alembic cann
 revision whose script it does not have.
 
 Rolling a release back therefore has to decide what to do about the schema. IdeGYM supports
-three answers, and they are not interchangeable.
+three answers, and they are not interchangeable — they differ in what they cost you in data:
 
-| Kind | What it does to data | When |
-|---|---|---|
-| **Application-only** | Nothing | The target release declares the same schema revision, or the newer schema is backwards compatible |
-| **Exact schema rollback** | Discards whatever the reverted revisions store | The target release declares an older revision |
-| **Restore a backup** | Discards *every* write since the backup | The downgrade failed or is not reversible |
+```mermaid
+flowchart TD
+    A["Roll release N+1 back to N"] --> B{"Do both releases declare the same database.schemaRevision?"}
+    B -->|yes| C["Application-only rollback: helm rollback alone, no data touched"]
+    B -->|"N declares an older revision"| D{"Does every revision in between have a down migration?"}
+    D -->|yes| E["Exact schema rollback: stop writers, downgrade, then helm rollback. The reverted revisions lose what they stored"]
+    D -->|no| F["Restore a backup: discards every write made since the dump"]
+```
 
-Everything below is an explicit operator action. Nothing restores a backup automatically —
-that would silently turn a code rollback into a point-in-time data rollback.
+`scripts/rollback.py` makes the first decision for you, from what the two releases declare, and
+refuses to continue if the second one comes out "no". The third row is a manual recovery path.
+
+Everything here is an explicit operator action. Nothing restores a backup automatically — that
+would silently turn a code rollback into a point-in-time data rollback.
 
 ---
 
@@ -85,20 +91,29 @@ When the target release declares an older revision, ordering is what keeps the r
 
 ```mermaid
 sequenceDiagram
+    autonumber
     participant Op as scripts/rollback.py
     participant K as Kubernetes
     participant DB as PostgreSQL
     participant H as Helm
 
-    Op->>K: Job: migrate --dry-run (source image) — can it make the move?
-    Op->>K: scale orchestrator + watcher to 0
-    K-->>Op: no IdeGYM process can write
-    Op->>K: Job: migrate --target <older> (source image)
-    K->>DB: Alembic downgrade under the advisory lock
-    DB-->>Op: schema at the target revision
+    Note over Op,H: Ask first, while everything is still running
+    Op->>K: Job on the deployed image, migrate --dry-run
+    K-->>Op: the plan resolves, nothing was changed
+
+    Note over Op,H: Maintenance window opens
+    Op->>K: scale orchestrator and watcher to 0
+    K-->>Op: no IdeGYM process can write any more
+
+    Note over Op,H: Move the schema
+    Op->>K: Job on the deployed image, migrate --target N
+    K->>DB: alembic downgrade, under the migration lock
+    DB-->>Op: schema is now at N
+
+    Note over Op,H: Hand over to Helm, then check
     Op->>H: helm rollback --wait --wait-for-jobs
-    H-->>Op: target release running
-    Op->>DB: verify the recorded revision
+    H-->>Op: release N is running, writers are back
+    Op->>DB: schema verify --expect N
 ```
 
 Three properties of that sequence matter:

--- a/website/docs/reference/database_rollback.md
+++ b/website/docs/reference/database_rollback.md
@@ -55,7 +55,10 @@ uv run python scripts/rollback.py \
 ```
 
 The dry run prints both schema revisions, the image that would run the downgrade, and — when a
-downgrade is needed — the plan the **deployed** image reports for it. It changes nothing.
+downgrade is needed — the plan that image itself reports. That preflight runs as a short-lived
+Job on the deployed image rather than `kubectl exec`, because a rollback usually follows a
+failed rollout, when no pod of that image may be healthy enough to exec into. It reads the
+schema and is deleted afterwards; the release, the schema, and both writers are untouched.
 
 Then run it for real (drop `--dry-run`). A schema downgrade asks for confirmation unless you
 pass `--yes`:
@@ -87,7 +90,7 @@ sequenceDiagram
     participant DB as PostgreSQL
     participant H as Helm
 
-    Op->>K: ask the live image whether it can downgrade (dry run)
+    Op->>K: Job: migrate --dry-run (source image) — can it make the move?
     Op->>K: scale orchestrator + watcher to 0
     K-->>Op: no IdeGYM process can write
     Op->>K: Job: migrate --target <older> (source image)

--- a/website/docs/reference/remote_deployment.md
+++ b/website/docs/reference/remote_deployment.md
@@ -527,6 +527,23 @@ either `helm upgrade` (which restarts pods) or:
 kubectl rollout restart deployment/idegym -n idegym
 ```
 
+A release that adds a migration must bump `database.schemaRevision` in the same change — the
+orchestrator refuses to start when it disagrees with the migrations in its image.
+
+### Rolling back
+
+`helm rollback` restores Kubernetes resources only; the schema stays at the newer revision.
+Use `scripts/rollback.py`, which resolves the target release's declared revision and downgrades
+the schema first when it differs:
+
+```shell
+uv run python scripts/rollback.py \
+  --release idegym --namespace idegym --revision 7 --dry-run
+```
+
+See [Database Rollback](/reference/database_rollback) for the full procedure, what a downgrade
+discards, and how to take a dump first.
+
 ---
 
 ## Accessing Observability Tools
@@ -563,12 +580,19 @@ Open <http://localhost:9090>.
 
 ### Migrations
 
-The orchestrator runs Alembic migrations automatically on startup. To run them manually:
+The orchestrator runs Alembic migrations automatically on startup, up to the head its image
+contains. To inspect the schema, or to move it to an exact revision:
 
 ```shell
-kubectl exec -it deployment/idegym -n idegym -- \
-  uv run alembic upgrade head
+kubectl exec deployment/idegym -n idegym -- \
+  uv run python -m idegym.orchestrator.db_cli schema current
+
+kubectl exec deployment/idegym -n idegym -- \
+  uv run python -m idegym.orchestrator.db_cli migrate --target 003 --dry-run
 ```
+
+Only run `migrate` for real with every writer stopped — see
+[Database Rollback](/reference/database_rollback#the-migration-cli).
 
 ### Connecting to PostgreSQL
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -44,6 +44,7 @@ const sidebars: SidebarsConfig = {
     'reference/mcp',
     'reference/local_deployment',
     'reference/remote_deployment',
+    'reference/database_rollback',
     'reference/http_error_codes',
     {
       type: 'category',


### PR DESCRIPTION
`helm rollback` restores Kubernetes resources and nothing else. The orchestrator migrates the
schema forward on startup, so after a failed upgrade the database is left on the *newer*
revision — which the older image may not contain at all, and Alembic cannot traverse a revision
whose script it does not have.

This adds the explicit, guarded workflow rather than automatic snapshot restoration.

Resolves: JBRes-9944

## What changed

**The bug first.** `001_down.sql` dropped `alembic_version`. Alembic deletes the revision row in
that same transaction, so the statement failed and aborted the whole downgrade — `downgrade base`
was impossible, not merely lossy. Removed on both sides (`001_up.sql` also created the table
redundantly), and a unit test now forbids any migration from naming it.

**Every release declares its schema revision.** `database.schemaRevision` in the chart, rendered
as `IDEGYM_DATABASE_SCHEMA_REVISION` through `required`, so a release cannot omit it. The
orchestrator refuses to start when it disagrees with its own migration head, and a unit test
fails CI when it drifts from Alembic's sole head.

**Exact-target migration.** `MigrationManager.migrate_to(target, allow_downgrade=)` resolves a
`MigrationPlan` before touching anything, then executes it under the existing advisory lock,
re-planning once the lock is held. It refuses — rather than guesses — on an unknown target, a
database sitting on a revision this image does not contain (the signature of rolling back with
the wrong image), a reverted revision that ships no down SQL, a branched history, or any
backwards move without explicit approval. Exposed as `python -m idegym.orchestrator.db_cli`
(`schema current|head|verify`, `migrate --target … [--allow-downgrade] [--dry-run]`).

**`scripts/rollback.py`** compares what the two releases declare. Same revision → plain
`helm rollback --wait`. Older revision → preflight, stop orchestrator *and* watcher, downgrade
with the **currently deployed** image, then Helm, then verify the recorded revision and the
replica counts.

## How it works

The reviewable part is where it stops. Both abort paths leave the release untouched, and a
failed downgrade never reaches Helm — rolling the resources back onto a half-reverted schema
would leave the old code facing a schema it cannot read.

```mermaid
flowchart TD
    A["scripts/rollback.py --revision N"] --> B{"schemaRevision: deployed vs release N"}
    B -->|same| H["helm rollback --wait"]
    B -->|"N declares an older one"| C{"Preflight Job: can the deployed image revert those revisions?"}
    C -->|no| X1["Stop. Nothing was stopped, the release is untouched"]
    C -->|yes| D["Scale orchestrator and watcher to 0"]
    D --> E["Downgrade Job on the deployed image: migrate --target N --allow-downgrade"]
    E -->|failed| X2["Stop. Helm never called, writers stay down, recovery commands printed"]
    E -->|succeeded| H
    H --> V["Verify: schema verify --expect N, both writers ready"]
```

The preflight runs as a Job rather than `kubectl exec` because a rollback usually follows a
failed rollout, when no pod of the source image may be healthy enough to exec into — and a pod of
the *previous* image would answer "can you revert these?" wrongly. It runs exactly the image from
the Deployment spec and is deleted afterwards.

[Database Rollback](https://github.com/JetBrains-Research/idegym/blob/vladimir.poliakov/jbres-9944-db-rollback/website/docs/reference/database_rollback.md)
carries the operator-facing pair: a decision flowchart for which of the three rollbacks applies,
and a phase-labelled sequence diagram of the exact-schema one.

Main review risk: the downgrade Job inherits the live orchestrator's image, env, service account,
tolerations and affinity, but nothing else. A future pod-spec field that migrations depend on
would have to be added to `INHERITED_POD_SPEC_KEYS`.

## Not in this PR

**Backup and restore automation is deliberately deferred** to a follow-up ticket, so two of the
ticket's acceptance criteria (a retained release-bound `pg_dump` backup, a checksum-verified
restore) are not met here. The reason is that `pg_dump` must be at least the server's major
version, which Debian bookworm's `postgresql-client` is not for the bundled PostgreSQL — that
means adding the PGDG repo to the orchestrator image plus hook/PVC templates, a materially larger
and more environment-dependent change than the rollback mechanism itself.
[Database Rollback](https://github.com/JetBrains-Research/idegym/blob/vladimir.poliakov/jbres-9944-db-rollback/website/docs/reference/database_rollback.md)
documents the manual `pg_dump`/`pg_restore` procedure and says plainly that the automation does
not exist yet.

## Testing

- Unit: **930 passed, 2 skipped** (59 new, across `test_db_cli.py`, `test_rollback.py`,
  `test_migrations.py`). The rollback script's cluster calls are mocked; what is pinned down is
  the decision-making and the ordering guarantee.
- DB integration: **94 passed**, including 7 new round-trip tests that drive every revision up
  and down against real PostgreSQL with data seeded at each step, assert the head schema matches
  the ORM models, and cover the `downgrade base` regression. Each test gets a throwaway database
  in the shared container, because Alembic owns the whole schema and cannot share one with the
  ORM-created database the other modules truncate.
- `ruff check` and `ruff format --check` pass; `uv lock --check` unchanged.
- `helm lint` passes, `helm template` renders the new env, and rendering fails as intended when
  `schemaRevision` is null.
- `cd website && npm run build` succeeded when the docs were written; the later diagram edits
  changed only mermaid blocks, so no link or anchor moved (CI's Build site job is the check).

`e2e-tests/test_db_rollback.py` runs in the `other` group. Its first CI run failed all three
tests and was right to: selecting Deployments by `app.kubernetes.io/instance` also matched the
grafana and prometheus subcharts, which share the release, so the rollback aborted before doing
anything on any chart with observability enabled. Fixed in 0e7ede8 by matching on
`app.kubernetes.io/name`, with subchart Deployments added to the unit fixtures.

Note the e2e file cannot stage a literal N → N+1 → N rollback: one image means one set of
migrations, and any running orchestrator drags the schema back to its own head, so no release in
the history can hold it lower. It instead exercises every mechanism that case depends on —
declared revision vs. image vs. database, the downgrade Job built from the live Deployment, a full
down/up round trip with data, and a real application-only `helm rollback` driven through `main()`.

## Checklist

- [x] `uv run ruff check` and `uv run ruff format --check` both pass (CI does not check formatting).
- [x] Tests cover the change at the lowest suite that can express it (`unit` > `integration` > `e2e`).
- [x] [`AGENTS.md`](AGENTS.md) is still accurate — the migrations playbook now says a migration is
      a four-file change (module, up SQL, down SQL, `schemaRevision`), that downgrades are executed
      rather than decorative, and how to run the round-trip suite.
