### PR TITLE
[JBAI-21836] Enforce a hard per-node sandbox cap

### DIFF
--- a/api/src/idegym/api/config.py
+++ b/api/src/idegym/api/config.py
@@ -205,6 +205,28 @@ class NodePoolConfig(ConfigModel):
     preference_weight: int = Field(
         description="Weight (1-100) for preferring dedicated pool nodes", ge=1, le=100, default=100
     )
+    max_sandboxes_per_node: int = Field(
+        description="Hard scheduler-accounted sandbox pod limit on each node (0 disables the limit)",
+        ge=0,
+        le=2_147_483_647,
+        default=0,
+    )
+    sandbox_capacity_owner: Optional[str] = Field(
+        description="Stable cluster-global owner of the managed sandbox capacity",
+        default=None,
+    )
+    sandbox_capacity_cleanup: bool = Field(
+        description="Remove previously managed sandbox capacity after workloads are drained",
+        default=False,
+    )
+
+    @model_validator(mode="after")
+    def validate_sandbox_capacity(self):
+        if self.max_sandboxes_per_node and self.sandbox_capacity_cleanup:
+            raise ValueError("max_sandboxes_per_node and sandbox_capacity_cleanup are mutually exclusive")
+        if (self.max_sandboxes_per_node or self.sandbox_capacity_cleanup) and not self.sandbox_capacity_owner:
+            raise ValueError("sandbox_capacity_owner is required when capacity management is enabled")
+        return self
 
 
 class CloudBuildGKEConfig(ConfigModel):

--- a/backend-utils/src/idegym/backend/utils/kubernetes_client.py
+++ b/backend-utils/src/idegym/backend/utils/kubernetes_client.py
@@ -1,5 +1,5 @@
 import json
-from asyncio import CancelledError, gather, sleep, timeout
+from asyncio import CancelledError, Lock, gather, sleep, timeout
 from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable
 from contextlib import asynccontextmanager
 from os import environ as env
@@ -16,6 +16,7 @@ from idegym.api.type import ConditionStatus
 from idegym.utils.dict import deep_merge
 from idegym.utils.functools import cached_async_result
 from idegym.utils.logging import get_logger
+from kubernetes.utils.quantity import parse_quantity
 from kubernetes_asyncio.client import (
     ApiClient,
     ApiException,
@@ -36,6 +37,7 @@ from kubernetes_asyncio.client import (
     V1Deployment,
     V1DeploymentList,
     V1DeploymentSpec,
+    V1DeploymentStrategy,
     V1EnvVar,
     V1EnvVarSource,
     V1HTTPGetAction,
@@ -83,6 +85,366 @@ KubernetesV1Apis = tuple[AppsV1Api, BatchV1Api, CoreV1Api, PolicyV1Api, CustomOb
 V1ResourceList = V1ConfigMapList | V1DeploymentList | V1PodDisruptionBudgetList | V1ServiceList
 
 logger = get_logger(__name__)
+
+SANDBOX_COMPONENT_LABEL = "app.kubernetes.io/component"
+SANDBOX_COMPONENT_VALUE = "sandbox"
+SANDBOX_CAPACITY_RESOURCE = "idegym.jetbrains.com/sandbox"
+SANDBOX_CAPACITY_OWNER_ANNOTATION = "idegym.jetbrains.com/sandbox-capacity-owner"
+SANDBOX_CAPACITY_LIMIT_ANNOTATION = "idegym.jetbrains.com/sandbox-capacity-limit"
+SANDBOX_CAPACITY_RECONCILE_INTERVAL_SECONDS = 30
+SANDBOX_CAPACITY_CONVERGENCE_TIMEOUT_SECONDS = 60
+SANDBOX_CAPACITY_CONVERGENCE_POLL_SECONDS = 1
+_prepared_sandbox_capacity: Optional[tuple[int, str]] = None
+_sandbox_capacity_prepare_lock = Lock()
+
+
+def _requests_sandbox_capacity(pod_spec: V1PodSpec) -> bool:
+    """Return whether any scheduled container reserves the managed sandbox resource."""
+    containers = [*(pod_spec.containers or []), *(pod_spec.init_containers or [])]
+    for container in containers:
+        requests = container.resources.requests if container.resources else None
+        value = requests.get(SANDBOX_CAPACITY_RESOURCE) if requests else None
+        if value is None:
+            continue
+        try:
+            if parse_quantity(value) >= 1:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
+def _add_sandbox_capacity_request(
+    resources: Optional[V1ResourceRequirements],
+) -> V1ResourceRequirements:
+    """Reserve one scheduler-accounted sandbox unit without changing caller resources."""
+    resources = resources or V1ResourceRequirements()
+    requests = dict(resources.requests or {})
+    limits = dict(resources.limits or {})
+    if SANDBOX_CAPACITY_RESOURCE in requests or SANDBOX_CAPACITY_RESOURCE in limits:
+        raise ValueError(f"{SANDBOX_CAPACITY_RESOURCE} is managed by max_sandboxes_per_node")
+
+    requests[SANDBOX_CAPACITY_RESOURCE] = "1"
+    limits[SANDBOX_CAPACITY_RESOURCE] = "1"
+    return V1ResourceRequirements(claims=resources.claims, requests=requests, limits=limits)
+
+
+async def find_legacy_sandbox_workloads() -> list[str]:
+    """Find live sandbox workloads that do not reserve managed capacity."""
+    selector = f"{SANDBOX_COMPONENT_LABEL}={SANDBOX_COMPONENT_VALUE}"
+    async with async_kube_api() as (apps, _, core, _, _):
+        deployments, pods = await gather(
+            apps.list_deployment_for_all_namespaces(label_selector=selector),
+            core.list_pod_for_all_namespaces(label_selector=selector),
+        )
+
+    legacy = {
+        f"Deployment {deployment.metadata.namespace}/{deployment.metadata.name}"
+        for deployment in deployments.items
+        if not _requests_sandbox_capacity(deployment.spec.template.spec)
+    }
+    legacy.update(
+        f"Pod {pod.metadata.namespace}/{pod.metadata.name}"
+        for pod in pods.items
+        if (not pod.status or pod.status.phase not in {"Succeeded", "Failed"})
+        and not _requests_sandbox_capacity(pod.spec)
+    )
+    return sorted(legacy)
+
+
+def _json_pointer(value: str) -> str:
+    return value.replace("~", "~0").replace("/", "~1")
+
+
+def _node_owner(node) -> Optional[str]:
+    return (node.metadata.annotations or {}).get(SANDBOX_CAPACITY_OWNER_ANNOTATION)
+
+
+def _resource_matches(resources, expected: int) -> bool:
+    value = (resources or {}).get(SANDBOX_CAPACITY_RESOURCE)
+    if value is None:
+        return expected == 0
+    try:
+        return parse_quantity(value) == expected
+    except (TypeError, ValueError):
+        return False
+
+
+def _assert_sandbox_capacity_owner(nodes, owner: str) -> None:
+    conflicting = sorted({value for node in nodes if (value := _node_owner(node)) and value != owner})
+    if conflicting:
+        raise RuntimeError(f"Sandbox capacity is owned by another IdeGYM installation: {', '.join(conflicting)}")
+
+
+async def _claim_sandbox_capacity_owner(core, nodes, owner: str, limit: int) -> None:
+    """Atomically establish one cluster-global owner using the first node as an anchor."""
+    for _ in range(5):
+        _assert_sandbox_capacity_owner(nodes, owner)
+        if any(_node_owner(node) == owner for node in nodes):
+            return
+        if not nodes:
+            raise RuntimeError("Cannot manage sandbox capacity because the cluster has no nodes")
+
+        anchor = min(nodes, key=lambda node: node.metadata.name)
+        patch = [{"op": "test", "path": "/metadata/resourceVersion", "value": anchor.metadata.resource_version}]
+        if anchor.metadata.annotations is None:
+            patch.append(
+                {
+                    "op": "add",
+                    "path": "/metadata/annotations",
+                    "value": {
+                        SANDBOX_CAPACITY_OWNER_ANNOTATION: owner,
+                        SANDBOX_CAPACITY_LIMIT_ANNOTATION: str(limit),
+                    },
+                }
+            )
+        else:
+            patch.extend(
+                [
+                    {
+                        "op": "add",
+                        "path": f"/metadata/annotations/{_json_pointer(SANDBOX_CAPACITY_OWNER_ANNOTATION)}",
+                        "value": owner,
+                    },
+                    {
+                        "op": "add",
+                        "path": f"/metadata/annotations/{_json_pointer(SANDBOX_CAPACITY_LIMIT_ANNOTATION)}",
+                        "value": str(limit),
+                    },
+                ]
+            )
+        try:
+            await core.patch_node(
+                name=anchor.metadata.name,
+                body=patch,
+                _content_type="application/json-patch+json",
+            )
+            return
+        except ApiException as error:
+            if error.status not in {404, 409, 422}:
+                raise
+            nodes = (await core.list_node()).items
+
+    raise RuntimeError("Could not claim sandbox capacity ownership after concurrent node updates")
+
+
+async def _wait_for_sandbox_capacity(
+    core,
+    node_names: set[str],
+    expected: int,
+    timeout_seconds: float = SANDBOX_CAPACITY_CONVERGENCE_TIMEOUT_SECONDS,
+) -> None:
+    """Wait until both capacity and scheduler-visible allocatable have converged."""
+    try:
+        async with timeout(timeout_seconds):
+            while True:
+                nodes = {node.metadata.name: node for node in (await core.list_node()).items}
+                if all(
+                    name not in nodes
+                    or (
+                        _resource_matches(nodes[name].status.capacity, expected)
+                        and _resource_matches(nodes[name].status.allocatable, expected)
+                    )
+                    for name in node_names
+                ):
+                    return
+                await sleep(SANDBOX_CAPACITY_CONVERGENCE_POLL_SECONDS)
+    except TimeoutError as error:
+        raise RuntimeError(
+            f"Timed out waiting for sandbox capacity and allocatable to converge to {expected}"
+        ) from error
+
+
+async def reconcile_sandbox_node_capacity(max_sandboxes_per_node: int, owner: str) -> None:
+    """Claim and advertise scheduler-accounted sandbox capacity on every current node."""
+    if max_sandboxes_per_node <= 0:
+        raise ValueError("max_sandboxes_per_node must be positive")
+    if not owner:
+        raise ValueError("sandbox capacity owner must be non-empty")
+
+    json_pointer_resource = _json_pointer(SANDBOX_CAPACITY_RESOURCE)
+    async with async_kube_api() as (_, _, core, _, _):
+        nodes = (await core.list_node()).items
+        await _claim_sandbox_capacity_owner(core, nodes, owner, max_sandboxes_per_node)
+        patches = []
+        for node in nodes:
+            patches.append(
+                core.patch_node(
+                    name=node.metadata.name,
+                    body={
+                        "metadata": {
+                            "annotations": {
+                                SANDBOX_CAPACITY_OWNER_ANNOTATION: owner,
+                                SANDBOX_CAPACITY_LIMIT_ANNOTATION: str(max_sandboxes_per_node),
+                            }
+                        }
+                    },
+                    _content_type="application/merge-patch+json",
+                )
+            )
+            if _resource_matches(node.status.capacity, max_sandboxes_per_node):
+                continue
+            patches.append(
+                core.patch_node_status(
+                    name=node.metadata.name,
+                    body=[
+                        {
+                            "op": "add",
+                            "path": f"/status/capacity/{json_pointer_resource}",
+                            "value": str(max_sandboxes_per_node),
+                        }
+                    ],
+                    _content_type="application/json-patch+json",
+                )
+            )
+
+        if patches:
+            await gather(*patches)
+        await _wait_for_sandbox_capacity(core, {node.metadata.name for node in nodes}, max_sandboxes_per_node)
+
+    logger.info(
+        "Reconciled sandbox capacity on Kubernetes nodes",
+        nodes=len(nodes),
+        updated_nodes=sum(not _resource_matches(node.status.capacity, max_sandboxes_per_node) for node in nodes),
+        max_sandboxes_per_node=max_sandboxes_per_node,
+        owner=owner,
+    )
+
+
+async def reconcile_sandbox_node_capacity_periodically(max_sandboxes_per_node: int, owner: str) -> None:
+    """Keep capacity present on nodes added after orchestrator startup."""
+    while True:
+        await sleep(SANDBOX_CAPACITY_RECONCILE_INTERVAL_SECONDS)
+        try:
+            await reconcile_sandbox_node_capacity(max_sandboxes_per_node, owner)
+        except CancelledError:
+            raise
+        except Exception:
+            logger.exception("Failed to reconcile sandbox node capacity")
+
+
+async def prepare_sandbox_node_capacity(max_sandboxes_per_node: int, owner: str) -> None:
+    """Reject unsafe enablement transitions and ensure nodes advertise capacity."""
+    global _prepared_sandbox_capacity
+    prepared = (max_sandboxes_per_node, owner)
+    if _prepared_sandbox_capacity == prepared:
+        return
+
+    async with _sandbox_capacity_prepare_lock:
+        if _prepared_sandbox_capacity == prepared:
+            return
+
+        legacy = await find_legacy_sandbox_workloads()
+        if legacy:
+            preview = ", ".join(legacy[:5])
+            suffix = f" and {len(legacy) - 5} more" if len(legacy) > 5 else ""
+            raise RuntimeError(
+                "Cannot enable max_sandboxes_per_node while sandbox workloads without capacity requests exist; "
+                f"drain them first: {preview}{suffix}"
+            )
+
+        await reconcile_sandbox_node_capacity(max_sandboxes_per_node, owner)
+        _prepared_sandbox_capacity = prepared
+
+
+async def cleanup_sandbox_node_capacity(owner: str) -> None:
+    """Safely zero managed capacity and release ownership after all requesters are drained."""
+    global _prepared_sandbox_capacity
+    if not owner:
+        raise ValueError("sandbox capacity owner must be non-empty")
+
+    async with async_kube_api() as (apps, _, core, _, _):
+        nodes = (await core.list_node()).items
+        _assert_sandbox_capacity_owner(nodes, owner)
+        if any(not _resource_matches(node.status.capacity, 0) for node in nodes) and not any(
+            _node_owner(node) == owner for node in nodes
+        ):
+            raise RuntimeError("Refusing to clean up unowned sandbox capacity")
+
+        capacity_patches = [
+            core.patch_node_status(
+                name=node.metadata.name,
+                body=[
+                    {
+                        "op": "add",
+                        "path": f"/status/capacity/{_json_pointer(SANDBOX_CAPACITY_RESOURCE)}",
+                        "value": "0",
+                    }
+                ],
+                _content_type="application/json-patch+json",
+            )
+            for node in nodes
+            if not _resource_matches(node.status.capacity, 0)
+        ]
+        if capacity_patches:
+            await gather(*capacity_patches)
+        await _wait_for_sandbox_capacity(core, {node.metadata.name for node in nodes}, 0)
+
+        selector = f"{SANDBOX_COMPONENT_LABEL}={SANDBOX_COMPONENT_VALUE}"
+        deployments, pods = await gather(
+            apps.list_deployment_for_all_namespaces(label_selector=selector),
+            core.list_pod_for_all_namespaces(),
+        )
+        requesting = {
+            f"Deployment {item.metadata.namespace}/{item.metadata.name}"
+            for item in deployments.items
+            if _requests_sandbox_capacity(item.spec.template.spec)
+        }
+        requesting.update(
+            f"Pod {item.metadata.namespace}/{item.metadata.name}"
+            for item in pods.items
+            if (not item.status or item.status.phase not in {"Succeeded", "Failed"})
+            and _requests_sandbox_capacity(item.spec)
+        )
+        if requesting:
+            preview = ", ".join(sorted(requesting)[:5])
+            suffix = f" and {len(requesting) - 5} more" if len(requesting) > 5 else ""
+            raise RuntimeError(f"Cannot clean up sandbox capacity while requesting workloads exist: {preview}{suffix}")
+
+        await gather(*(_release_sandbox_capacity_owner(core, node, owner) for node in nodes))
+
+    _prepared_sandbox_capacity = None
+    logger.info("Cleaned up sandbox node capacity", nodes=len(nodes), owner=owner)
+
+
+async def _release_sandbox_capacity_owner(core, node, owner: str) -> None:
+    """Release one node only while its owner still matches the cleanup installation."""
+    for _ in range(3):
+        annotations = node.metadata.annotations or {}
+        current_owner = annotations.get(SANDBOX_CAPACITY_OWNER_ANNOTATION)
+        if current_owner is None:
+            return
+        if current_owner != owner:
+            raise RuntimeError(f"Sandbox capacity is now owned by another IdeGYM installation: {current_owner}")
+
+        owner_path = f"/metadata/annotations/{_json_pointer(SANDBOX_CAPACITY_OWNER_ANNOTATION)}"
+        patch = [{"op": "test", "path": owner_path, "value": owner}]
+        if SANDBOX_CAPACITY_LIMIT_ANNOTATION in annotations:
+            patch.append(
+                {
+                    "op": "remove",
+                    "path": f"/metadata/annotations/{_json_pointer(SANDBOX_CAPACITY_LIMIT_ANNOTATION)}",
+                }
+            )
+        patch.append({"op": "remove", "path": owner_path})
+        try:
+            await core.patch_node(
+                name=node.metadata.name,
+                body=patch,
+                _content_type="application/json-patch+json",
+            )
+            return
+        except ApiException as error:
+            if error.status == 404:
+                return
+            if error.status not in {409, 422}:
+                raise
+            current_nodes = {item.metadata.name: item for item in (await core.list_node()).items}
+            if node.metadata.name not in current_nodes:
+                return
+            node = current_nodes[node.metadata.name]
+
+    raise RuntimeError(f"Could not release sandbox capacity ownership on node {node.metadata.name}")
 
 
 def build_node_affinity(taint_key: str, preference_weight: int) -> V1NodeAffinity:
@@ -255,6 +617,8 @@ async def deploy_server(
     node_selector: Optional[dict[str, str]] = None,
     node_pool_taint_key: Optional[str] = None,
     node_pool_preference_weight: int = 100,
+    max_sandboxes_per_node: int = 0,
+    sandbox_capacity_owner: Optional[str] = None,
     resources: Optional[V1ResourceRequirements | dict[str, Any]] = None,
     environment_variables: Iterable[V1EnvVar | dict[str, Any]] = (),
     volumes: Optional[Iterable[dict[str, Any]]] = None,
@@ -286,6 +650,14 @@ async def deploy_server(
     if isinstance(resources, dict):  # noinspection PyUnnecessaryCast
         dictionary = cast(dict, resources)
         resources = V1ResourceRequirements(**dictionary)
+
+    if max_sandboxes_per_node < 0:
+        raise ValueError("max_sandboxes_per_node must be non-negative")
+    if max_sandboxes_per_node:
+        if not sandbox_capacity_owner:
+            raise ValueError("sandbox_capacity_owner is required when max_sandboxes_per_node is enabled")
+        await prepare_sandbox_node_capacity(max_sandboxes_per_node, sandbox_capacity_owner)
+        resources = _add_sandbox_capacity_request(resources)
 
     env = [
         environment_variable if isinstance(environment_variable, V1EnvVar) else to_env_var(environment_variable)
@@ -331,7 +703,7 @@ async def deploy_server(
         annotations["podsnapshot.gke.io/ps-name"] = snapshot_tag
     match_labels = {
         "app": server_name,
-        "app.kubernetes.io/component": "sandbox",
+        SANDBOX_COMPONENT_LABEL: SANDBOX_COMPONENT_VALUE,
         "app.kubernetes.io/name": server_name,
         "app.kubernetes.io/part-of": "idegym",
     }
@@ -378,11 +750,21 @@ async def deploy_server(
         #   - drop null values so callers cannot delete a managed field by setting it to null;
         #   - the ServiceAccount is owned by `service_account_name` (so the snapshot ServiceAccount
         #     stays authoritative during snapshot preparation), never by pod_overrides;
+        #   - a hard node cap requires the Kubernetes scheduler, so nodeName and custom schedulers
+        #     cannot bypass its managed extended-resource accounting;
         #   - the managed "server" container may be augmented with sidecars but never replaced.
         overrides = {key: value for key, value in pod_overrides.items() if value is not None}
 
         if overrides.keys() & {"serviceAccountName", "service_account_name"}:
             raise ValueError("pod_overrides must not set serviceAccountName; use service_account_name instead")
+
+        if max_sandboxes_per_node and overrides.keys() & {
+            "nodeName",
+            "node_name",
+            "schedulerName",
+            "scheduler_name",
+        }:
+            raise ValueError("pod_overrides must not bypass scheduling while max_sandboxes_per_node is enabled")
 
         sidecars = overrides.get("containers")
         if sidecars is not None:
@@ -403,6 +785,7 @@ async def deploy_server(
         ),
         spec=V1DeploymentSpec(
             replicas=1,
+            strategy=V1DeploymentStrategy(type="Recreate") if max_sandboxes_per_node else None,
             selector=V1LabelSelector(
                 match_labels=match_labels,
             ),

--- a/charts/idegym/templates/clusterrolebindings.yaml
+++ b/charts/idegym/templates/clusterrolebindings.yaml
@@ -14,3 +14,20 @@ roleRef:
   name: {{ include "idegym.fullname" . }}-node-reader
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
+{{- if or .Values.deployment.maxSandboxesPerNode .Values.deployment.cleanupSandboxCapacity }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "idegym.fullname" . }}-sandbox-capacity
+  labels:
+    {{- include "idegym.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "idegym.deployment.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "idegym.fullname" . }}-sandbox-capacity
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/idegym/templates/clusterroles.yaml
+++ b/charts/idegym/templates/clusterroles.yaml
@@ -10,3 +10,25 @@ rules:
     resources: ["nodes"]
     verbs: ["get"]
 {{- end }}
+{{- if or .Values.deployment.maxSandboxesPerNode .Values.deployment.cleanupSandboxCapacity }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "idegym.fullname" . }}-sandbox-capacity
+  labels:
+    {{- include "idegym.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes/status"]
+    verbs: ["get", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list"]
+{{- end }}

--- a/charts/idegym/templates/deployment.yaml
+++ b/charts/idegym/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.deployment.maxSandboxesPerNode .Values.deployment.cleanupSandboxCapacity }}
+{{- fail "deployment.maxSandboxesPerNode and deployment.cleanupSandboxCapacity are mutually exclusive" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -6,6 +9,11 @@ metadata:
     {{- include "idegym.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.deployment.replicas }}
+  {{- if or .Values.deployment.maxSandboxesPerNode .Values.deployment.cleanupSandboxCapacity }}
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  {{- end }}
   selector:
     matchLabels:
       {{- include "idegym.selectorLabels" . | nindent 6 }}
@@ -117,6 +125,18 @@ spec:
               value: "jetbrains.com/idegym"
             - name: IDEGYM_NODE_POOL_PREFERENCE_WEIGHT
               value: "100"
+            {{- if .Values.deployment.maxSandboxesPerNode }}
+            - name: IDEGYM_NODE_POOL_MAX_SANDBOXES_PER_NODE
+              value: {{ .Values.deployment.maxSandboxesPerNode | quote }}
+            {{- end }}
+            {{- if or .Values.deployment.maxSandboxesPerNode .Values.deployment.cleanupSandboxCapacity }}
+            - name: IDEGYM_NODE_POOL_SANDBOX_CAPACITY_OWNER
+              value: {{ printf "%s/%s" .Release.Namespace .Release.Name | quote }}
+            {{- end }}
+            {{- if .Values.deployment.cleanupSandboxCapacity }}
+            - name: IDEGYM_NODE_POOL_SANDBOX_CAPACITY_CLEANUP
+              value: "True"
+            {{- end }}
             - name: IDEGYM_DATABASE_SCHEMA_REVISION
               value: {{ required "database.schemaRevision must name the Alembic revision this release expects" .Values.database.schemaRevision | quote }}
             {{- include "idegym.databaseEnv" . | nindent 12 }}

--- a/charts/idegym/values.yaml
+++ b/charts/idegym/values.yaml
@@ -11,6 +11,10 @@ deployment:
   otel:
     tracing: { }
   replicas: 4
+  # Hard sandbox limit on each node. Zero disables it.
+  maxSandboxesPerNode: 0
+  # One-shot cleanup mode after capped sandbox workloads have been drained.
+  cleanupSandboxCapacity: false
   # Safe to raise when mcp.statelessHttp is true. With session mode
   # (statelessHttp: false) this must stay at 1.
   uvicornWorkers: 1

--- a/orchestrator/src/idegym/orchestrator/main.py
+++ b/orchestrator/src/idegym/orchestrator/main.py
@@ -9,7 +9,12 @@ from httpx import AsyncClient, Limits, Timeout
 from idegym.api.config import Config
 from idegym.backend.utils.diagnostics import dump_tasks_periodically
 from idegym.backend.utils.instrumentation.uvicorn import UvicornInstrumentor
-from idegym.backend.utils.kubernetes_client import load_kubernetes_config
+from idegym.backend.utils.kubernetes_client import (
+    cleanup_sandbox_node_capacity,
+    load_kubernetes_config,
+    prepare_sandbox_node_capacity,
+    reconcile_sandbox_node_capacity_periodically,
+)
 from idegym.backend.utils.logging import configure_logging, configure_sqlalchemy_logging
 from idegym.backend.utils.otel import configure_telemetry, system_metrics_config
 from idegym.backend.utils.starlette.middleware import AsyncioTaskContextMiddleware, TracingMiddleware
@@ -67,6 +72,21 @@ async def lifespan(app: FastAPI):
         declared_schema_revision=config.orchestrator.database.schema_revision,
     )
 
+    node_pool = config.orchestrator.node_pool
+    max_sandboxes_per_node = node_pool.max_sandboxes_per_node
+    sandbox_capacity_owner = node_pool.sandbox_capacity_owner
+    sandbox_capacity_task = None
+    if max_sandboxes_per_node:
+        assert sandbox_capacity_owner is not None
+        await prepare_sandbox_node_capacity(max_sandboxes_per_node, sandbox_capacity_owner)
+        sandbox_capacity_task = create_task(
+            name="idegym-sandbox-capacity-reconciler",
+            coro=reconcile_sandbox_node_capacity_periodically(max_sandboxes_per_node, sandbox_capacity_owner),
+        )
+    elif node_pool.sandbox_capacity_cleanup:
+        assert sandbox_capacity_owner is not None
+        await cleanup_sandbox_node_capacity(sandbox_capacity_owner)
+
     get_event_loop().set_debug(config.orchestrator.asyncio.debug)
     coroutine_dump_task = create_task(
         name="idegym-coroutine-dump",
@@ -96,8 +116,12 @@ async def lifespan(app: FastAPI):
         logger.info("Closing HTTP client...")
     logger.info("HTTP client closed!")
 
-    coroutine_dump_task.cancel()
-    await gather(coroutine_dump_task)
+    background_tasks = [coroutine_dump_task]
+    if sandbox_capacity_task:
+        background_tasks.append(sandbox_capacity_task)
+    for task in background_tasks:
+        task.cancel()
+    await gather(*background_tasks, return_exceptions=True)
 
 
 def create_app() -> FastAPI:

--- a/orchestrator/src/idegym/orchestrator/router/server.py
+++ b/orchestrator/src/idegym/orchestrator/router/server.py
@@ -355,6 +355,8 @@ async def _task_start_server(
                 node_selector=request.node_selector,
                 node_pool_taint_key=node_pool.taint_key if node_pool.enabled else None,
                 node_pool_preference_weight=node_pool.preference_weight,
+                max_sandboxes_per_node=node_pool.max_sandboxes_per_node,
+                sandbox_capacity_owner=node_pool.sandbox_capacity_owner,
                 resources=resources,
                 environment_variables=environment_variables,
                 volumes=[volume.model_dump(by_alias=True, exclude_none=True) for volume in request.volumes],

--- a/orchestrator/src/idegym/orchestrator/snapshot_pipeline.py
+++ b/orchestrator/src/idegym/orchestrator/snapshot_pipeline.py
@@ -95,6 +95,8 @@ async def run_snapshot_pipeline_job(
             node_selector=request.node_selector,
             node_pool_taint_key=node_pool.taint_key if node_pool.enabled else None,
             node_pool_preference_weight=node_pool.preference_weight,
+            max_sandboxes_per_node=node_pool.max_sandboxes_per_node,
+            sandbox_capacity_owner=node_pool.sandbox_capacity_owner,
             resources=resources,
             environment_variables=(),
             volumes=[volume.model_dump(by_alias=True, exclude_none=True) for volume in request.volumes],

--- a/unit-tests/test_kubernetes_client.py
+++ b/unit-tests/test_kubernetes_client.py
@@ -5,10 +5,26 @@ The Kubernetes API is mocked so the test runs without a cluster. A real ``ApiCli
 only for its (offline) camelCase deserializer.
 """
 
+from types import SimpleNamespace
+
 import pytest
 from idegym.api.orchestrator.servers import StartServerRequest
 from idegym.backend.utils import kubernetes_client as kc
-from kubernetes_asyncio.client import ApiClient
+from kubernetes_asyncio.client import ApiClient, V1Container, V1ObjectMeta, V1PodSpec, V1ResourceRequirements
+
+SANDBOX_CAPACITY_OWNER = "grazie/idegym"
+
+
+def _node(name, *, capacity=None, allocatable=None, owner=None, resource_version="1"):
+    annotations = {kc.SANDBOX_CAPACITY_OWNER_ANNOTATION: owner} if owner else None
+    return SimpleNamespace(
+        metadata=V1ObjectMeta(
+            name=name,
+            annotations=annotations,
+            resource_version=resource_version,
+        ),
+        status=SimpleNamespace(capacity=capacity or {}, allocatable=allocatable or {}),
+    )
 
 
 @pytest.fixture
@@ -39,11 +55,11 @@ def _patch_clients(mocker, api_client):
 
     clients = (apps, mocker.MagicMock(), core, policy, mocker.MagicMock())
     mocker.patch.object(kc, "create_clients", mocker.AsyncMock(return_value=clients))
-    return apps
+    return apps, core
 
 
 async def _deploy_and_get_pod_spec(mocker, api_client, **kwargs):
-    apps = _patch_clients(mocker, api_client)
+    apps, _ = _patch_clients(mocker, api_client)
     await kc.deploy_server(image_tag="img:latest", server_name="srv", namespace="ns", **kwargs)
     body = apps.create_namespaced_deployment.call_args.kwargs["body"]
     return body.spec.template.spec
@@ -56,6 +72,395 @@ async def test_deploy_without_overrides_leaves_pod_unchanged(mocker, api_client)
     assert pod.volumes is None
     assert container.volume_mounts is None
     assert container.env_from is None
+
+
+async def test_max_sandboxes_per_node_requests_scheduler_accounted_capacity(mocker, api_client):
+    prepare_capacity = mocker.patch.object(kc, "prepare_sandbox_node_capacity", mocker.AsyncMock())
+    apps, _ = _patch_clients(mocker, api_client)
+    await kc.deploy_server(
+        image_tag="img:latest",
+        server_name="srv",
+        namespace="ns",
+        max_sandboxes_per_node=20,
+        sandbox_capacity_owner=SANDBOX_CAPACITY_OWNER,
+        resources={"requests": {"cpu": "1"}, "limits": {"memory": "2Gi"}},
+    )
+    deployment = apps.create_namespaced_deployment.await_args.kwargs["body"]
+    template = deployment.spec.template
+    resources = template.spec.containers[0].resources
+
+    prepare_capacity.assert_awaited_once_with(20, SANDBOX_CAPACITY_OWNER)
+    assert resources.requests == {"cpu": "1", kc.SANDBOX_CAPACITY_RESOURCE: "1"}
+    assert resources.limits == {"memory": "2Gi", kc.SANDBOX_CAPACITY_RESOURCE: "1"}
+    assert template.metadata.labels[kc.SANDBOX_COMPONENT_LABEL] == kc.SANDBOX_COMPONENT_VALUE
+    assert deployment.spec.strategy.type == "Recreate"
+
+
+async def test_max_sandboxes_per_node_rejects_negative_limit(mocker, api_client):
+    with pytest.raises(ValueError, match="must be non-negative"):
+        await _deploy_and_get_pod_spec(mocker, api_client, max_sandboxes_per_node=-1)
+
+
+async def test_max_sandboxes_per_node_rejects_caller_managed_capacity(mocker, api_client):
+    mocker.patch.object(kc, "prepare_sandbox_node_capacity", mocker.AsyncMock())
+    with pytest.raises(ValueError, match="is managed"):
+        await _deploy_and_get_pod_spec(
+            mocker,
+            api_client,
+            max_sandboxes_per_node=20,
+            sandbox_capacity_owner=SANDBOX_CAPACITY_OWNER,
+            resources={"requests": {kc.SANDBOX_CAPACITY_RESOURCE: "2"}},
+        )
+
+
+@pytest.mark.parametrize("field", ["nodeName", "node_name", "schedulerName", "scheduler_name"])
+async def test_max_sandboxes_per_node_rejects_scheduler_bypass(mocker, api_client, field):
+    mocker.patch.object(kc, "prepare_sandbox_node_capacity", mocker.AsyncMock())
+    with pytest.raises(ValueError, match="must not bypass scheduling"):
+        await _deploy_and_get_pod_spec(
+            mocker,
+            api_client,
+            max_sandboxes_per_node=20,
+            sandbox_capacity_owner=SANDBOX_CAPACITY_OWNER,
+            pod_overrides={field: "bypass"},
+        )
+
+
+async def test_prepare_sandbox_node_capacity_rejects_legacy_workloads(mocker):
+    mocker.patch.object(kc, "_prepared_sandbox_capacity", None)
+    reconcile = mocker.patch.object(kc, "reconcile_sandbox_node_capacity", mocker.AsyncMock())
+    mocker.patch.object(
+        kc,
+        "find_legacy_sandbox_workloads",
+        mocker.AsyncMock(return_value=["Deployment ns/legacy", "Pod ns/legacy-abc"]),
+    )
+
+    with pytest.raises(RuntimeError, match="drain them first"):
+        await kc.prepare_sandbox_node_capacity(20, SANDBOX_CAPACITY_OWNER)
+
+    reconcile.assert_not_awaited()
+
+
+async def test_prepare_sandbox_node_capacity_validates_once_per_process(mocker):
+    mocker.patch.object(kc, "_prepared_sandbox_capacity", None)
+    find_legacy = mocker.patch.object(kc, "find_legacy_sandbox_workloads", mocker.AsyncMock(return_value=[]))
+    reconcile = mocker.patch.object(kc, "reconcile_sandbox_node_capacity", mocker.AsyncMock())
+
+    await kc.prepare_sandbox_node_capacity(20, SANDBOX_CAPACITY_OWNER)
+    await kc.prepare_sandbox_node_capacity(20, SANDBOX_CAPACITY_OWNER)
+
+    find_legacy.assert_awaited_once()
+    reconcile.assert_awaited_once_with(20, SANDBOX_CAPACITY_OWNER)
+
+
+async def test_find_legacy_sandbox_workloads_checks_templates_and_live_pods(mocker, api_client):
+    apps, core = _patch_clients(mocker, api_client)
+    legacy_spec = V1PodSpec(containers=[V1Container(name="server")])
+    capped_spec = V1PodSpec(
+        containers=[
+            V1Container(
+                name="server",
+                resources=V1ResourceRequirements(requests={kc.SANDBOX_CAPACITY_RESOURCE: "1"}),
+            )
+        ]
+    )
+    zero_spec = V1PodSpec(
+        containers=[
+            V1Container(
+                name="server",
+                resources=V1ResourceRequirements(requests={kc.SANDBOX_CAPACITY_RESOURCE: "0"}),
+            )
+        ]
+    )
+    apps.list_deployment_for_all_namespaces = mocker.AsyncMock(
+        return_value=SimpleNamespace(
+            items=[
+                SimpleNamespace(
+                    metadata=V1ObjectMeta(namespace="ns", name="legacy"),
+                    spec=SimpleNamespace(template=SimpleNamespace(spec=legacy_spec)),
+                ),
+                SimpleNamespace(
+                    metadata=V1ObjectMeta(namespace="ns", name="capped"),
+                    spec=SimpleNamespace(template=SimpleNamespace(spec=capped_spec)),
+                ),
+                SimpleNamespace(
+                    metadata=V1ObjectMeta(namespace="ns", name="zero-unit"),
+                    spec=SimpleNamespace(template=SimpleNamespace(spec=zero_spec)),
+                ),
+            ]
+        )
+    )
+    core.list_pod_for_all_namespaces = mocker.AsyncMock(
+        return_value=SimpleNamespace(
+            items=[
+                SimpleNamespace(
+                    metadata=V1ObjectMeta(namespace="ns", name="legacy-pod"),
+                    spec=legacy_spec,
+                    status=SimpleNamespace(phase="Running"),
+                ),
+                SimpleNamespace(
+                    metadata=V1ObjectMeta(namespace="ns", name="finished-pod"),
+                    spec=legacy_spec,
+                    status=SimpleNamespace(phase="Succeeded"),
+                ),
+            ]
+        )
+    )
+
+    assert await kc.find_legacy_sandbox_workloads() == [
+        "Deployment ns/legacy",
+        "Deployment ns/zero-unit",
+        "Pod ns/legacy-pod",
+    ]
+
+
+async def test_wait_for_sandbox_capacity_waits_for_allocatable(mocker):
+    core = mocker.MagicMock()
+    core.list_node = mocker.AsyncMock(
+        side_effect=[
+            SimpleNamespace(
+                items=[
+                    _node(
+                        "node-a",
+                        capacity={kc.SANDBOX_CAPACITY_RESOURCE: "20"},
+                        allocatable={kc.SANDBOX_CAPACITY_RESOURCE: "10"},
+                    )
+                ]
+            ),
+            SimpleNamespace(
+                items=[
+                    _node(
+                        "node-a",
+                        capacity={kc.SANDBOX_CAPACITY_RESOURCE: "20"},
+                        allocatable={kc.SANDBOX_CAPACITY_RESOURCE: "20"},
+                    )
+                ]
+            ),
+        ]
+    )
+    sleep = mocker.patch.object(kc, "sleep", mocker.AsyncMock())
+
+    await kc._wait_for_sandbox_capacity(core, {"node-a"}, 20, timeout_seconds=1)
+
+    sleep.assert_awaited_once()
+    assert core.list_node.await_count == 2
+
+
+async def test_wait_for_sandbox_capacity_has_bounded_timeout(mocker):
+    core = mocker.MagicMock()
+    core.list_node = mocker.AsyncMock(return_value=SimpleNamespace(items=[_node("node-a")]))
+
+    with pytest.raises(RuntimeError, match="Timed out"):
+        await kc._wait_for_sandbox_capacity(core, {"node-a"}, 20, timeout_seconds=0)
+
+
+async def test_wait_for_sandbox_capacity_ignores_deleted_nodes(mocker):
+    core = mocker.MagicMock()
+    core.list_node = mocker.AsyncMock(return_value=SimpleNamespace(items=[]))
+    sleep = mocker.patch.object(kc, "sleep", mocker.AsyncMock())
+
+    await kc._wait_for_sandbox_capacity(core, {"deleted-node"}, 20, timeout_seconds=1)
+
+    sleep.assert_not_awaited()
+
+
+async def test_reconcile_rejects_conflicting_capacity_owner(mocker, api_client):
+    _, core = _patch_clients(mocker, api_client)
+    core.list_node = mocker.AsyncMock(return_value=SimpleNamespace(items=[_node("node-a", owner="other/idegym")]))
+
+    with pytest.raises(RuntimeError, match="another IdeGYM installation"):
+        await kc.reconcile_sandbox_node_capacity(20, SANDBOX_CAPACITY_OWNER)
+
+
+async def test_claim_sandbox_capacity_owner_uses_atomic_anchor_patch(mocker):
+    core = mocker.MagicMock()
+    core.patch_node = mocker.AsyncMock()
+    nodes = [_node("node-b", resource_version="12"), _node("node-a", resource_version="11")]
+
+    await kc._claim_sandbox_capacity_owner(core, nodes, SANDBOX_CAPACITY_OWNER, 20)
+
+    call = core.patch_node.await_args.kwargs
+    assert call["name"] == "node-a"
+    assert call["body"][0] == {
+        "op": "test",
+        "path": "/metadata/resourceVersion",
+        "value": "11",
+    }
+    assert call["body"][1]["value"][kc.SANDBOX_CAPACITY_OWNER_ANNOTATION] == SANDBOX_CAPACITY_OWNER
+
+
+@pytest.mark.parametrize("status", [404, 422])
+async def test_claim_sandbox_capacity_owner_retries_stale_anchor(mocker, status):
+    core = mocker.MagicMock()
+    core.patch_node = mocker.AsyncMock(side_effect=[kc.ApiException(status=status), None])
+    first = _node("node-a", resource_version="11")
+    second = _node("node-a", resource_version="12")
+    core.list_node = mocker.AsyncMock(return_value=SimpleNamespace(items=[second]))
+
+    await kc._claim_sandbox_capacity_owner(core, [first], SANDBOX_CAPACITY_OWNER, 20)
+
+    assert core.patch_node.await_count == 2
+    assert core.patch_node.await_args.kwargs["body"][0]["value"] == "12"
+
+
+async def test_cleanup_sandbox_capacity_refuses_requesting_pods(mocker, api_client):
+    apps, core = _patch_clients(mocker, api_client)
+    apps.list_deployment_for_all_namespaces = mocker.AsyncMock(return_value=SimpleNamespace(items=[]))
+    requesting_spec = V1PodSpec(
+        containers=[
+            V1Container(
+                name="server",
+                resources=V1ResourceRequirements(requests={kc.SANDBOX_CAPACITY_RESOURCE: "1"}),
+            )
+        ]
+    )
+    core.list_pod_for_all_namespaces = mocker.AsyncMock(
+        return_value=SimpleNamespace(
+            items=[
+                SimpleNamespace(
+                    metadata=V1ObjectMeta(namespace="ns", name="sandbox"),
+                    spec=requesting_spec,
+                    status=SimpleNamespace(phase="Running"),
+                )
+            ]
+        )
+    )
+    owned = _node(
+        "node-a",
+        capacity={kc.SANDBOX_CAPACITY_RESOURCE: "20"},
+        allocatable={kc.SANDBOX_CAPACITY_RESOURCE: "20"},
+        owner=SANDBOX_CAPACITY_OWNER,
+    )
+    zeroed = _node(
+        "node-a",
+        capacity={kc.SANDBOX_CAPACITY_RESOURCE: "0"},
+        allocatable={kc.SANDBOX_CAPACITY_RESOURCE: "0"},
+        owner=SANDBOX_CAPACITY_OWNER,
+    )
+    owned.metadata.annotations[kc.SANDBOX_CAPACITY_LIMIT_ANNOTATION] = "20"
+    core.list_node = mocker.AsyncMock(side_effect=[SimpleNamespace(items=[owned]), SimpleNamespace(items=[zeroed])])
+    core.patch_node_status = mocker.AsyncMock()
+    core.patch_node = mocker.AsyncMock()
+
+    with pytest.raises(RuntimeError, match="requesting workloads exist"):
+        await kc.cleanup_sandbox_node_capacity(SANDBOX_CAPACITY_OWNER)
+
+    core.patch_node_status.assert_awaited_once()
+    core.patch_node.assert_not_awaited()
+
+
+async def test_cleanup_sandbox_capacity_zeros_nodes_and_releases_owner(mocker, api_client):
+    apps, core = _patch_clients(mocker, api_client)
+    apps.list_deployment_for_all_namespaces = mocker.AsyncMock(return_value=SimpleNamespace(items=[]))
+    core.list_pod_for_all_namespaces = mocker.AsyncMock(return_value=SimpleNamespace(items=[]))
+    owned = _node(
+        "node-a",
+        capacity={kc.SANDBOX_CAPACITY_RESOURCE: "20"},
+        allocatable={kc.SANDBOX_CAPACITY_RESOURCE: "20"},
+        owner=SANDBOX_CAPACITY_OWNER,
+    )
+    zeroed = _node(
+        "node-a",
+        capacity={kc.SANDBOX_CAPACITY_RESOURCE: "0"},
+        allocatable={kc.SANDBOX_CAPACITY_RESOURCE: "0"},
+        owner=SANDBOX_CAPACITY_OWNER,
+    )
+    owned.metadata.annotations[kc.SANDBOX_CAPACITY_LIMIT_ANNOTATION] = "20"
+    core.list_node = mocker.AsyncMock(side_effect=[SimpleNamespace(items=[owned]), SimpleNamespace(items=[zeroed])])
+    core.patch_node_status = mocker.AsyncMock()
+    core.patch_node = mocker.AsyncMock()
+
+    await kc.cleanup_sandbox_node_capacity(SANDBOX_CAPACITY_OWNER)
+
+    core.patch_node_status.assert_awaited_once()
+    assert core.patch_node_status.await_args.kwargs["body"][0]["value"] == "0"
+    core.patch_node.assert_awaited_once()
+    patch = core.patch_node.await_args.kwargs["body"]
+    assert patch[0]["op"] == "test"
+    assert patch[0]["value"] == SANDBOX_CAPACITY_OWNER
+    assert [operation["op"] for operation in patch[1:]] == ["remove", "remove"]
+
+
+async def test_release_sandbox_capacity_owner_does_not_erase_successor(mocker):
+    core = mocker.MagicMock()
+    core.patch_node = mocker.AsyncMock(side_effect=kc.ApiException(status=422))
+    original = _node("node-a", owner=SANDBOX_CAPACITY_OWNER)
+    successor = _node("node-a", owner="other/idegym")
+    core.list_node = mocker.AsyncMock(return_value=SimpleNamespace(items=[successor]))
+
+    with pytest.raises(RuntimeError, match="now owned by another"):
+        await kc._release_sandbox_capacity_owner(core, original, SANDBOX_CAPACITY_OWNER)
+
+    core.patch_node.assert_awaited_once()
+
+
+async def test_release_sandbox_capacity_owner_accepts_deleted_node(mocker):
+    core = mocker.MagicMock()
+    core.patch_node = mocker.AsyncMock(side_effect=kc.ApiException(status=404))
+
+    await kc._release_sandbox_capacity_owner(
+        core,
+        _node("deleted-node", owner=SANDBOX_CAPACITY_OWNER),
+        SANDBOX_CAPACITY_OWNER,
+    )
+
+    core.list_node.assert_not_called()
+
+
+async def test_reconcile_sandbox_node_capacity_patches_only_stale_nodes(mocker, api_client):
+    _, core = _patch_clients(mocker, api_client)
+    wait_for_capacity = mocker.patch.object(kc, "_wait_for_sandbox_capacity", mocker.AsyncMock())
+    core.list_node = mocker.AsyncMock(
+        return_value=SimpleNamespace(
+            items=[
+                SimpleNamespace(
+                    metadata=V1ObjectMeta(name="fresh"),
+                    status=SimpleNamespace(capacity={kc.SANDBOX_CAPACITY_RESOURCE: "20"}),
+                ),
+                SimpleNamespace(
+                    metadata=V1ObjectMeta(name="stale"),
+                    status=SimpleNamespace(capacity={}),
+                ),
+            ]
+        )
+    )
+    core.patch_node_status = mocker.AsyncMock()
+    core.patch_node = mocker.AsyncMock()
+
+    await kc.reconcile_sandbox_node_capacity(20, SANDBOX_CAPACITY_OWNER)
+
+    core.patch_node_status.assert_awaited_once_with(
+        name="stale",
+        body=[
+            {
+                "op": "add",
+                "path": "/status/capacity/idegym.jetbrains.com~1sandbox",
+                "value": "20",
+            }
+        ],
+        _content_type="application/json-patch+json",
+    )
+    wait_for_capacity.assert_awaited_once_with(core, {"fresh", "stale"}, 20)
+
+
+async def test_reconcile_updates_positive_cap_for_same_owner(mocker, api_client):
+    _, core = _patch_clients(mocker, api_client)
+    node = _node(
+        "node-a",
+        capacity={kc.SANDBOX_CAPACITY_RESOURCE: "20"},
+        allocatable={kc.SANDBOX_CAPACITY_RESOURCE: "20"},
+        owner=SANDBOX_CAPACITY_OWNER,
+    )
+    core.list_node = mocker.AsyncMock(return_value=SimpleNamespace(items=[node]))
+    core.patch_node = mocker.AsyncMock()
+    core.patch_node_status = mocker.AsyncMock()
+    mocker.patch.object(kc, "_wait_for_sandbox_capacity", mocker.AsyncMock())
+
+    await kc.reconcile_sandbox_node_capacity(10, SANDBOX_CAPACITY_OWNER)
+
+    assert core.patch_node_status.await_args.kwargs["body"][0]["value"] == "10"
+    annotations = core.patch_node.await_args.kwargs["body"]["metadata"]["annotations"]
+    assert annotations[kc.SANDBOX_CAPACITY_LIMIT_ANNOTATION] == "10"
 
 
 async def test_deploy_applies_typed_volumes_mounts_and_env_from(mocker, api_client):

--- a/unit-tests/test_orchestrator_sandbox_capacity.py
+++ b/unit-tests/test_orchestrator_sandbox_capacity.py
@@ -1,0 +1,43 @@
+from asyncio import sleep
+from types import SimpleNamespace
+
+from idegym.api.config import Config, NodePoolConfig
+from idegym.orchestrator import main
+
+
+async def test_lifespan_prepares_capacity_before_serving(mocker):
+    config = Config()
+    config.orchestrator.node_pool = NodePoolConfig(
+        max_sandboxes_per_node=20,
+        sandbox_capacity_owner="grazie/idegym",
+    )
+    app = SimpleNamespace(state=SimpleNamespace(config=config))
+    mocker.patch.object(main, "load_kubernetes_config", mocker.AsyncMock())
+    mocker.patch.object(main, "init_db", mocker.AsyncMock())
+    prepare = mocker.patch.object(main, "prepare_sandbox_node_capacity", mocker.AsyncMock())
+    reconcile = mocker.patch.object(
+        main,
+        "reconcile_sandbox_node_capacity_periodically",
+        mocker.AsyncMock(),
+    )
+
+    async with main.lifespan(app):
+        prepare.assert_awaited_once_with(20, "grazie/idegym")
+        await sleep(0)
+
+    reconcile.assert_awaited_once_with(20, "grazie/idegym")
+
+
+async def test_lifespan_runs_capacity_cleanup_before_serving(mocker):
+    config = Config()
+    config.orchestrator.node_pool = NodePoolConfig(
+        sandbox_capacity_cleanup=True,
+        sandbox_capacity_owner="grazie/idegym",
+    )
+    app = SimpleNamespace(state=SimpleNamespace(config=config))
+    mocker.patch.object(main, "load_kubernetes_config", mocker.AsyncMock())
+    mocker.patch.object(main, "init_db", mocker.AsyncMock())
+    cleanup = mocker.patch.object(main, "cleanup_sandbox_node_capacity", mocker.AsyncMock())
+
+    async with main.lifespan(app):
+        cleanup.assert_awaited_once_with("grazie/idegym")

--- a/unit-tests/test_settings.py
+++ b/unit-tests/test_settings.py
@@ -12,7 +12,7 @@ from tempfile import gettempdir
 from typing import Any
 
 from idegym.api.auth import BasicAuth
-from idegym.api.config import Config, OTELConfig, TracingAuthConfig
+from idegym.api.config import Config, NodePoolConfig, OTELConfig, TracingAuthConfig
 from idegym.api.memory import MemoryQuantity
 from idegym.api.type import Duration
 from idegym.backend.utils.settings import (
@@ -60,7 +60,10 @@ HYDRA_DEFAULTS: dict[str, Any] = {
     "orchestrator.host": "0.0.0.0",
     "orchestrator.mcp.stateless_http": True,
     "orchestrator.node_pool.enabled": False,
+    "orchestrator.node_pool.max_sandboxes_per_node": 0,
     "orchestrator.node_pool.preference_weight": 100,
+    "orchestrator.node_pool.sandbox_capacity_cleanup": False,
+    "orchestrator.node_pool.sandbox_capacity_owner": None,
     "orchestrator.node_pool.taint_key": "jetbrains.com/idegym",
     "orchestrator.pod_snapshot.completion_timeout": "0:02:00",
     "orchestrator.pod_snapshot.enabled": False,
@@ -151,7 +154,10 @@ ENVIRONMENT_VARIABLES: dict[str, list[str]] = {
     "orchestrator.host": ["IDEGYM_ORCHESTRATOR_HOST", "IDEGYM_MANAGER_HOST"],
     "orchestrator.mcp.stateless_http": ["IDEGYM_MCP_STATELESS_HTTP"],
     "orchestrator.node_pool.enabled": ["IDEGYM_NODE_POOL_ENABLED"],
+    "orchestrator.node_pool.max_sandboxes_per_node": ["IDEGYM_NODE_POOL_MAX_SANDBOXES_PER_NODE"],
     "orchestrator.node_pool.preference_weight": ["IDEGYM_NODE_POOL_PREFERENCE_WEIGHT"],
+    "orchestrator.node_pool.sandbox_capacity_cleanup": ["IDEGYM_NODE_POOL_SANDBOX_CAPACITY_CLEANUP"],
+    "orchestrator.node_pool.sandbox_capacity_owner": ["IDEGYM_NODE_POOL_SANDBOX_CAPACITY_OWNER"],
     "orchestrator.node_pool.taint_key": ["IDEGYM_NODE_POOL_TAINT_KEY"],
     "orchestrator.pod_snapshot.completion_timeout": ["IDEGYM_POD_SNAPSHOT_COMPLETION_TIMEOUT"],
     "orchestrator.pod_snapshot.enabled": ["IDEGYM_POD_SNAPSHOT_ENABLED"],
@@ -192,6 +198,21 @@ ENVIRONMENT_VARIABLES: dict[str, list[str]] = {
     "server.response_buffer_size": ["IDEGYM_SERVER_RESPONSE_BUFFER_SIZE"],
     "server.shutdown_delay": ["IDEGYM_SERVER_SHUTDOWN_DELAY"],
 }
+
+
+def test_sandbox_capacity_management_requires_owner():
+    with raises(ValidationError, match="sandbox_capacity_owner is required"):
+        NodePoolConfig(max_sandboxes_per_node=20)
+
+
+def test_sandbox_capacity_cleanup_is_mutually_exclusive_with_cap():
+    with raises(ValidationError, match="mutually exclusive"):
+        NodePoolConfig(
+            max_sandboxes_per_node=20,
+            sandbox_capacity_cleanup=True,
+            sandbox_capacity_owner="grazie/idegym",
+        )
+
 
 # A non-default value per renamed field, used to prove the pre-rename name still reaches it.
 LEGACY_SAMPLES = {

--- a/website/docs/architecture/orchestrator.md
+++ b/website/docs/architecture/orchestrator.md
@@ -57,7 +57,8 @@ flowchart TB
 - **Client lifecycle** — register a client (with optional node pre-provisioning), track
   heartbeats, and on stop/finish tear down or release its servers.
 - **Server lifecycle** — start (or **reuse** a matching finished server), stop, finish
-  (release for reuse), and restart environment pods, waiting for readiness.
+  (release for reuse), and restart environment pods, waiting for readiness. An optional
+  scheduler-accounted extended resource provides a hard per-node sandbox limit.
 - **Image builds** — accept image-builder YAML, compile each `Image` to a spec, and submit
   it through a **pluggable build backend** (Kaniko by default, or GKE Cloud Build) driven by
   a shared `ImageBuildService` (see [image builder](/architecture/image-builder#build-backends)).

--- a/website/docs/reference/remote_deployment.md
+++ b/website/docs/reference/remote_deployment.md
@@ -343,7 +343,48 @@ The Docker config should contain credentials for your registry:
 
 ---
 
-## Step 9: Dedicated Node Pools (Optional)
+## Step 9: Sandbox Limits and Dedicated Node Pools (Optional)
+
+Set `deployment.maxSandboxesPerNode` to a positive integer to enforce a hard sandbox
+limit on each node. A value of `0` disables it.
+
+IdeGYM advertises `idegym.jetbrains.com/sandbox` as a node-level Kubernetes extended
+resource with the configured capacity. Every managed sandbox requests one unit, so the
+standard scheduler enforces the ceiling across namespaces and concurrent starts. Allocated
+resources remain charged while pods terminate, preventing replacement overlap from
+temporarily exceeding the cap. The orchestrator periodically reconciles capacity so newly
+added nodes become eligible without manual patching. Startup waits until both node capacity
+and scheduler-visible allocatable capacity converge before serving requests.
+
+The chart identifies the capacity owner as `<release namespace>/<release name>` in node
+annotations. Only one IdeGYM release can manage this cluster-global resource at a time;
+another release fails safely instead of racing to publish a different limit.
+
+When the limit is enabled, sandbox Deployments use the `Recreate` strategy and reject pod
+overrides that bypass normal scheduling. The orchestrator Deployment also uses `Recreate`,
+ensuring all replicas observe a changed positive limit before accepting more starts. This
+introduces brief control-plane downtime during upgrades.
+
+Before first enabling the limit, drain Deployments and pods carrying the stable
+`app.kubernetes.io/component=sandbox` label that were created without the extended-resource
+request. IdeGYM validates this transition and rejects new sandbox starts until those legacy
+workloads are gone. Positive cap changes are safe because existing capped sandboxes already
+request one unit; lowering capacity blocks new scheduling until usage falls below the new
+value but does not evict already-running sandboxes above the new limit.
+
+To disable or uninstall the feature without leaving capacity advertised on nodes:
+
+1. Drain all capped sandbox Deployments and pods.
+2. Set `maxSandboxesPerNode: 0` and `cleanupSandboxCapacity: true`, then wait for the
+   orchestrator to start successfully. It zeroes capacity, waits for allocatable capacity
+   to converge, verifies that no live workload requests the resource, and atomically releases
+   the ownership annotations.
+3. Set `cleanupSandboxCapacity: false` or uninstall the release. This removes the temporary
+   cluster-wide RBAC used by cleanup.
+
+The guarantee covers sandboxes created by this IdeGYM installation and other pods that
+request the same extended resource. A direct pod creator with permission to bind pods and
+omit the managed request is outside this control boundary.
 
 You can isolate IdeGYM workloads onto dedicated nodes using a tainted node pool.
 When enabled, pods prefer dedicated nodes but fall back to regular ones if capacity is unavailable.
@@ -369,6 +410,9 @@ Set these environment variables on the orchestrator deployment:
 | `IDEGYM_NODE_POOL_ENABLED`           | Enable dedicated node pool scheduling                    | `False`                |
 | `IDEGYM_NODE_POOL_TAINT_KEY`         | Taint/label key on dedicated nodes                       | `jetbrains.com/idegym` |
 | `IDEGYM_NODE_POOL_PREFERENCE_WEIGHT` | Scheduling weight (1-100) for preferring dedicated nodes | `100`                  |
+| `IDEGYM_NODE_POOL_MAX_SANDBOXES_PER_NODE` | Hard scheduler-accounted sandbox limit per node; `0` disables it | `0`             |
+| `IDEGYM_NODE_POOL_SANDBOX_CAPACITY_OWNER` | Stable cluster-global capacity owner; the chart sets this automatically | unset |
+| `IDEGYM_NODE_POOL_SANDBOX_CAPACITY_CLEANUP` | Safely zero and release owned capacity after workloads are drained | `False` |
 
 When enabled, all dynamically created pods (sandbox servers, Kaniko image builds, and node holders)
 receive a preferred node affinity and toleration matching the configured key.


### PR DESCRIPTION
Resolves: JBAI-21836

## Operational context

Agentic RL can create large bursts of short-lived sandbox Deployments. CPU and memory requests describe resource consumption, but they do not express a required maximum sandbox count per node; Kubernetes may therefore place more sandboxes on one node than it is desirable, because we use the same GPU nodes for training and idegym sandboxes

This PR provides an opt-in, scheduler-enforced density ceiling: each managed sandbox consumes one unit of a per-node extended resource. It is a per-node sandbox-count guard, not a cluster-wide rollout quota, a placement-group mechanism, or a replacement for ordinary CPU and memory sizing.

## Summary

- Add `deployment.maxSandboxesPerNode` and `IDEGYM_NODE_POOL_MAX_SANDBOXES_PER_NODE`.
- Enforce a cluster-wide hard per-node sandbox cap with the Kubernetes extended resource `idegym.jetbrains.com/sandbox`.
- Make every managed sandbox request and limit one resource unit while preserving caller CPU and memory resources.
- Use `Recreate` for capped sandbox Deployments and for the orchestrator during cap or cleanup transitions.
- Reject scheduler-bypass overrides while the cap is active.

## Coordination and correctness

- Identify the single cluster-global capacity owner as `<release namespace>/<release name>` in node annotations.
- Atomically claim a deterministic anchor node and reject another IdeGYM installation before it can publish a conflicting cap.
- Reconcile capacity on every node and wait for both `status.capacity` and scheduler-visible `status.allocatable` to converge before serving.
- Periodically reconcile newly added nodes.
- Count terminating pods through standard scheduler resource accounting, preventing replacement overlap above the limit.
- Validate legacy sandbox Deployments and live pods, including rejecting missing, invalid, or zero-unit requests.

## Safe disable and cleanup

Set `maxSandboxesPerNode: 0` and `cleanupSandboxCapacity: true` only after draining capped sandbox workloads. Cleanup:

1. Verifies ownership.
2. Zeroes node capacity and waits for allocatable convergence.
3. Rechecks requesting Deployments and live pods.
4. Atomically releases ownership annotations.

After cleanup succeeds, disable cleanup or uninstall the release to remove temporary cluster-wide RBAC.

## Scope

The guarantee covers IdeGYM-managed sandboxes and any other pod requesting the same extended resource. Direct pod binding or pods that deliberately omit the resource request are outside this control boundary.

## Relationship to the other PRs

The three PRs are independent and address different phases of the same sandbox workload: [#285](https://github.com/JetBrains-Research/idegym/pull/285) is an optional soft preference for cold same-image placement, [#286](https://github.com/JetBrains-Research/idegym/pull/286) bounds Bash result retention and process cleanup, and [#287](https://github.com/JetBrains-Research/idegym/pull/287) is a hard per-node scheduling constraint.

When #285 and #287 are both enabled, the hard cap remains authoritative and limits how far same-image affinity can pack a node.

## Validation

- [x] Focused Kubernetes/config/snapshot tests: 206 passed
- [x] Full unit suite: 1,115 passed, 2 skipped
- [x] Repository-wide Ruff check and format check
- [x] `uv lock --check`
- [x] Helm lint
- [x] Capped, cleanup, and uncapped Helm renders
- [x] Invalid cap plus cleanup render rejected
- [x] `rollingUpdate: null` rendered with `Recreate`
- [x] Docusaurus production build
- [x] `git diff --check`
- [x] Independent final review: no remaining actionable findings
