### PR TITLE
[JBAI-21836] Improve sandbox placement locality

### DIFF
--- a/api/src/idegym/api/config.py
+++ b/api/src/idegym/api/config.py
@@ -207,6 +207,17 @@ class NodePoolConfig(ConfigModel):
     )
 
 
+class SameImageAffinityConfig(ConfigModel):
+    env_segment = "SAME_IMAGE_AFFINITY"
+
+    enabled: bool = Field(
+        description="Prefer placing sandbox pods with the same image reference together", default=False
+    )
+    preference_weight: int = Field(
+        description="Weight (1-100) for same-image preferred pod affinity", ge=1, le=100, default=100
+    )
+
+
 class CloudBuildGKEConfig(ConfigModel):
     """GKE Cloud Build backend settings. Only consulted when the build backend is
     `cloudbuild_gke`; `project_id`/`region`/`staging_bucket` are then required."""
@@ -420,6 +431,7 @@ class OrchestratorConfig(ConfigModel):
     asyncio: AsyncioConfig = Field(default_factory=AsyncioConfig)
     resources: ResourcesConfig = Field(default_factory=ResourcesConfig)
     node_pool: NodePoolConfig = Field(default_factory=NodePoolConfig)
+    same_image_affinity: SameImageAffinityConfig = Field(default_factory=SameImageAffinityConfig)
     build: BuildConfig = Field(default_factory=BuildConfig)
     mcp: MCPConfig = Field(default_factory=MCPConfig)
     client_request_timeout: float = env(

--- a/backend-utils/src/idegym/backend/utils/kubernetes_client.py
+++ b/backend-utils/src/idegym/backend/utils/kubernetes_client.py
@@ -15,6 +15,7 @@ from idegym.api.status import Status
 from idegym.api.type import ConditionStatus
 from idegym.utils.dict import deep_merge
 from idegym.utils.functools import cached_async_result
+from idegym.utils.hashing import sha256
 from idegym.utils.logging import get_logger
 from kubernetes_asyncio.client import (
     ApiClient,
@@ -51,6 +52,8 @@ from kubernetes_asyncio.client import (
     V1ObjectMeta,
     V1OwnerReference,
     V1Pod,
+    V1PodAffinity,
+    V1PodAffinityTerm,
     V1PodDisruptionBudget,
     V1PodDisruptionBudgetList,
     V1PodDisruptionBudgetSpec,
@@ -71,6 +74,7 @@ from kubernetes_asyncio.client import (
     V1Toleration,
     V1Volume,
     V1VolumeMount,
+    V1WeightedPodAffinityTerm,
 )
 from kubernetes_asyncio.config import (
     ConfigException,
@@ -83,6 +87,37 @@ KubernetesV1Apis = tuple[AppsV1Api, BatchV1Api, CoreV1Api, PolicyV1Api, CustomOb
 V1ResourceList = V1ConfigMapList | V1DeploymentList | V1PodDisruptionBudgetList | V1ServiceList
 
 logger = get_logger(__name__)
+
+SANDBOX_IMAGE_LABEL = "idegym.jetbrains.com/image-id"
+
+
+def sandbox_image_id(image_tag: str) -> str:
+    """Hash the exact image reference string, not its registry-resolved digest."""
+    return sha256(image_tag)[:32]
+
+
+def _add_same_image_affinity(affinity: Optional[V1Affinity], image_id: str, preference_weight: int) -> V1Affinity:
+    """Append same-image preference without replacing existing affinity rules."""
+    affinity = affinity or V1Affinity()
+    pod_affinity = affinity.pod_affinity or V1PodAffinity()
+    preferred = list(pod_affinity.preferred_during_scheduling_ignored_during_execution or ())
+    preferred.append(
+        V1WeightedPodAffinityTerm(
+            weight=preference_weight,
+            pod_affinity_term=V1PodAffinityTerm(
+                label_selector=V1LabelSelector(
+                    match_labels={
+                        "app.kubernetes.io/component": "sandbox",
+                        SANDBOX_IMAGE_LABEL: image_id,
+                    }
+                ),
+                topology_key="kubernetes.io/hostname",
+            ),
+        )
+    )
+    pod_affinity.preferred_during_scheduling_ignored_during_execution = preferred
+    affinity.pod_affinity = pod_affinity
+    return affinity
 
 
 def build_node_affinity(taint_key: str, preference_weight: int) -> V1NodeAffinity:
@@ -264,6 +299,8 @@ async def deploy_server(
     server_kind: ServerKind = ServerKind.IDEGYM,
     snapshot_id: Optional[str] = None,
     snapshot_tag: Optional[str] = None,
+    same_image_affinity_enabled: bool = False,
+    same_image_affinity_preference_weight: int = 100,
 ):
     """
     Create a Kubernetes Deployment, Service, and PodDisruptionBudget for a server.
@@ -340,6 +377,8 @@ async def deploy_server(
         "app.kubernetes.io/version": __version__,
         "idegym.jetbrains.com/snapshot-id": snapshot_id or server_name,
     }
+    if same_image_affinity_enabled:
+        labels[SANDBOX_IMAGE_LABEL] = sandbox_image_id(image_tag)
 
     toleration = (
         V1Toleration(
@@ -359,6 +398,13 @@ async def deploy_server(
         if node_pool_taint_key
         else None
     )
+
+    if same_image_affinity_enabled:
+        affinity = _add_same_image_affinity(
+            affinity,
+            image_id=labels[SANDBOX_IMAGE_LABEL],
+            preference_weight=same_image_affinity_preference_weight,
+        )
 
     pod_spec = V1PodSpec(
         containers=[container],

--- a/common-utils/src/idegym/utils/hashing.py
+++ b/common-utils/src/idegym/utils/hashing.py
@@ -7,3 +7,11 @@ def md5(value: str, /, *other: str) -> str:
     for item in (value, *other):
         digest.update(item.encode())
     return digest.hexdigest()
+
+
+def sha256(value: str, /, *other: str) -> str:
+    """Compute the SHA-256 hash of the given value(s)."""
+    digest = hashlib.sha256()
+    for item in (value, *other):
+        digest.update(item.encode())
+    return digest.hexdigest()

--- a/orchestrator/src/idegym/orchestrator/router/server.py
+++ b/orchestrator/src/idegym/orchestrator/router/server.py
@@ -282,6 +282,7 @@ async def _task_start_server(
             server_image_tag = server.image_tag
 
             node_pool: NodePoolConfig = config.orchestrator.node_pool
+            same_image_affinity = config.orchestrator.same_image_affinity
             pod_snapshot: PodSnapshotConfig = config.orchestrator.pod_snapshot
             otel_config: OTELConfig = config.otel
             environment_variables = [
@@ -364,6 +365,8 @@ async def _task_start_server(
                 server_kind=request.server_kind,
                 snapshot_id=request.snapshot.id if request.snapshot else None,
                 snapshot_tag=request.snapshot.tag if request.snapshot else None,
+                same_image_affinity_enabled=same_image_affinity.enabled,
+                same_image_affinity_preference_weight=same_image_affinity.preference_weight,
             )
 
             await wait_for_pods_ready(

--- a/orchestrator/src/idegym/orchestrator/snapshot_pipeline.py
+++ b/orchestrator/src/idegym/orchestrator/snapshot_pipeline.py
@@ -74,6 +74,7 @@ async def run_snapshot_pipeline_job(
         server_generated_name = server.generated_name
 
         node_pool = config.orchestrator.node_pool
+        same_image_affinity = config.orchestrator.same_image_affinity
         pod_snapshot = config.orchestrator.pod_snapshot
 
         if not pod_snapshot.enabled:
@@ -102,6 +103,8 @@ async def run_snapshot_pipeline_job(
             env_from=[source.model_dump(by_alias=True, exclude_none=True) for source in request.env_from],
             pod_overrides=request.pod_overrides.model_dump(by_alias=True, exclude_none=True),
             server_kind=request.server_kind,
+            same_image_affinity_enabled=same_image_affinity.enabled,
+            same_image_affinity_preference_weight=same_image_affinity.preference_weight,
         )
 
         await wait_for_pods_ready(

--- a/unit-tests/test_hashing.py
+++ b/unit-tests/test_hashing.py
@@ -1,4 +1,4 @@
-from idegym.utils.hashing import md5
+from idegym.utils.hashing import md5, sha256
 
 
 def test_identity():
@@ -12,3 +12,8 @@ def test_equality():
 
 def test_order():
     assert md5("abc") != md5("cba")
+
+
+def test_sha256():
+    assert sha256("abc") == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    assert sha256("abc") == sha256("a", "b", "c")

--- a/unit-tests/test_kubernetes_client.py
+++ b/unit-tests/test_kubernetes_client.py
@@ -8,7 +8,14 @@ only for its (offline) camelCase deserializer.
 import pytest
 from idegym.api.orchestrator.servers import StartServerRequest
 from idegym.backend.utils import kubernetes_client as kc
-from kubernetes_asyncio.client import ApiClient
+from kubernetes_asyncio.client import (
+    ApiClient,
+    V1Affinity,
+    V1LabelSelector,
+    V1PodAffinity,
+    V1PodAffinityTerm,
+    V1WeightedPodAffinityTerm,
+)
 
 
 @pytest.fixture
@@ -56,6 +63,7 @@ async def test_deploy_without_overrides_leaves_pod_unchanged(mocker, api_client)
     assert pod.volumes is None
     assert container.volume_mounts is None
     assert container.env_from is None
+    assert pod.affinity is None
 
 
 async def test_deploy_applies_typed_volumes_mounts_and_env_from(mocker, api_client):
@@ -100,6 +108,94 @@ async def test_pod_overrides_concatenate_lists_keeping_managed_entries(mocker, a
     )
     toleration_keys = {t.key for t in pod.tolerations}
     assert toleration_keys == {"node-pool", "dedicated"}
+
+
+async def test_same_image_prefers_same_node(mocker, api_client):
+    apps = _patch_clients(mocker, api_client)
+    await kc.deploy_server(
+        image_tag="registry.example/task:123",
+        server_name="srv",
+        namespace="ns",
+        same_image_affinity_enabled=True,
+        same_image_affinity_preference_weight=73,
+    )
+    body = apps.create_namespaced_deployment.call_args.kwargs["body"]
+    template = body.spec.template
+    preferred = template.spec.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution[0]
+
+    image_id = kc.sandbox_image_id("registry.example/task:123")
+    assert template.metadata.labels[kc.SANDBOX_IMAGE_LABEL] == image_id
+    assert preferred.weight == 73
+    assert preferred.pod_affinity_term.topology_key == "kubernetes.io/hostname"
+    assert preferred.pod_affinity_term.label_selector.match_labels == {
+        "app.kubernetes.io/component": "sandbox",
+        kc.SANDBOX_IMAGE_LABEL: image_id,
+    }
+    assert template.spec.affinity.node_affinity is None
+
+
+async def test_same_image_affinity_is_disabled_by_default(mocker, api_client):
+    apps = _patch_clients(mocker, api_client)
+    await kc.deploy_server(image_tag="registry.example/task:123", server_name="srv", namespace="ns")
+
+    template = apps.create_namespaced_deployment.call_args.kwargs["body"].spec.template
+    assert kc.SANDBOX_IMAGE_LABEL not in template.metadata.labels
+    assert template.spec.affinity is None
+
+
+async def test_same_image_affinity_composes_with_pod_overrides(mocker, api_client):
+    pod = await _deploy_and_get_pod_spec(
+        mocker,
+        api_client,
+        node_pool_taint_key="node-pool",
+        same_image_affinity_enabled=True,
+        pod_overrides={
+            "affinity": {
+                "podAffinity": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": [
+                        {
+                            "weight": 10,
+                            "podAffinityTerm": {
+                                "labelSelector": {"matchLabels": {"example.com/workload": "other"}},
+                                "topologyKey": "topology.kubernetes.io/zone",
+                            },
+                        }
+                    ]
+                }
+            }
+        },
+    )
+
+    preferred = pod.affinity.pod_affinity.preferred_during_scheduling_ignored_during_execution
+    assert sorted(term.weight for term in preferred) == [10, 100]
+    assert pod.affinity.node_affinity is not None
+
+
+def test_same_image_affinity_appends_to_existing_pod_affinity():
+    required = V1PodAffinityTerm(
+        label_selector=V1LabelSelector(match_labels={"example.com/required": "true"}),
+        topology_key="topology.kubernetes.io/zone",
+    )
+    existing_preference = V1WeightedPodAffinityTerm(
+        weight=10,
+        pod_affinity_term=V1PodAffinityTerm(
+            label_selector=V1LabelSelector(match_labels={"example.com/preferred": "true"}),
+            topology_key="topology.kubernetes.io/zone",
+        ),
+    )
+    affinity = V1Affinity(
+        pod_affinity=V1PodAffinity(
+            required_during_scheduling_ignored_during_execution=[required],
+            preferred_during_scheduling_ignored_during_execution=[existing_preference],
+        )
+    )
+
+    result = kc._add_same_image_affinity(affinity, image_id="image-hash", preference_weight=100)
+
+    assert result is affinity
+    assert result.pod_affinity.required_during_scheduling_ignored_during_execution == [required]
+    preferred = result.pod_affinity.preferred_during_scheduling_ignored_during_execution
+    assert sorted(term.weight for term in preferred) == [10, 100]
 
 
 async def test_pod_overrides_can_add_sidecar_without_dropping_server(mocker, api_client):

--- a/unit-tests/test_server_start.py
+++ b/unit-tests/test_server_start.py
@@ -1,0 +1,46 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from idegym.api.config import Config, SameImageAffinityConfig
+from idegym.api.orchestrator.servers import ServerReuseStrategy, StartServerRequest
+from idegym.orchestrator.router import server as server_router
+
+pytestmark = pytest.mark.unit
+
+
+async def test_fresh_server_passes_same_image_affinity_config_to_deployment(mocker):
+    config = Config()
+    config.orchestrator.same_image_affinity = SameImageAffinityConfig(enabled=True, preference_weight=73)
+    request = StartServerRequest(
+        client_id=uuid4(),
+        image_tag="registry.example/task:123",
+        reuse_strategy=ServerReuseStrategy.NONE,
+    )
+    mocker.patch.object(server_router, "extract_resources_request", return_value=(1.0, 2.0))
+    mocker.patch.object(
+        server_router,
+        "validate_client",
+        new=mocker.AsyncMock(return_value=SimpleNamespace(name="client")),
+    )
+    mocker.patch.object(
+        server_router,
+        "check_resources_and_save_server_in_db",
+        new=mocker.AsyncMock(
+            return_value=SimpleNamespace(
+                id=7,
+                generated_name="server-7",
+                server_name="default-idegym-server",
+                image_tag=request.image_tag,
+            )
+        ),
+    )
+    deploy_server = mocker.patch.object(server_router, "deploy_server", new=mocker.AsyncMock())
+    mocker.patch.object(server_router, "wait_for_pods_ready", new=mocker.AsyncMock())
+    mocker.patch.object(server_router, "update_server_status", new=mocker.AsyncMock())
+    mocker.patch.object(server_router, "update_operation_status", new=mocker.AsyncMock())
+
+    await server_router._task_start_server(config=config, request=request, async_operation_id=11)
+
+    assert deploy_server.await_args.kwargs["same_image_affinity_enabled"] is True
+    assert deploy_server.await_args.kwargs["same_image_affinity_preference_weight"] == 73

--- a/unit-tests/test_settings.py
+++ b/unit-tests/test_settings.py
@@ -70,6 +70,8 @@ HYDRA_DEFAULTS: dict[str, Any] = {
     "orchestrator.prometheus_multiproc_dir": join(gettempdir(), "idegym", "prometheus"),
     "orchestrator.resources.default_cpu_request": 1.0,
     "orchestrator.resources.default_ram_request": 2.0,
+    "orchestrator.same_image_affinity.enabled": False,
+    "orchestrator.same_image_affinity.preference_weight": 100,
     "orchestrator.sqlalchemy.max_overflow": 5,
     "orchestrator.sqlalchemy.pool_pre_ping": True,
     "orchestrator.sqlalchemy.pool_recycle": 1800,
@@ -167,6 +169,8 @@ ENVIRONMENT_VARIABLES: dict[str, list[str]] = {
         "IDEGYM_RESOURCES_DEFAULT_RAM_REQUEST",
         "IDEGYM_DEFAULT_RAM_REQUEST",
     ],
+    "orchestrator.same_image_affinity.enabled": ["IDEGYM_SAME_IMAGE_AFFINITY_ENABLED"],
+    "orchestrator.same_image_affinity.preference_weight": ["IDEGYM_SAME_IMAGE_AFFINITY_PREFERENCE_WEIGHT"],
     "orchestrator.sqlalchemy.max_overflow": ["IDEGYM_SQLALCHEMY_MAX_OVERFLOW"],
     "orchestrator.sqlalchemy.pool_pre_ping": ["IDEGYM_SQLALCHEMY_POOL_PRE_PING"],
     "orchestrator.sqlalchemy.pool_recycle": ["IDEGYM_SQLALCHEMY_POOL_RECYCLE"],
@@ -231,6 +235,7 @@ SAMPLES = {
     "IDEGYM_WATCHER_INACTIVE_TIMEOUT": ("watcher.inactive_timeout", "PT20M", Duration(minutes=20)),
     "IDEGYM_MCP_STATELESS_HTTP": ("orchestrator.mcp.stateless_http", "False", False),
     "IDEGYM_CLOUDBUILD_DISK_SIZE_GB": ("orchestrator.build.cloudbuild_gke.disk_size_gb", "200", 200),
+    "IDEGYM_SAME_IMAGE_AFFINITY_ENABLED": ("orchestrator.same_image_affinity.enabled", "True", True),
     "IDEGYM_SERVER_SHUTDOWN_DELAY": ("server.shutdown_delay", "PT45S", Duration(seconds=45)),
     "IDEGYM_PROJECT_PATH": ("project.path", "/tmp/proj", "/tmp/proj"),
 }
@@ -424,6 +429,12 @@ def test_unknown_key_is_rejected_rather_than_ignored():
     """Without extra="forbid" a misspelled key would silently leave the default in place."""
     with raises(ValidationError, match="Extra inputs are not permitted"):
         Config(orchestrator={"prot": 9100})
+
+
+@mark.parametrize("weight", [0, 101])
+def test_same_image_affinity_weight_is_bounded(weight: int):
+    with raises(ValidationError):
+        Config(orchestrator={"same_image_affinity": {"preference_weight": weight}})
 
 
 def test_cross_field_validation_still_applies_to_environment_values():

--- a/unit-tests/test_snapshot_pipeline.py
+++ b/unit-tests/test_snapshot_pipeline.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
-from idegym.api.config import Config, NodePoolConfig, PodSnapshotConfig
+from idegym.api.config import Config, NodePoolConfig, PodSnapshotConfig, SameImageAffinityConfig
 from idegym.api.orchestrator.servers import ServerKind, StartServerRequest
 from idegym.api.status import Status
 from idegym.orchestrator.snapshot_pipeline import run_snapshot_pipeline_job
@@ -65,9 +65,9 @@ def _patch_all(mocker, *, deploy_error=None):
     mocker.patch("idegym.orchestrator.snapshot_pipeline.extract_resources_request", return_value=(1.0, 2.0))
 
     if deploy_error:
-        mocker.patch("idegym.orchestrator.snapshot_pipeline.deploy_server", side_effect=deploy_error)
+        deploy_server = mocker.patch("idegym.orchestrator.snapshot_pipeline.deploy_server", side_effect=deploy_error)
     else:
-        mocker.patch("idegym.orchestrator.snapshot_pipeline.deploy_server", return_value=None)
+        deploy_server = mocker.patch("idegym.orchestrator.snapshot_pipeline.deploy_server", return_value=None)
 
     mocker.patch("idegym.orchestrator.snapshot_pipeline.wait_for_pods_ready", return_value=None)
     mocker.patch("idegym.orchestrator.snapshot_pipeline.update_server_status", return_value=None)
@@ -90,6 +90,7 @@ def _patch_all(mocker, *, deploy_error=None):
         server=server,
         snapshot=snapshot,
         snapshot_svc=snapshot_svc,
+        deploy_server=deploy_server,
         create_snapshot=create_snapshot,
         update_job=update_job,
         update_succeeded=update_succeeded,
@@ -153,6 +154,17 @@ async def test_success_calls_snapshot_service(mocker):
     await run_snapshot_pipeline_job(job_id=str(uuid4()), request=_request(), config=_config())
 
     instance.snapshot_server.assert_awaited_once()
+
+
+async def test_success_passes_same_image_affinity_config_to_deployment(mocker):
+    mocks = _patch_all(mocker)
+    config = _config()
+    config.orchestrator.same_image_affinity = SameImageAffinityConfig(enabled=True, preference_weight=73)
+
+    await run_snapshot_pipeline_job(job_id=str(uuid4()), request=_request(), config=config)
+
+    assert mocks.deploy_server.await_args.kwargs["same_image_affinity_enabled"] is True
+    assert mocks.deploy_server.await_args.kwargs["same_image_affinity_preference_weight"] == 73
 
 
 async def test_success_persists_pod_snapshot_name(mocker):

--- a/website/docs/architecture/orchestrator.md
+++ b/website/docs/architecture/orchestrator.md
@@ -57,7 +57,9 @@ flowchart TB
 - **Client lifecycle** — register a client (with optional node pre-provisioning), track
   heartbeats, and on stop/finish tear down or release its servers.
 - **Server lifecycle** — start (or **reuse** a matching finished server), stop, finish
-  (release for reuse), and restart environment pods, waiting for readiness.
+  (release for reuse), and restart environment pods, waiting for readiness. An opt-in
+  preferred pod-affinity policy can group simultaneous cold starts that use the same image
+  reference; normal Kubernetes image-locality scoring remains the default.
 - **Image builds** — accept image-builder YAML, compile each `Image` to a spec, and submit
   it through a **pluggable build backend** (Kaniko by default, or GKE Cloud Build) driven by
   a shared `ImageBuildService` (see [image builder](/architecture/image-builder#build-backends)).

--- a/website/docs/reference/remote_deployment.md
+++ b/website/docs/reference/remote_deployment.md
@@ -343,7 +343,28 @@ The Docker config should contain credentials for your registry:
 
 ---
 
-## Step 9: Dedicated Node Pools (Optional)
+## Step 9: Sandbox Placement and Dedicated Node Pools (Optional)
+
+Kubernetes' default ImageLocality scheduler plugin already favors nodes that cache a requested
+image. For simultaneous cold starts, before any node reports the image as cached, IdeGYM can
+optionally prefer placing pods with the same image reference on one host. This trades parallel
+pulls for one shared pull within each Kubernetes namespace and is intended for controlled burst
+workloads; leave it disabled for large clusters where inter-pod affinity cost or even spreading
+is more important.
+
+The policy hashes the exact textual image reference into a compact, label-safe value because
+references commonly contain characters such as `/`, `:`, and `@` that Kubernetes label values
+do not accept. It does not resolve a registry digest: a mutable reference such as `:latest`
+keeps the same hash when its contents change. Prefer immutable references when cache identity
+must track image contents. The affinity is a soft preference, so resource and scheduling
+constraints may still place a pod elsewhere.
+
+Configure the policy on the orchestrator:
+
+| Variable                                         | Description                                        | Default |
+|--------------------------------------------------|----------------------------------------------------|---------|
+| `IDEGYM_SAME_IMAGE_AFFINITY_ENABLED`             | Enable same-image preferred pod affinity           | `False` |
+| `IDEGYM_SAME_IMAGE_AFFINITY_PREFERENCE_WEIGHT`   | Scheduling weight for that preference (1-100)      | `100`   |
 
 You can isolate IdeGYM workloads onto dedicated nodes using a tainted node pool.
 When enabled, pods prefer dedicated nodes but fall back to regular ones if capacity is unavailable.


### PR DESCRIPTION
Resolves: JBAI-21836

## Operational context

Our agentic RL workload starts concurrent fleets of short-lived sandboxes, with several rollouts often using the same multi-GB image. During a cold burst, Kubernetes ImageLocality has no cached-image signal yet; `nodes_count` only keeps capacity alive with pause pods and neither pre-pulls the task image nor assigns sandbox pods to those nodes. The result can be duplicate pulls of one image across several nodes and slower, less predictable group startup.

This PR addresses only that cold-start window: when explicitly enabled, it adds a soft same-image-reference preference. It does not create exact GRPO placement groups

## Summary

- Add an opt-in preferred pod-affinity policy for simultaneous sandbox cold starts using the same image reference.
- Keep the policy disabled by default and configure its 1-100 weight through orchestrator environment settings.
- Preserve existing node, pod, and anti-affinity rules while appending the same-image preference.
- Use the shared SHA-256 helper to produce a compact Kubernetes label value from the exact image reference.
- Document namespace scope, tag-versus-digest behavior, native Kubernetes ImageLocality, and the scheduling tradeoffs.

## Design rationale

Kubernetes ImageLocality handles warm node caches. In the initial cold tie, this optional policy lets later scheduled pods prefer the first pod's host and share one pull instead of starting duplicate pulls across nodes.

This intentionally favors packing over even spreading when enabled. It remains a soft preference, is scoped to one namespace, and should stay disabled where inter-pod-affinity scheduler cost or even distribution is more important.

## Configuration

- `IDEGYM_SAME_IMAGE_AFFINITY_ENABLED=False`
- `IDEGYM_SAME_IMAGE_AFFINITY_PREFERENCE_WEIGHT=100`

The hash identifies the textual image reference, not resolved image bytes. Mutable tags such as `:latest` therefore retain the same label when their contents change; immutable references are recommended when that distinction matters.

## Relationship to the other PRs

The three PRs are independent and address different phases of the same sandbox workload: [#285](https://github.com/JetBrains-Research/idegym/pull/285) improves cold-image placement, [#286](https://github.com/JetBrains-Research/idegym/pull/286) bounds Bash result retention and hardens process cleanup inside a running sandbox, and [#287](https://github.com/JetBrains-Research/idegym/pull/287) enforces a hard sandbox-density ceiling per node.

If #285 and #287 are enabled together, #285 may pack same-image pods only until #287's scheduler-enforced cap is reached; further pods spill to another eligible node.

## Validation

- [x] Focused placement/config/router tests: 188 passed
- [x] Full unit suite: 1,097 passed, 2 skipped
- [x] Repository-wide Ruff format and lint checks
- [x] `uv lock --check`
- [x] Docusaurus production build
- [x] `git diff --check`
- [x] Independent final review: no findings
