### PR TITLE
[JBAI-21836] Bound and sanitize bash executor output

### DIFF
--- a/api/src/idegym/api/tools/bash.py
+++ b/api/src/idegym/api/tools/bash.py
@@ -1,4 +1,8 @@
+from typing import Optional
+
 from pydantic import BaseModel, Field
+
+DEFAULT_MAX_OUTPUT_BYTES = 1024 * 1024
 
 
 class BashCommandRequest(BaseModel):
@@ -6,6 +10,12 @@ class BashCommandRequest(BaseModel):
     timeout: float = Field(default=600.0, description="Timeout for the command execution in seconds")
     graceful_termination_timeout: float = Field(
         default=2.0, description="Timeout in seconds for graceful process termination"
+    )
+    max_output_bytes: Optional[int] = Field(
+        default=DEFAULT_MAX_OUTPUT_BYTES,
+        ge=1,
+        strict=True,
+        description="Maximum retained bytes for each output stream; null retains complete output",
     )
 
 

--- a/backend-utils/src/idegym/backend/utils/bash_executor.py
+++ b/backend-utils/src/idegym/backend/utils/bash_executor.py
@@ -3,6 +3,7 @@ import os
 import shlex
 import signal
 from asyncio.subprocess import Process
+from collections import deque
 from importlib.resources import files
 from pathlib import Path
 from typing import Optional
@@ -14,6 +15,11 @@ from idegym.utils.logging import get_logger
 logger = get_logger(__name__)
 
 __BASH_INIT_FILEPATH__ = files(resources).joinpath("bash-integration.bash")
+_READ_CHUNK_BYTES = 64 * 1024
+_LOG_EXCERPT_CHARS = 1800
+_OUTPUT_DRAIN_TIMEOUT_SECONDS = 0.25
+_PROCESS_GROUP_POLL_INTERVAL_SECONDS = 0.01
+_PROCESS_REAP_TIMEOUT_SECONDS = 0.25
 
 
 class BashExecutorError(Exception):
@@ -24,16 +30,187 @@ class BashCommandExecutionTimeoutError(BashExecutorError):
     pass
 
 
-async def terminate_process_group(process: Process, graceful_termination_timeout: float = 2.0):
+class _OutputCollector:
+    """Retain complete output or a bounded head and chunk-ring tail while tracking total bytes."""
+
+    def __init__(self, max_bytes: Optional[int]):
+        if max_bytes is not None:
+            if isinstance(max_bytes, bool) or not isinstance(max_bytes, int):
+                raise TypeError("max_output_bytes must be an integer or None")
+            if max_bytes <= 0:
+                raise ValueError("max_output_bytes must be positive or None")
+        self.max_bytes = max_bytes
+        self.total = 0
+        self._head = bytearray()
+        self._tail: deque[bytes] = deque()
+        self._tail_bytes = 0
+        self._chunks: list[bytes] = []
+
+    def append(self, chunk: bytes) -> None:
+        self.total += len(chunk)
+        if self.max_bytes is None:
+            self._chunks.append(chunk)
+            return
+
+        head_limit = self.max_bytes // 2
+        tail_limit = self.max_bytes - head_limit
+        head_space = head_limit - len(self._head)
+        if head_space > 0:
+            self._head.extend(chunk[:head_space])
+            chunk = chunk[head_space:]
+        if not chunk or tail_limit == 0:
+            return
+
+        self._tail.append(chunk)
+        self._tail_bytes += len(chunk)
+        overflow = self._tail_bytes - tail_limit
+        while overflow > 0:
+            first = self._tail[0]
+            if len(first) <= overflow:
+                self._tail.popleft()
+                self._tail_bytes -= len(first)
+                overflow -= len(first)
+            else:
+                self._tail[0] = first[overflow:]
+                self._tail_bytes -= overflow
+                overflow = 0
+
+    def retained(self) -> bytes:
+        if self.max_bytes is None:
+            return b"".join(self._chunks)
+        tail = b"".join(self._tail)
+        if self.total <= self.max_bytes:
+            return bytes(self._head) + tail
+        omitted = self.total - len(self._head) - len(tail)
+        marker = f"\n... [IdeGYM truncated {omitted} output bytes] ...\n".encode()
+        return bytes(self._head) + marker + tail
+
+
+async def _drain_output(stream: asyncio.StreamReader, collector: _OutputCollector) -> None:
+    while chunk := await stream.read(_READ_CHUNK_BYTES):
+        collector.append(chunk)
+
+
+async def _read_bounded(stream: asyncio.StreamReader, max_bytes: Optional[int]) -> tuple[bytes, int]:
+    """Drain one stream and return retained output plus its unbounded byte count."""
+    collector = _OutputCollector(max_bytes)
+    await _drain_output(stream, collector)
+    return collector.retained(), collector.total
+
+
+async def _communicate_bounded(
+    process: Process,
+    stdout_collector: _OutputCollector,
+    stderr_collector: _OutputCollector,
+) -> None:
+    """Drain both pipes to EOF, which lets asyncio close their transports, and reap the process."""
+    if process.stdout is None or process.stderr is None:
+        raise RuntimeError("Subprocess output pipes are unavailable")
+    await asyncio.gather(
+        _drain_output(process.stdout, stdout_collector),
+        _drain_output(process.stderr, stderr_collector),
+        process.wait(),
+    )
+
+
+def _close_output_pipes(process: Process) -> None:
+    """Close subprocess read transports when a detached descendant prevents pipe EOF."""
+    process_transport = getattr(process, "_transport", None)
+    if process_transport is None:
+        return
+    for file_descriptor in (1, 2):
+        pipe_transport = process_transport.get_pipe_transport(file_descriptor)
+        if pipe_transport is not None:
+            pipe_transport.close()
+
+
+async def _finish_output_drain(process: Process, communication_task: asyncio.Task[None]) -> None:
+    """Give shutdown output a bounded drain window, then close and cancel lingering readers."""
+    if not communication_task.done():
+        done, _ = await asyncio.wait({communication_task}, timeout=_OUTPUT_DRAIN_TIMEOUT_SECONDS)
+        if not done:
+            _close_output_pipes(process)
+            communication_task.cancel()
+    await asyncio.gather(communication_task, return_exceptions=True)
+
+
+async def _reap_process(process: Process) -> None:
+    """Bound the final wait in case process-group signaling failed unexpectedly."""
+    if process.returncode is not None:
+        return
     try:
-        os.killpg(process.pid, signal.SIGTERM)
-        await asyncio.wait_for(process.wait(), timeout=graceful_termination_timeout)
-        logger.info(f"Process group {process.pid} terminated gracefully")
+        await asyncio.wait_for(process.wait(), timeout=_PROCESS_REAP_TIMEOUT_SECONDS)
     except TimeoutError:
-        os.killpg(process.pid, signal.SIGKILL)
-        await process.wait()
-        logger.info(f"Process group {process.pid} was forcefully killed")
+        logger.warning(
+            "Process did not exit after termination",
+            process_id=process.pid,
+            timeout_seconds=_PROCESS_REAP_TIMEOUT_SECONDS,
+        )
+
+
+def _decode_output(output: bytes) -> str:
+    return output.decode("utf-8", errors="replace").rstrip() if output else ""
+
+
+def _log_excerpt(text: str) -> str:
+    if len(text) <= _LOG_EXCERPT_CHARS:
+        return text
+    half = _LOG_EXCERPT_CHARS // 2
+    return f"{text[:half]}\n... [log excerpt truncated] ...\n{text[-half:]}"
+
+
+def _signal_process_group(process: Process, requested_signal: signal.Signals) -> bool:
+    """Signal a process group, tolerating races after its leader has exited."""
+    try:
+        os.killpg(process.pid, requested_signal)
     except ProcessLookupError:
+        return False
+    except OSError as group_error:
+        if process.returncode is not None:
+            return False
+        try:
+            process.send_signal(requested_signal)
+        except ProcessLookupError:
+            return False
+        except OSError:
+            raise group_error
+        return True
+    return True
+
+
+def _process_group_exists(process_group_id: int) -> bool:
+    try:
+        os.killpg(process_group_id, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+async def _wait_for_process_group_exit(process_group_id: int, timeout: float) -> bool:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + max(timeout, 0)
+    while _process_group_exists(process_group_id):
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            return False
+        await asyncio.sleep(min(_PROCESS_GROUP_POLL_INTERVAL_SECONDS, remaining))
+    return True
+
+
+async def terminate_process_group(process: Process, graceful_termination_timeout: float = 2.0) -> None:
+    if not _signal_process_group(process, signal.SIGTERM):
+        logger.info(f"Process group {process.pid} was already terminated")
+        return
+
+    if await _wait_for_process_group_exit(process.pid, graceful_termination_timeout):
+        logger.info(f"Process group {process.pid} terminated gracefully")
+        return
+
+    if _signal_process_group(process, signal.SIGKILL):
+        logger.info(f"Process group {process.pid} was forcefully killed")
+    else:
         logger.info(f"Process group {process.pid} was already terminated")
 
 
@@ -46,6 +223,7 @@ class BashExecutor:
         command: str,
         timeout: Optional[float] = 600.0,
         graceful_termination_timeout: float = 2.0,
+        max_output_bytes: Optional[int] = None,
     ) -> tuple[str, str, int]:
         """
         Execute a bash command asynchronously.
@@ -58,7 +236,9 @@ class BashExecutor:
         Returns a tuple of (stdout, stderr, exit_code).
         Raises BashCommandExecutionTimeoutError if the timeout is exceeded.
         """
-        logger.info(f"Executing bash command: {command}")
+        stdout_collector = _OutputCollector(max_output_bytes)
+        stderr_collector = _OutputCollector(max_output_bytes)
+        logger.info("Executing bash command", command=_log_excerpt(command))
 
         bash_command = f"source {__BASH_INIT_FILEPATH__} && {command}"
         process = await asyncio.create_subprocess_shell(
@@ -70,20 +250,54 @@ class BashExecutor:
             env=cleanenv(),
         )
 
+        communication_task = asyncio.create_task(
+            _communicate_bounded(process, stdout_collector, stderr_collector),
+            name=f"bash-output-{process.pid}",
+        )
+        termination_started = False
+        timed_out = False
         try:
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(process.communicate(), timeout=timeout)
+            try:
+                await asyncio.wait_for(asyncio.shield(communication_task), timeout=timeout)
+            except TimeoutError:
+                timed_out = True
+                termination_started = True
+                await terminate_process_group(process, graceful_termination_timeout)
+            except asyncio.CancelledError:
+                termination_started = True
+                await terminate_process_group(process, graceful_termination_timeout)
+                raise
+        finally:
+            if not termination_started and (process.returncode is None or not communication_task.done()):
+                await terminate_process_group(process, graceful_termination_timeout)
+            await _finish_output_drain(process, communication_task)
+            _close_output_pipes(process)
+            await _reap_process(process)
 
-            stdout_text = stdout_bytes.decode("utf-8").strip() if stdout_bytes else ""
-            stderr_text = stderr_bytes.decode("utf-8").strip() if stderr_bytes else ""
-
-            exit_code = process.returncode
-
-        except TimeoutError:
-            logger.warning(f"Command execution timed out after {timeout} seconds")
-            await terminate_process_group(process, graceful_termination_timeout)
-
+        if timed_out:
+            logger.warning(
+                "Command execution timed out",
+                timeout_seconds=timeout,
+                stdout_bytes=stdout_collector.total,
+                stderr_bytes=stderr_collector.total,
+                stdout=_log_excerpt(_decode_output(stdout_collector.retained())),
+                stderr=_log_excerpt(_decode_output(stderr_collector.retained())),
+            )
             raise BashCommandExecutionTimeoutError(f"Command execution timed out after {timeout} seconds")
 
-        logger.info(f"Command output:\nstdout:\n{stdout_text}\n\nstderr:\n{stderr_text}")
+        stdout_text = _decode_output(stdout_collector.retained())
+        stderr_text = _decode_output(stderr_collector.retained())
+        exit_code = process.returncode
+        if exit_code is None:
+            raise RuntimeError("Bash process completed without an exit code")
+
+        logger.info(
+            "Command completed",
+            exit_code=exit_code,
+            stdout_bytes=stdout_collector.total,
+            stderr_bytes=stderr_collector.total,
+            stdout=_log_excerpt(stdout_text),
+            stderr=_log_excerpt(stderr_text),
+        )
 
         return stdout_text, stderr_text, exit_code

--- a/client/src/idegym/client/operations/tools.py
+++ b/client/src/idegym/client/operations/tools.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from idegym.api.paths import ToolsPath
 from idegym.api.tools.bash import (
+    DEFAULT_MAX_OUTPUT_BYTES,
     BashCommandRequest,
     BashCommandResponse,
 )
@@ -23,11 +24,13 @@ class ToolsOperations:
         client_id: Optional[UUID] = None,
         request_timeout: Optional[int] = None,
         polling_config: PollingConfig = PollingConfig(),
+        max_output_bytes: Optional[int] = DEFAULT_MAX_OUTPUT_BYTES,
     ) -> BashCommandResponse:
         request = BashCommandRequest(
             command=script,
             timeout=command_timeout,
             graceful_termination_timeout=graceful_termination_timeout,
+            max_output_bytes=max_output_bytes,
         )
         response_raw = await self._forward.forward_request(
             "POST", server_id, ToolsPath.BASH, request, client_id, request_timeout, polling_config

--- a/client/src/idegym/client/server.py
+++ b/client/src/idegym/client/server.py
@@ -12,7 +12,7 @@ from idegym.api.project.reset import ResetResult
 from idegym.api.rewards.compilation import CompilationResult
 from idegym.api.rewards.setup import SetupResult
 from idegym.api.rewards.test import TestReport
-from idegym.api.tools.bash import BashCommandResponse
+from idegym.api.tools.bash import DEFAULT_MAX_OUTPUT_BYTES, BashCommandResponse
 from idegym.api.tools.file import FileResult
 from idegym.client.operations.files import FileOperations
 from idegym.client.operations.forwarding import ForwardingOperations
@@ -190,6 +190,7 @@ class IdeGYMServer:
         graceful_termination_timeout: float = 2.0,
         request_timeout: Optional[int] = None,
         polling_config: Optional[PollingConfig] = None,
+        max_output_bytes: Optional[int] = DEFAULT_MAX_OUTPUT_BYTES,
     ) -> BashCommandResponse:
         """Execute a bash script on the server."""
         return await self.tools.execute_bash(
@@ -200,6 +201,7 @@ class IdeGYMServer:
             client_id=self.client_id,
             request_timeout=request_timeout,
             polling_config=polling_config or self.polling_config,
+            max_output_bytes=max_output_bytes,
         )
 
     async def create_file(

--- a/integration-tests/docker_tests/test_bash_executor.py
+++ b/integration-tests/docker_tests/test_bash_executor.py
@@ -1,8 +1,48 @@
+import asyncio
+import contextlib
 import os
+import shlex
+import signal
+import sys
 from pathlib import Path
 
+import psutil
 import pytest
 from idegym.backend.utils.bash_executor import BashCommandExecutionTimeoutError, BashExecutor
+from structlog.testing import capture_logs
+
+
+def _detached_child_command(child_pid_path: Path) -> str:
+    child_script = (
+        "import os,pathlib,time; "
+        "os.setsid(); "
+        f"pathlib.Path({str(child_pid_path)!r}).write_text(str(os.getpid())); "
+        "time.sleep(10)"
+    )
+    return f"{shlex.quote(sys.executable)} -c {shlex.quote(child_script)} & wait"
+
+
+async def _wait_for_pid_file(child_pid_path: Path, timeout: float = 1.0) -> int:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not child_pid_path.exists():
+        if loop.time() >= deadline:
+            raise AssertionError(f"Child did not write its PID to {child_pid_path}")
+        await asyncio.sleep(0.01)
+    return int(child_pid_path.read_text())
+
+
+def _process_is_running(process_id: int) -> bool:
+    try:
+        process = psutil.Process(process_id)
+        return process.is_running() and process.status() != psutil.STATUS_ZOMBIE
+    except psutil.NoSuchProcess:
+        return False
+
+
+def _kill_process_if_running(process_id: int) -> None:
+    with contextlib.suppress(ProcessLookupError):
+        os.kill(process_id, signal.SIGKILL)
 
 
 class TestBashExecutor:
@@ -79,3 +119,139 @@ class TestBashExecutor:
 
         with pytest.raises(BashCommandExecutionTimeoutError):
             await executor.execute_bash_command("sleep 10", timeout=0.5)
+
+    @pytest.mark.asyncio
+    async def test_bounded_stdout_and_stderr_preserve_head_tail_and_exit_code(self):
+        executor = BashExecutor()
+
+        stdout, stderr, exit_code = await executor.execute_bash_command(
+            "(printf '%200000sTAIL' '' | tr ' ' H) & (printf '%200000sTAIL' '' | tr ' ' E >&2) & wait; exit 7",
+            max_output_bytes=64,
+        )
+
+        assert stdout.startswith("H" * 32)
+        assert stdout.endswith("H" * 28 + "TAIL")
+        assert "IdeGYM truncated 199940 output bytes" in stdout
+        assert stderr.startswith("E" * 32)
+        assert stderr.endswith("E" * 28 + "TAIL")
+        assert "IdeGYM truncated 199940 output bytes" in stderr
+        assert exit_code == 7
+
+    @pytest.mark.asyncio
+    async def test_unlimited_output_and_decoding(self):
+        executor = BashExecutor()
+
+        stdout, _, exit_code = await executor.execute_bash_command(
+            "printf '  indented\\377\\n'",
+            max_output_bytes=None,
+        )
+
+        assert stdout == "  indented�"
+        assert exit_code == 0
+
+    @pytest.mark.asyncio
+    async def test_timeout_logs_partial_bounded_output_and_reaps_process(self):
+        executor = BashExecutor()
+
+        with capture_logs() as logs, pytest.raises(BashCommandExecutionTimeoutError):
+            await executor.execute_bash_command(
+                "printf 'partial output'; sleep 10",
+                timeout=0.05,
+                max_output_bytes=64,
+            )
+
+        timeout_log = next(entry for entry in logs if entry["event"] == "Command execution timed out")
+        assert timeout_log["stdout"] == "partial output"
+        assert timeout_log["stdout_bytes"] == len("partial output")
+        assert timeout_log["stderr"] == ""
+
+    @pytest.mark.asyncio
+    async def test_timeout_does_not_wait_for_detached_descendant_holding_pipes(self, tmp_path):
+        executor = BashExecutor()
+        child_pid_path = tmp_path / "detached-child.pid"
+        execution_task = asyncio.create_task(
+            executor.execute_bash_command(
+                _detached_child_command(child_pid_path),
+                timeout=0.5,
+                graceful_termination_timeout=0,
+            )
+        )
+        child_pid = None
+
+        try:
+            child_pid = await _wait_for_pid_file(child_pid_path)
+            done, _ = await asyncio.wait({execution_task}, timeout=1.5)
+            assert execution_task in done
+            with pytest.raises(BashCommandExecutionTimeoutError):
+                await execution_task
+        finally:
+            if child_pid is not None:
+                _kill_process_if_running(child_pid)
+            if not execution_task.done():
+                execution_task.cancel()
+            await asyncio.gather(execution_task, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_cancellation_does_not_wait_for_detached_descendant_holding_pipes(self, tmp_path):
+        executor = BashExecutor()
+        child_pid_path = tmp_path / "cancelled-detached-child.pid"
+        execution_task = asyncio.create_task(
+            executor.execute_bash_command(
+                _detached_child_command(child_pid_path),
+                timeout=10,
+                graceful_termination_timeout=0,
+            )
+        )
+        child_pid = None
+
+        try:
+            child_pid = await _wait_for_pid_file(child_pid_path)
+            execution_task.cancel()
+            done, _ = await asyncio.wait({execution_task}, timeout=1.0)
+            assert execution_task in done
+            with pytest.raises(asyncio.CancelledError):
+                await execution_task
+        finally:
+            if child_pid is not None:
+                _kill_process_if_running(child_pid)
+            if not execution_task.done():
+                execution_task.cancel()
+            await asyncio.gather(execution_task, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_timeout_kills_same_group_child_that_ignores_sigterm(self, tmp_path):
+        executor = BashExecutor()
+        child_pid_path = tmp_path / "same-group-child.pid"
+        child_script = "\n".join(
+            [
+                "import os, pathlib, signal, time",
+                "child_pid = os.fork()",
+                "if child_pid == 0:",
+                "    signal.signal(signal.SIGTERM, signal.SIG_IGN)",
+                f"    pathlib.Path({str(child_pid_path)!r}).write_text(str(os.getpid()))",
+                "    time.sleep(10)",
+                "else:",
+                f"    while not pathlib.Path({str(child_pid_path)!r}).exists():",
+                "        time.sleep(0.01)",
+                "    time.sleep(10)",
+            ]
+        )
+        child_pid = None
+
+        try:
+            with pytest.raises(BashCommandExecutionTimeoutError):
+                await executor.execute_bash_command(
+                    f"{shlex.quote(sys.executable)} -c {shlex.quote(child_script)}",
+                    timeout=0.5,
+                    graceful_termination_timeout=0.1,
+                )
+
+            child_pid = await _wait_for_pid_file(child_pid_path)
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + 1.0
+            while _process_is_running(child_pid) and loop.time() < deadline:
+                await asyncio.sleep(0.01)
+            assert not _process_is_running(child_pid)
+        finally:
+            if child_pid is not None:
+                _kill_process_if_running(child_pid)

--- a/integration-tests/test_test_checker.py
+++ b/integration-tests/test_test_checker.py
@@ -37,6 +37,9 @@ class TestTestChecker(IsolatedAsyncioTestCase):
 
         result = await self.test_checker.check_repository_tests(test_script)
 
+        for call in self.mock_bash_executor.execute_bash_command.await_args_list:
+            self.assertIsNone(call.kwargs["max_output_bytes"])
+
         expected_scores = {
             "total": 15,  # 10 + 5
             "passed": 11,  # (10 - (2 + 1 + 1)) + (5 - (0 + 0 + 0))

--- a/integration-tests/test_tool_service.py
+++ b/integration-tests/test_tool_service.py
@@ -2,6 +2,8 @@ from asyncio import Future
 from unittest import IsolatedAsyncioTestCase, main
 from unittest.mock import MagicMock
 
+from idegym.api.tools.bash import BashCommandRequest
+from idegym.tools.router import execute_bash_script
 from idegym.tools.tool_service import ToolService
 
 # TODO: Rewrite with pytest!
@@ -21,13 +23,23 @@ class TestToolService(IsolatedAsyncioTestCase):
         # Mocking async return value
         self.service.bash_executor.execute_bash_command.return_value = Future()
         self.service.bash_executor.execute_bash_command.return_value.set_result((stdout, stderr, 0))
-        parameters = {"command": "echo 'Hello'", "timeout": 600.0, "graceful_termination_timeout": 3.0}
+        parameters = {
+            "command": "echo 'Hello'",
+            "timeout": 600.0,
+            "graceful_termination_timeout": 3.0,
+            "max_output_bytes": None,
+        }
 
         # Await the async method call
         result = await self.service.execute_tool("bash", parameters)
 
         self.assertEqual(result, (stdout, stderr, 0))
-        self.service.bash_executor.execute_bash_command.assert_called_once_with("echo 'Hello'", 600.0, 3.0)
+        self.service.bash_executor.execute_bash_command.assert_called_once_with(
+            command="echo 'Hello'",
+            timeout=600.0,
+            graceful_termination_timeout=3.0,
+            max_output_bytes=None,
+        )
 
     async def test_execute_bash_tool_missing_command(self):
         parameters = {}
@@ -35,6 +47,26 @@ class TestToolService(IsolatedAsyncioTestCase):
         with self.assertRaises(ValueError) as context:
             await self.service.execute_tool("bash", parameters)
         self.assertEqual(str(context.exception), "Missing 'command' in parameters for bash tool")
+
+    async def test_bash_router_propagates_output_limit(self):
+        self.service.execute_tool = MagicMock(return_value=Future())
+        self.service.execute_tool.return_value.set_result(("out", "", 0))
+
+        result = await execute_bash_script(
+            BashCommandRequest(command="echo hello", max_output_bytes=None),
+            self.service,
+        )
+
+        self.assertEqual(result.stdout, "out")
+        self.service.execute_tool.assert_called_once_with(
+            tool_name="bash",
+            parameters={
+                "command": "echo hello",
+                "timeout": 600.0,
+                "graceful_termination_timeout": 2.0,
+                "max_output_bytes": None,
+            },
+        )
 
     async def test_execute_file_tool_create_success(self):
         parameters = {"action": "create", "path": "/tmp/test.txt", "content": "Hello, world!"}

--- a/orchestrator/src/idegym/orchestrator/mcp.py
+++ b/orchestrator/src/idegym/orchestrator/mcp.py
@@ -24,7 +24,7 @@ from idegym.api.orchestrator.servers import (
     StartServerResponse,
     StopServerRequest,
 )
-from idegym.api.tools.bash import BashCommandRequest
+from idegym.api.tools.bash import DEFAULT_MAX_OUTPUT_BYTES, BashCommandRequest
 from idegym.orchestrator.database.helpers import validate_server
 from idegym.orchestrator.router.async_operation import get_operation_status as get_operation_status_endpoint
 from idegym.orchestrator.router.build_images import build_and_push_with_config
@@ -66,6 +66,12 @@ class RunBashCommandToolRequest(BaseModel):
     graceful_termination_timeout: float = Field(
         default=2.0,
         description="Timeout in seconds for graceful process termination",
+    )
+    max_output_bytes: Optional[int] = Field(
+        default=DEFAULT_MAX_OUTPUT_BYTES,
+        ge=1,
+        strict=True,
+        description="Maximum retained bytes for each output stream; null retains complete output",
     )
 
 
@@ -188,6 +194,7 @@ def create_mcp_server(
             command=request.command,
             timeout=request.command_timeout,
             graceful_termination_timeout=request.graceful_termination_timeout,
+            max_output_bytes=request.max_output_bytes,
         )
         return await forward_request_to_server(
             client_id=request.client_id,

--- a/rewards/src/idegym/rewards/test_checker.py
+++ b/rewards/src/idegym/rewards/test_checker.py
@@ -17,12 +17,18 @@ class TestChecker:
         graceful_termination_timeout: float = 2.0,
     ) -> dict:
         _, _, exit_code = await self.bash_executor.execute_bash_command(
-            test_script, timeout, graceful_termination_timeout
+            command=test_script,
+            timeout=timeout,
+            graceful_termination_timeout=graceful_termination_timeout,
+            max_output_bytes=None,
         )
 
         find_command = "find . -type f -iname 'test-*.xml' -exec realpath {} \\;"
         report_files_stdout, _, _ = await self.bash_executor.execute_bash_command(
-            find_command, timeout, graceful_termination_timeout
+            command=find_command,
+            timeout=timeout,
+            graceful_termination_timeout=graceful_termination_timeout,
+            max_output_bytes=None,
         )
         report_files = self._extract_report_files(report_files_stdout)
 

--- a/tools/src/idegym/tools/router.py
+++ b/tools/src/idegym/tools/router.py
@@ -32,6 +32,7 @@ async def execute_bash_script(
             "command": request.command,
             "timeout": request.timeout,
             "graceful_termination_timeout": request.graceful_termination_timeout,
+            "max_output_bytes": request.max_output_bytes,
         },
     )
 

--- a/tools/src/idegym/tools/tool_service.py
+++ b/tools/src/idegym/tools/tool_service.py
@@ -1,6 +1,7 @@
 from enum import StrEnum
 from typing import Any
 
+from idegym.api.tools.bash import DEFAULT_MAX_OUTPUT_BYTES
 from idegym.backend.utils.bash_executor import BashExecutor
 from idegym.tools.file_manager import FileManager
 
@@ -27,10 +28,14 @@ class ToolService:
                 command = parameters.get("command")
                 timeout = parameters.get("timeout", 600.0)
                 graceful_termination_timeout = parameters.get("graceful_termination_timeout", 2.0)
+                max_output_bytes = parameters.get("max_output_bytes", DEFAULT_MAX_OUTPUT_BYTES)
                 if not command:
                     raise ValueError("Missing 'command' in parameters for bash tool")
                 stdout, stderr, exit_code = await self.bash_executor.execute_bash_command(
-                    command, timeout, graceful_termination_timeout
+                    command=command,
+                    timeout=timeout,
+                    graceful_termination_timeout=graceful_termination_timeout,
+                    max_output_bytes=max_output_bytes,
                 )
                 return stdout, stderr, exit_code
             case ToolName.FILE:

--- a/unit-tests/test_bash_executor.py
+++ b/unit-tests/test_bash_executor.py
@@ -1,0 +1,137 @@
+import asyncio
+
+import pytest
+from idegym.api.tools.bash import BashCommandRequest
+from idegym.backend.utils import bash_executor
+from pydantic import ValidationError
+
+
+def _stream(*chunks: bytes) -> asyncio.StreamReader:
+    stream = asyncio.StreamReader()
+    for chunk in chunks:
+        stream.feed_data(chunk)
+    stream.feed_eof()
+    return stream
+
+
+@pytest.mark.parametrize("payload", [b"short", b"12345678"])
+async def test_read_bounded_preserves_output_within_limit(payload) -> None:
+    retained, total = await bash_executor._read_bounded(_stream(payload), 8)
+
+    assert retained == payload
+    assert total == len(payload)
+
+
+async def test_read_bounded_preserves_odd_head_and_tail_across_chunks() -> None:
+    retained, total = await bash_executor._read_bounded(
+        _stream(b"abc", b"defgh", b"ijklmno"),
+        7,
+    )
+
+    assert retained.startswith(b"abc\n... [IdeGYM truncated 8 output bytes] ...\n")
+    assert retained.endswith(b"lmno")
+    assert total == 15
+
+
+async def test_read_bounded_supports_one_byte_limit() -> None:
+    retained, total = await bash_executor._read_bounded(_stream(b"abc"), 1)
+
+    assert retained == b"\n... [IdeGYM truncated 2 output bytes] ...\nc"
+    assert total == 3
+
+
+async def test_read_bounded_none_retains_complete_multichunk_output() -> None:
+    retained, total = await bash_executor._read_bounded(_stream(b"head", b"middle", b"tail"), None)
+
+    assert retained == b"headmiddletail"
+    assert total == 14
+
+
+@pytest.mark.parametrize(
+    ("limit", "error"),
+    [(0, ValueError), (-1, ValueError), (True, TypeError), (1.5, TypeError)],
+)
+async def test_read_bounded_rejects_invalid_limit(limit, error) -> None:
+    with pytest.raises(error, match="max_output_bytes"):
+        await bash_executor._read_bounded(_stream(b"output"), limit)
+
+
+@pytest.mark.parametrize("exit_error", [ProcessLookupError, PermissionError])
+async def test_terminate_process_group_tolerates_exit_before_sigkill(monkeypatch, mocker, exit_error) -> None:
+    process = mocker.Mock(pid=123, returncode=-15)
+    process.send_signal.side_effect = ProcessLookupError
+    signals = []
+
+    def kill_process_group(pid, requested_signal) -> None:
+        signals.append((pid, requested_signal))
+        if requested_signal == bash_executor.signal.SIGKILL:
+            raise exit_error
+
+    async def group_did_not_exit(process_group_id, timeout) -> bool:
+        return False
+
+    monkeypatch.setattr(bash_executor.os, "killpg", kill_process_group)
+    monkeypatch.setattr(bash_executor, "_wait_for_process_group_exit", group_did_not_exit)
+
+    await bash_executor.terminate_process_group(process, graceful_termination_timeout=0.001)
+
+    assert signals == [
+        (process.pid, bash_executor.signal.SIGTERM),
+        (process.pid, bash_executor.signal.SIGKILL),
+    ]
+
+
+def test_signal_process_group_tolerates_permission_race_before_returncode_update(monkeypatch, mocker) -> None:
+    process = mocker.Mock(pid=123, returncode=None)
+    process.send_signal.side_effect = ProcessLookupError
+    monkeypatch.setattr(bash_executor.os, "killpg", mocker.Mock(side_effect=PermissionError))
+
+    assert not bash_executor._signal_process_group(process, bash_executor.signal.SIGKILL)
+    process.send_signal.assert_called_once_with(bash_executor.signal.SIGKILL)
+
+
+async def test_finish_output_drain_closes_pipes_and_cancels_reader(monkeypatch, mocker) -> None:
+    stdout_transport = mocker.Mock()
+    stderr_transport = mocker.Mock()
+    process = mocker.Mock()
+    process._transport.get_pipe_transport.side_effect = [stdout_transport, stderr_transport]
+    communication_task = asyncio.create_task(asyncio.Event().wait())
+    monkeypatch.setattr(bash_executor, "_OUTPUT_DRAIN_TIMEOUT_SECONDS", 0)
+
+    await bash_executor._finish_output_drain(process, communication_task)
+
+    stdout_transport.close.assert_called_once_with()
+    stderr_transport.close.assert_called_once_with()
+    assert communication_task.cancelled()
+
+
+def test_collector_exposes_bounded_partial_output() -> None:
+    collector = bash_executor._OutputCollector(8)
+    collector.append(b"abcdefgh")
+    collector.append(b"ijkl")
+
+    assert collector.retained().startswith(b"abcd\n... [IdeGYM truncated 4 output bytes] ...\n")
+    assert collector.retained().endswith(b"ijkl")
+    assert collector.total == 12
+
+
+def test_decode_output_replaces_invalid_utf8_and_preserves_leading_whitespace() -> None:
+    assert bash_executor._decode_output(b"  indented\xff\n") == "  indented�"
+
+
+def test_log_excerpt_is_bounded_to_one_page() -> None:
+    excerpt = bash_executor._log_excerpt("x" * 4000)
+
+    assert excerpt.startswith("x" * 900)
+    assert excerpt.endswith("x" * 900)
+    assert "log excerpt truncated" in excerpt
+
+
+@pytest.mark.parametrize("limit", [0, -1, True, 1.5])
+def test_bash_request_rejects_invalid_output_limit(limit) -> None:
+    with pytest.raises(ValidationError):
+        BashCommandRequest(command="echo hello", max_output_bytes=limit)
+
+
+def test_bash_request_supports_explicit_unlimited_output() -> None:
+    assert BashCommandRequest(command="echo hello", max_output_bytes=None).max_output_bytes is None

--- a/unit-tests/test_client.py
+++ b/unit-tests/test_client.py
@@ -3,6 +3,7 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
+from idegym.client.operations.tools import ToolsOperations
 from idegym.client.operations.utils import PollingConfig
 from idegym.client.server import IdeGYMServer
 
@@ -80,6 +81,37 @@ def test_forward_passes_body():
 
     _call_kwargs = server._forwarding.forward_request.call_args.kwargs
     assert _call_kwargs["body"] is body
+
+
+def test_execute_bash_propagates_unlimited_output_without_shifting_existing_arguments():
+    server = _make_server(server_id=7)
+    server.tools = MagicMock()
+    server.tools.execute_bash = AsyncMock(return_value=MagicMock())
+    polling = PollingConfig()
+
+    asyncio.run(server.execute_bash("echo hello", 30.0, 3.0, 45, polling, None))
+
+    server.tools.execute_bash.assert_awaited_once_with(
+        server_id=7,
+        script="echo hello",
+        command_timeout=30.0,
+        graceful_termination_timeout=3.0,
+        client_id=None,
+        request_timeout=45,
+        polling_config=polling,
+        max_output_bytes=None,
+    )
+
+
+def test_tools_operations_puts_output_limit_in_forwarded_request():
+    forwarding = MagicMock()
+    forwarding.forward_request = AsyncMock(return_value={"stdout": "", "stderr": "", "exit_code": 0})
+    tools = ToolsOperations(forward=forwarding)
+
+    asyncio.run(tools.execute_bash(7, "echo hello", max_output_bytes=2048))
+
+    request = forwarding.forward_request.await_args.args[3]
+    assert request.max_output_bytes == 2048
 
 
 # ---------------------------------------------------------------------------

--- a/unit-tests/test_orchestrator_mcp.py
+++ b/unit-tests/test_orchestrator_mcp.py
@@ -168,9 +168,31 @@ async def test_run_bash_command_mcp_tool_calls_forwarding_endpoint(mocker):
     assert isinstance(endpoint.await_args.kwargs["headers"], Headers)
     assert endpoint.await_args.kwargs["headers"]["content-type"] == "application/json"
     assert endpoint.await_args.kwargs["body"] == (
-        '{"command":"echo hello","timeout":600.0,"graceful_termination_timeout":2.0}'
+        '{"command":"echo hello","timeout":600.0,"graceful_termination_timeout":2.0,"max_output_bytes":1048576}'
     )
     assert result.structured_content == {"async_operation_id": 43}
+
+
+async def test_run_bash_command_mcp_tool_supports_unlimited_output(mocker):
+    endpoint = mocker.patch(
+        "idegym.orchestrator.mcp.forward_request_to_server",
+        return_value={"async_operation_id": 43},
+    )
+    mcp = create_mcp_server(get_http_client=lambda: object())
+
+    await mcp.call_tool(
+        MCPToolName.RUN_BASH_COMMAND,
+        {
+            "request": {
+                "client_id": str(uuid4()),
+                "server_id": 7,
+                "command": "echo hello",
+                "max_output_bytes": None,
+            },
+        },
+    )
+
+    assert '"max_output_bytes":null' in endpoint.await_args.kwargs["body"]
 
 
 async def test_run_bash_command_mcp_tool_requires_http_client():

--- a/website/docs/architecture/rewards-tools.md
+++ b/website/docs/architecture/rewards-tools.md
@@ -53,7 +53,7 @@ Every server ships the **tools** plugin, available on all images:
 
 | Tool | Endpoint | What it does |
 |---|---|---|
-| Bash | `POST /api/tools/bash` | Run a bash script; returns stdout/stderr/exit code |
+| Bash | `POST /api/tools/bash` | Run a bash script; returns bounded stdout/stderr and the exit code |
 | Create file | `POST /api/tools/file/create` | Create a file with given content |
 | Edit file | `POST /api/tools/file/edit` | Replace a 1-indexed, inclusive line range |
 | Patch file | `POST /api/tools/file/patch` | Apply a unified diff |
@@ -63,6 +63,12 @@ The three file tools are **also exposed as MCP tools** (`create_file`, `edit_fil
 `inspect` endpoint runs the full IntelliJ static-analysis pipeline, and **mcp-steroid**
 exposes the IntelliJ Platform API (PSI, refactoring, debugger, VCS) as MCP tools. See the
 [tools reference](/reference/tools).
+
+The Bash tool retains 1 MiB by default for each of stdout and stderr, split between the
+beginning and end of each stream. Callers can choose another positive byte limit or request
+complete output with `max_output_bytes=None`. A short marker reports omitted bytes when a
+stream is truncated; the marker itself is outside the per-stream limit. Output is still
+drained until completion or the execution timeout, preventing subprocess pipe deadlocks.
 
 ```python
 result = await server.execute_bash("python -m pytest -q")

--- a/website/docs/reference/client.md
+++ b/website/docs/reference/client.md
@@ -175,12 +175,17 @@ result = await server.execute_bash(
     command_timeout=600.0,  # seconds
     graceful_termination_timeout=2.0,  # seconds
     request_timeout=None,  # HTTP timeout (uses client default)
+    max_output_bytes=1048576,  # retained bytes for each stream; None disables truncation
 )
 
 print(result.exit_code)  # 0
 print(result.stdout)  # "2\n"
 print(result.stderr)  # ""
 ```
+
+The default retains the beginning and end of stdout and stderr independently and inserts a
+marker when bytes are omitted. Use `max_output_bytes=None` when a caller must parse complete,
+trusted output.
 
 ### `reset_project(...)`
 

--- a/website/docs/reference/mcp.md
+++ b/website/docs/reference/mcp.md
@@ -155,6 +155,7 @@ command = await mcp.call_tool(
             "server_id": server_id,
             "command": "python -c 'print(\"hello\")'",
             "command_timeout": 60.0,
+            "max_output_bytes": 1048576,
         },
     },
 )
@@ -167,6 +168,10 @@ print(bash_response["stdout"])
 print(bash_response["stderr"])
 print(bash_response["exit_code"])
 ```
+
+`max_output_bytes` limits retained stdout and stderr independently. It defaults to 1 MiB;
+set it to `null` only when complete output is required and its size is trusted. Truncated
+streams preserve their beginning and end with an omitted-byte marker.
 
 To keep a server available for reuse, call `finish_server`. A later `start_server` call with matching parameters and
 `reuse_strategy: "RESTART"` or `"RESET"` can reuse the same server.

--- a/website/docs/reference/tools.md
+++ b/website/docs/reference/tools.md
@@ -30,14 +30,21 @@ Execute a bash script inside the container.
 | `command` | string | — | Bash script to execute |
 | `timeout` | float | 600.0 | Maximum execution time in seconds |
 | `graceful_termination_timeout` | float | 2.0 | Seconds to wait for graceful process exit before SIGKILL |
+| `max_output_bytes` | integer or null | 1048576 | Maximum retained bytes per stream; `null` retains complete output |
 
 **Response:**
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `stdout` | string | Standard output |
-| `stderr` | string | Standard error |
+| `stdout` | string | Retained standard output |
+| `stderr` | string | Retained standard error |
 | `exit_code` | int | Exit code returned by the process |
+
+The default limit applies independently to stdout and stderr. Truncated output keeps its
+beginning and end and includes a marker with the number of omitted bytes; the marker itself
+is outside the configured limit. Set `max_output_bytes` to `null` only when complete output
+is required and its size is trusted. IdeGYM still drains all produced output until the command
+finishes or reaches its execution timeout so subprocess pipes cannot deadlock.
 
 **Via orchestrator MCP (`run_bash_command`):**
 
@@ -50,6 +57,7 @@ command = await mcp.call_tool(
             "server_id": server_id,
             "command": "python -c 'import sys; print(sys.version)'",
             "command_timeout": 30.0,
+            "max_output_bytes": 1048576,
         },
     },
 )

--- a/website/static/openapi/server.json
+++ b/website/static/openapi/server.json
@@ -279,6 +279,20 @@
             "title": "Graceful Termination Timeout",
             "description": "Timeout in seconds for graceful process termination",
             "default": 2.0
+          },
+          "max_output_bytes": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Output Bytes",
+            "description": "Maximum retained bytes for each output stream; null retains complete output",
+            "default": 1048576
           }
         },
         "type": "object",


### PR DESCRIPTION
Resolves: JBAI-21836

## Operational context

Agentic rollouts execute model-authored Bash commands whose stdout or stderr can be unexpectedly large, and timed-out commands can leave descendant processes holding inherited output pipes. Retaining complete streams increases server and client memory use and inflates returned, persisted, and logged payloads; lingering pipes can turn a command timeout or cancellation into a rollout stall. 

This PR bounds retained output per stream and makes timeout and cancellation cleanup deterministic. It still drains produced output until command completion or timeout to avoid pipe deadlocks, so it is not a kill-after-total-bytes policy. Parser-sensitive reward checks explicitly opt into complete output.

## Summary

- Add configurable `max_output_bytes` propagation from the Python client and orchestrator MCP through the HTTP tool to `BashExecutor`.
- Retain bounded head-and-tail stdout and stderr with a deque-based collector while tracking total produced bytes.
- Replace malformed UTF-8, preserve leading indentation, and emit bounded structured log excerpts.
- Preserve partial output and byte totals in timeout logs.
- Bound timeout/cancellation pipe draining, close inherited pipes, reap the process, and escalate surviving process-group members to `SIGKILL`.
- Keep parser-sensitive `TestChecker` calls explicitly unlimited and document client, MCP, tool, and architecture behavior.

## Semantics

- External Bash tool calls retain 1 MiB per stream by default.
- Callers may choose another positive per-stream byte limit or use `None` / JSON `null` for trusted output that must remain complete.
- Zero, negative, boolean, and non-integer limits are rejected.
- The truncation marker is outside the configured retained-byte limit.
- Produced output is still drained until command completion or execution timeout to prevent pipe deadlocks. A separate kill-after-total-produced-bytes ceiling remains follow-up work.

## Relationship to the other PRs

The three PRs are independent and address different phases of the same sandbox workload: [#285](https://github.com/JetBrains-Research/idegym/pull/285) concerns cold-image pod placement, [#286](https://github.com/JetBrains-Research/idegym/pull/286) concerns one Bash process and its output after a sandbox is running, and [#287](https://github.com/JetBrains-Research/idegym/pull/287) concerns the maximum number of sandboxes schedulable on one node.

#286 neither changes Kubernetes placement nor imposes a sandbox-capacity policy.

## Validation

- [x] Full unit suite: 1,109 passed, 2 skipped
- [x] Targeted tool, reward-parser, and real-process integration suite: 31 passed
- [x] Repository-wide Ruff format and lint checks
- [x] `uv lock --check`
- [x] Docusaurus production build
- [x] Generated server OpenAPI matches the committed schema
- [x] `git diff --check`
- [x] Independent final review, including detached pipe holders, cancellation, zero grace, signal races, and `SIGTERM`-ignoring process-group children
