### PR TITLE
[JBRes-10676] Bash tool: verbatim output and safe logging (stack 1/8)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,10 @@ it belongs in `_HASH_FIELDS`
 deliberately stays out. Getting this wrong means either a snapshot that is silently reused
 with the wrong configuration, or one that never matches and is rebuilt every time.
 
+A frozen payload string in `unit-tests/test_orchestrator_mcp.py` serialises a whole request
+model, so adding a field to `BashCommandRequest` or `StartServerRequest` fails that test until
+the string is updated. That is the point — it is the only place the wire shape is written out.
+
 A handler that needs `Config` reads it from `low_level_request.app.state.config` and delegates
 to a `<name>_with_config` twin holding the actual logic. The MCP tools in
 `orchestrator/src/idegym/orchestrator/mcp.py` call these functions directly rather than over

--- a/api/src/idegym/api/tools/bash.py
+++ b/api/src/idegym/api/tools/bash.py
@@ -17,6 +17,13 @@ class BashCommandRequest(BaseModel):
         strict=True,
         description="Maximum retained bytes for each output stream; null retains complete output",
     )
+    strip_output: bool = Field(
+        default=False,
+        description=(
+            "Trim leading and trailing whitespace from stdout and stderr. Off by default so that "
+            "output is byte-for-byte what the command wrote; undecodable bytes are still replaced."
+        ),
+    )
 
 
 class BashCommandResponse(BaseModel):

--- a/backend-utils/src/idegym/backend/utils/bash_executor.py
+++ b/backend-utils/src/idegym/backend/utils/bash_executor.py
@@ -148,8 +148,17 @@ async def _reap_process(process: Process) -> None:
         )
 
 
-def _decode_output(output: bytes) -> str:
-    return output.decode("utf-8", errors="replace").rstrip() if output else ""
+def _decode_output(output: bytes, strip: bool = False) -> str:
+    """Decode one stream, replacing undecodable bytes so a binary write cannot fail the request.
+
+    Output is returned byte-for-byte otherwise: a trailing newline is part of a ``git diff`` and
+    ``printf 'x'`` must stay distinguishable from ``printf '  x  '``. ``strip`` is the opt-in for
+    callers that would otherwise trim the result themselves.
+    """
+    if not output:
+        return ""
+    text = output.decode("utf-8", errors="replace")
+    return text.strip() if strip else text
 
 
 def _log_excerpt(text: str) -> str:
@@ -224,6 +233,7 @@ class BashExecutor:
         timeout: Optional[float] = 600.0,
         graceful_termination_timeout: float = 2.0,
         max_output_bytes: Optional[int] = None,
+        strip_output: bool = False,
     ) -> tuple[str, str, int]:
         """
         Execute a bash command asynchronously.
@@ -232,6 +242,9 @@ class BashExecutor:
         bundled init script) in a clean subprocess environment with IdeGYM-specific
         variables stripped. The process is started in its own process group so the
         entire group can be killed on timeout.
+
+        Output is returned verbatim unless ``strip_output`` asks for surrounding
+        whitespace to be trimmed.
 
         Returns a tuple of (stdout, stderr, exit_code).
         Raises BashCommandExecutionTimeoutError if the timeout is exceeded.
@@ -285,8 +298,8 @@ class BashExecutor:
             )
             raise BashCommandExecutionTimeoutError(f"Command execution timed out after {timeout} seconds")
 
-        stdout_text = _decode_output(stdout_collector.retained())
-        stderr_text = _decode_output(stderr_collector.retained())
+        stdout_text = _decode_output(stdout_collector.retained(), strip=strip_output)
+        stderr_text = _decode_output(stderr_collector.retained(), strip=strip_output)
         exit_code = process.returncode
         if exit_code is None:
             raise RuntimeError("Bash process completed without an exit code")

--- a/backend-utils/src/idegym/backend/utils/bash_executor.py
+++ b/backend-utils/src/idegym/backend/utils/bash_executor.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import re
 import shlex
 import signal
 from asyncio.subprocess import Process
@@ -20,6 +21,9 @@ _LOG_EXCERPT_CHARS = 1800
 _OUTPUT_DRAIN_TIMEOUT_SECONDS = 0.25
 _PROCESS_GROUP_POLL_INTERVAL_SECONDS = 0.01
 _PROCESS_REAP_TIMEOUT_SECONDS = 0.25
+_EXPORT_ASSIGNMENT_PATTERN = re.compile(
+    r"""\bexport[ \t]+(?P<name>[A-Za-z_][A-Za-z0-9_]*)=(?:'[^']*'|"[^"]*"|[^\s;&|)]*)"""
+)
 
 
 class BashExecutorError(Exception):
@@ -168,6 +172,20 @@ def _log_excerpt(text: str) -> str:
     return f"{text[:half]}\n... [log excerpt truncated] ...\n{text[-half:]}"
 
 
+def _redact_exports(command: str) -> str:
+    """Mask the values of ``export NAME=...`` assignments in a script before it is logged.
+
+    A script is the only channel for setting per-command environment, so callers routinely
+    ship credentials inside it. The variable name is kept because it is what makes a log line
+    useful; only the value goes.
+    """
+    return _EXPORT_ASSIGNMENT_PATTERN.sub(lambda match: f"export {match.group('name')}=<redacted>", command)
+
+
+def _command_excerpt(command: str) -> str:
+    return _log_excerpt(_redact_exports(command))
+
+
 def _signal_process_group(process: Process, requested_signal: signal.Signals) -> bool:
     """Signal a process group, tolerating races after its leader has exited."""
     try:
@@ -251,7 +269,8 @@ class BashExecutor:
         """
         stdout_collector = _OutputCollector(max_output_bytes)
         stderr_collector = _OutputCollector(max_output_bytes)
-        logger.info("Executing bash command", command=_log_excerpt(command))
+        logger.info("Executing bash command", command_chars=len(command))
+        logger.debug("Bash command", command=_command_excerpt(command))
 
         bash_command = f"source {__BASH_INIT_FILEPATH__} && {command}"
         process = await asyncio.create_subprocess_shell(
@@ -293,6 +312,9 @@ class BashExecutor:
                 timeout_seconds=timeout,
                 stdout_bytes=stdout_collector.total,
                 stderr_bytes=stderr_collector.total,
+            )
+            logger.debug(
+                "Partial output of the timed-out command",
                 stdout=_log_excerpt(_decode_output(stdout_collector.retained())),
                 stderr=_log_excerpt(_decode_output(stderr_collector.retained())),
             )
@@ -309,6 +331,9 @@ class BashExecutor:
             exit_code=exit_code,
             stdout_bytes=stdout_collector.total,
             stderr_bytes=stderr_collector.total,
+        )
+        logger.debug(
+            "Command output",
             stdout=_log_excerpt(stdout_text),
             stderr=_log_excerpt(stderr_text),
         )

--- a/e2e-tests/test_orchestrator_mcp.py
+++ b/e2e-tests/test_orchestrator_mcp.py
@@ -148,8 +148,10 @@ async def test_mcp_start_server_and_run_bash_command(test_image, test_id):
             command_status = await wait_for_mcp_operation(mcp, command_operation_id, timeout=120.0)
             bash_response = parse_forwarded_body(command_status)
 
+            # The trailing newline is `print`'s and the bash tool returns output verbatim, so it
+            # survives the whole MCP -> orchestrator -> server round trip.
             assert bash_response == {
-                "stdout": "Hello World!",
+                "stdout": "Hello World!\n",
                 "stderr": "",
                 "exit_code": 0,
             }

--- a/integration-tests/docker_tests/test_bash_executor.py
+++ b/integration-tests/docker_tests/test_bash_executor.py
@@ -185,9 +185,40 @@ class TestBashExecutor:
             )
 
         timeout_log = next(entry for entry in logs if entry["event"] == "Command execution timed out")
-        assert timeout_log["stdout"] == "partial output"
+        assert timeout_log["log_level"] == "warning"
         assert timeout_log["stdout_bytes"] == len("partial output")
-        assert timeout_log["stderr"] == ""
+        assert "stdout" not in timeout_log
+
+        partial_log = next(entry for entry in logs if entry["event"] == "Partial output of the timed-out command")
+        assert partial_log["log_level"] == "debug"
+        assert partial_log["stdout"] == "partial output"
+        assert partial_log["stderr"] == ""
+
+    @pytest.mark.asyncio
+    async def test_info_logs_carry_no_command_text_or_output(self):
+        executor = BashExecutor()
+
+        with capture_logs() as logs:
+            await executor.execute_bash_command("export TOKEN=s3cr3t; printf 'result'")
+
+        info_logs = [entry for entry in logs if entry["log_level"] == "info"]
+        assert "s3cr3t" not in repr(info_logs)
+        assert "result" not in repr(info_logs)
+
+        completed = next(entry for entry in info_logs if entry["event"] == "Command completed")
+        assert completed["exit_code"] == 0
+        assert completed["stdout_bytes"] == len("result")
+
+    @pytest.mark.asyncio
+    async def test_debug_log_of_the_command_masks_exported_values(self):
+        executor = BashExecutor()
+
+        with capture_logs() as logs:
+            await executor.execute_bash_command("export TOKEN=s3cr3t; printf 'result'")
+
+        command_log = next(entry for entry in logs if entry["event"] == "Bash command")
+        assert command_log["log_level"] == "debug"
+        assert command_log["command"] == "export TOKEN=<redacted>; printf 'result'"
 
     @pytest.mark.asyncio
     async def test_timeout_does_not_wait_for_detached_descendant_holding_pipes(self, tmp_path):

--- a/integration-tests/docker_tests/test_bash_executor.py
+++ b/integration-tests/docker_tests/test_bash_executor.py
@@ -113,6 +113,30 @@ class TestBashExecutor:
         assert exit_code == 0
 
     @pytest.mark.asyncio
+    async def test_output_is_returned_byte_for_byte(self):
+        executor = BashExecutor()
+        stdout, _stderr, exit_code = await executor.execute_bash_command("printf '  padded  \\n\\n'")
+
+        assert stdout == "  padded  \n\n"
+        assert exit_code == 0
+
+    @pytest.mark.asyncio
+    async def test_strip_output_trims_surrounding_whitespace(self):
+        executor = BashExecutor()
+        stdout, _stderr, exit_code = await executor.execute_bash_command("printf '  padded  \\n\\n'", strip_output=True)
+
+        assert stdout == "padded"
+        assert exit_code == 0
+
+    @pytest.mark.asyncio
+    async def test_non_utf8_output_is_replaced_and_exit_code_survives(self):
+        executor = BashExecutor()
+        stdout, _stderr, exit_code = await executor.execute_bash_command("printf '\\xff\\xfe'; exit 3")
+
+        assert stdout == "��"
+        assert exit_code == 3
+
+    @pytest.mark.asyncio
     async def test_command_with_timeout(self):
         """Test that a command with a timeout raises the appropriate exception."""
         executor = BashExecutor()
@@ -146,7 +170,7 @@ class TestBashExecutor:
             max_output_bytes=None,
         )
 
-        assert stdout == "  indented�"
+        assert stdout == "  indented�\n"
         assert exit_code == 0
 
     @pytest.mark.asyncio

--- a/integration-tests/test_tool_service.py
+++ b/integration-tests/test_tool_service.py
@@ -39,7 +39,16 @@ class TestToolService(IsolatedAsyncioTestCase):
             timeout=600.0,
             graceful_termination_timeout=3.0,
             max_output_bytes=None,
+            strip_output=False,
         )
+
+    async def test_execute_bash_tool_forwards_strip_request(self):
+        self.service.bash_executor.execute_bash_command.return_value = Future()
+        self.service.bash_executor.execute_bash_command.return_value.set_result(("out", "", 0))
+
+        await self.service.execute_tool("bash", {"command": "echo 'Hello'", "strip_output": True})
+
+        self.assertTrue(self.service.bash_executor.execute_bash_command.call_args.kwargs["strip_output"])
 
     async def test_execute_bash_tool_missing_command(self):
         parameters = {}
@@ -65,6 +74,7 @@ class TestToolService(IsolatedAsyncioTestCase):
                 "timeout": 600.0,
                 "graceful_termination_timeout": 2.0,
                 "max_output_bytes": None,
+                "strip_output": False,
             },
         )
 

--- a/tools/src/idegym/tools/router.py
+++ b/tools/src/idegym/tools/router.py
@@ -33,6 +33,7 @@ async def execute_bash_script(
             "timeout": request.timeout,
             "graceful_termination_timeout": request.graceful_termination_timeout,
             "max_output_bytes": request.max_output_bytes,
+            "strip_output": request.strip_output,
         },
     )
 

--- a/tools/src/idegym/tools/tool_service.py
+++ b/tools/src/idegym/tools/tool_service.py
@@ -29,6 +29,7 @@ class ToolService:
                 timeout = parameters.get("timeout", 600.0)
                 graceful_termination_timeout = parameters.get("graceful_termination_timeout", 2.0)
                 max_output_bytes = parameters.get("max_output_bytes", DEFAULT_MAX_OUTPUT_BYTES)
+                strip_output = parameters.get("strip_output", False)
                 if not command:
                     raise ValueError("Missing 'command' in parameters for bash tool")
                 stdout, stderr, exit_code = await self.bash_executor.execute_bash_command(
@@ -36,6 +37,7 @@ class ToolService:
                     timeout=timeout,
                     graceful_termination_timeout=graceful_termination_timeout,
                     max_output_bytes=max_output_bytes,
+                    strip_output=strip_output,
                 )
                 return stdout, stderr, exit_code
             case ToolName.FILE:

--- a/unit-tests/test_bash_executor.py
+++ b/unit-tests/test_bash_executor.py
@@ -128,6 +128,31 @@ def test_decode_output_of_empty_stream_is_empty_either_way() -> None:
     assert bash_executor._decode_output(b"", strip=True) == ""
 
 
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        ("export TOKEN=s3cr3t", "export TOKEN=<redacted>"),
+        ("export TOKEN='s3 cr3t'", "export TOKEN=<redacted>"),
+        ('export TOKEN="s3 cr3t"', "export TOKEN=<redacted>"),
+        ("export EMPTY=", "export EMPTY=<redacted>"),
+        ("export A=1; export B=2 && echo done", "export A=<redacted>; export B=<redacted> && echo done"),
+        ("exporting TOKEN=keepme", "exporting TOKEN=keepme"),
+        ("TOKEN=keepme echo hi", "TOKEN=keepme echo hi"),
+    ],
+)
+def test_redact_exports_masks_only_the_assigned_value(command, expected) -> None:
+    assert bash_executor._redact_exports(command) == expected
+
+
+def test_command_excerpt_redacts_before_truncating() -> None:
+    command = "export TOKEN=" + "s" * 4000
+
+    excerpt = bash_executor._command_excerpt(command)
+
+    assert "s" * 20 not in excerpt
+    assert excerpt.startswith("export TOKEN=<redacted>")
+
+
 def test_log_excerpt_is_bounded_to_one_page() -> None:
     excerpt = bash_executor._log_excerpt("x" * 4000)
 

--- a/unit-tests/test_bash_executor.py
+++ b/unit-tests/test_bash_executor.py
@@ -115,8 +115,17 @@ def test_collector_exposes_bounded_partial_output() -> None:
     assert collector.total == 12
 
 
-def test_decode_output_replaces_invalid_utf8_and_preserves_leading_whitespace() -> None:
-    assert bash_executor._decode_output(b"  indented\xff\n") == "  indented�"
+def test_decode_output_replaces_invalid_utf8_and_preserves_surrounding_whitespace() -> None:
+    assert bash_executor._decode_output(b"  indented\xff\n") == "  indented�\n"
+
+
+def test_decode_output_trims_only_when_asked() -> None:
+    assert bash_executor._decode_output(b"\n  spaced  \n", strip=True) == "spaced"
+
+
+def test_decode_output_of_empty_stream_is_empty_either_way() -> None:
+    assert bash_executor._decode_output(b"") == ""
+    assert bash_executor._decode_output(b"", strip=True) == ""
 
 
 def test_log_excerpt_is_bounded_to_one_page() -> None:
@@ -135,3 +144,7 @@ def test_bash_request_rejects_invalid_output_limit(limit) -> None:
 
 def test_bash_request_supports_explicit_unlimited_output() -> None:
     assert BashCommandRequest(command="echo hello", max_output_bytes=None).max_output_bytes is None
+
+
+def test_bash_request_keeps_output_verbatim_by_default() -> None:
+    assert BashCommandRequest(command="echo hello").strip_output is False

--- a/unit-tests/test_orchestrator_mcp.py
+++ b/unit-tests/test_orchestrator_mcp.py
@@ -168,7 +168,7 @@ async def test_run_bash_command_mcp_tool_calls_forwarding_endpoint(mocker):
     assert isinstance(endpoint.await_args.kwargs["headers"], Headers)
     assert endpoint.await_args.kwargs["headers"]["content-type"] == "application/json"
     assert endpoint.await_args.kwargs["body"] == (
-        '{"command":"echo hello","timeout":600.0,"graceful_termination_timeout":2.0,"max_output_bytes":1048576}'
+        '{"command":"echo hello","timeout":600.0,"graceful_termination_timeout":2.0,"max_output_bytes":1048576,"strip_output":false}'
     )
     assert result.structured_content == {"async_operation_id": 43}
 

--- a/website/docs/reference/tools.md
+++ b/website/docs/reference/tools.md
@@ -31,6 +31,7 @@ Execute a bash script inside the container.
 | `timeout` | float | 600.0 | Maximum execution time in seconds |
 | `graceful_termination_timeout` | float | 2.0 | Seconds to wait for graceful process exit before SIGKILL |
 | `max_output_bytes` | integer or null | 1048576 | Maximum retained bytes per stream; `null` retains complete output |
+| `strip_output` | bool | `false` | Trim leading and trailing whitespace from `stdout` and `stderr` |
 
 **Response:**
 
@@ -45,6 +46,19 @@ beginning and end and includes a marker with the number of omitted bytes; the ma
 is outside the configured limit. Set `max_output_bytes` to `null` only when complete output
 is required and its size is trusted. IdeGYM still drains all produced output until the command
 finishes or reaches its execution timeout so subprocess pipes cannot deadlock.
+
+#### Output fidelity
+
+Within the retained window, output is returned exactly as the command wrote it. Nothing is
+trimmed, so a trailing newline that belongs to a `git diff` survives and `printf 'x'` stays
+distinguishable from `printf '  x  '`. Set `strip_output` to `true` if you would otherwise call
+`.strip()` on the result yourself.
+
+Bytes that are not valid UTF-8 are replaced with `U+FFFD` rather than failing the request, so
+`cat` on a binary file or a compiler emitting latin-1 diagnostics still returns the command's
+real exit code. The response is JSON text: to move binary data out of the container intact,
+encode it inside the command (`base64 -w0 …`) or use the
+[file endpoints](client.md).
 
 **Via orchestrator MCP (`run_bash_command`):**
 

--- a/website/docs/reference/tools.md
+++ b/website/docs/reference/tools.md
@@ -60,6 +60,18 @@ real exit code. The response is JSON text: to move binary data out of the contai
 encode it inside the command (`base64 -w0 …`) or use the
 [file endpoints](client.md).
 
+#### What gets logged
+
+The server never writes a command or its output to the log at INFO. An INFO record carries the
+shape of the call only — the command's length on the way in, then the exit code and the byte
+count of each stream on the way out.
+
+The command itself and excerpts of both streams are logged at DEBUG, and the command passes
+through a redaction step first that replaces the value of every `export NAME=...` assignment
+with `<redacted>`. Raise the level with `IDEGYM_LOG_LEVEL=DEBUG` when you need to see what a
+sandbox actually ran, and be aware that anything a script sets by other means — an inline
+`NAME=value cmd` prefix, a heredoc, a literal in an argument — is not redacted.
+
 **Via orchestrator MCP (`run_bash_command`):**
 
 ```python


### PR DESCRIPTION
**Stack 1/8** — **#289** ← #290 ← #291 ← #292 ← #293 ← #294 ← #295 ← #296 (merge in order, oldest first).
Base: `main`. Branch: `vladimir.poliakov/jbres-10676-01-…`.

JBRes-10676 splits into 18 independent improvements found while integrating IdeGYM as a NeMo Gym sandbox provider. One PR would be 59 commits, so it is a stack, cut by subsystem and ordered so each layer only depends on the ones below. Every branch is independently green; **merge the whole stack in order** rather than piecemeal.

This one is the two High-priority bash-tool fixes. Depends on nothing.

## What changed

**Output is returned verbatim** (improvement #1). The executor trimmed every command's output, so a caller could not tell `printf 'x'` from `printf '  x  '` and a trailing newline that is part of a `git diff` was dropped. `BashCommandRequest.strip_output` is the opt-in for the old behaviour.

**Command and output logging moved to DEBUG** (#2). Both went to the log at INFO. Since setting per-command environment means writing `export TOKEN=…` into the script, that leaked credentials verbatim; and because file transfer rides base64 over bash, a 10 MB upload wrote hundreds of megabytes of logs. INFO now carries only command length, exit code and per-stream byte counts. The command moved to DEBUG behind a redaction pass that masks every `export NAME=…` value.

## How to verify

```
uv run pytest -m unit unit-tests/test_bash_executor.py
uv run pytest integration-tests/docker_tests/test_bash_executor.py
```

- `unit-tests/test_bash_executor.py` — decode/strip behaviour, the redaction table, redact-before-truncate.
- `integration-tests/docker_tests/test_bash_executor.py` — real bash: padded and non-UTF-8 output round-trips with its exit code; an exported credential reaches neither the INFO records nor the DEBUG excerpt.

Full suite on this branch: **1173 passed, 2 skipped**; `ruff check` clean; docs site builds.

## Breaking change

Output is no longer stripped. Every caller in this repository and in the e2e suite already strips its own, but downstream consumers comparing exact output should pass `strip_output=True`.

Resolves: JBRes-10676 (partially — #1, #2)
