### PR TITLE
[JBRes-10676] Binary-safe chunked file transfer (stack 2/8)

### DIFF
--- a/api/src/idegym/api/paths.py
+++ b/api/src/idegym/api/paths.py
@@ -44,3 +44,5 @@ class ToolsPath(APIPath):
     CREATE_FILE = "/tools/file/create"
     EDIT_FILE = "/tools/file/edit"
     PATCH_FILE = "/tools/file/patch"
+    UPLOAD_FILE = "/tools/file/upload"
+    DOWNLOAD_FILE = "/tools/file/download"

--- a/api/src/idegym/api/tools/file.py
+++ b/api/src/idegym/api/tools/file.py
@@ -24,3 +24,46 @@ class PatchFileRequest(FileRequest):
 
 class FileResult(BaseModel):
     status: Status
+
+
+DEFAULT_FILE_CHUNK_BYTES = 1024 * 1024
+"""Raw bytes carried by one transfer chunk. Base64 inflates it to roughly 4/3 of this on the wire."""
+
+
+class UploadFileChunkRequest(FileRequest):
+    """One chunk of a binary upload.
+
+    Chunks travel as base64 inside the ordinary JSON forwarding path, which is what makes them
+    binary-safe: the orchestrator stores and replays a forwarded request as JSON text, so raw
+    bytes would not survive the round trip.
+    """
+
+    content_base64: str = Field(description="Base64-encoded bytes to write at 'offset'")
+    offset: int = Field(default=0, ge=0, description="Byte offset in the file at which to write this chunk")
+    truncate: bool = Field(
+        default=True,
+        description=(
+            "Cut the file off at the end of this chunk once it is written, so a re-upload cannot "
+            "leave the tail of a longer previous file behind. Set false for out-of-order writes."
+        ),
+    )
+
+
+class UploadFileChunkResponse(BaseModel):
+    file_path: str
+    bytes_written: int
+    size: int = Field(description="Size of the file after the write")
+
+
+class DownloadFileChunkRequest(FileRequest):
+    offset: int = Field(default=0, ge=0, description="Byte offset in the file to read from")
+    length: int = Field(default=DEFAULT_FILE_CHUNK_BYTES, ge=1, description="Maximum number of raw bytes to read")
+
+
+class DownloadFileChunkResponse(BaseModel):
+    file_path: str
+    offset: int
+    content_base64: str = Field(description="Base64-encoded bytes read at 'offset'")
+    bytes_read: int
+    size: int = Field(description="Total size of the file")
+    eof: bool = Field(description="True when this chunk reaches the end of the file")

--- a/client/src/idegym/client/operations/files.py
+++ b/client/src/idegym/client/operations/files.py
@@ -248,10 +248,11 @@ class FileOperations:
         offset = 0
         # An empty source still sends one request, otherwise the file would never be created.
         while True:
+            chunk = await read_chunk_at(offset)
             response = await self.upload_chunk(
                 server_id=server_id,
                 file_path=file_path,
-                data=await read_chunk_at(offset),
+                data=chunk,
                 offset=offset,
                 client_id=client_id,
                 request_timeout=request_timeout,
@@ -260,6 +261,14 @@ class FileOperations:
             offset += response.bytes_written
             if offset >= total:
                 return response.size
+            if not chunk:
+                # The loop advances by bytes written, so a short read before `total` would spin
+                # forever sending empty chunks. Happens when the source shrinks mid-upload:
+                # `total` was measured up front, and reads past the new end return nothing.
+                raise RuntimeError(
+                    f"Upload source ended at {offset} bytes, before the expected {total}: "
+                    f"it shrank while {file_path} was being uploaded"
+                )
 
     async def _download_chunks(
         self,

--- a/client/src/idegym/client/operations/files.py
+++ b/client/src/idegym/client/operations/files.py
@@ -1,8 +1,22 @@
-from typing import Optional
+import asyncio
+from base64 import b64decode, b64encode
+from collections.abc import AsyncIterator, Awaitable, Callable
+from pathlib import Path
+from typing import BinaryIO, Optional
 from uuid import UUID
 
 from idegym.api.paths import ToolsPath
-from idegym.api.tools.file import CreateFileRequest, EditFileRequest, FileResult, PatchFileRequest
+from idegym.api.tools.file import (
+    DEFAULT_FILE_CHUNK_BYTES,
+    CreateFileRequest,
+    DownloadFileChunkRequest,
+    DownloadFileChunkResponse,
+    EditFileRequest,
+    FileResult,
+    PatchFileRequest,
+    UploadFileChunkRequest,
+    UploadFileChunkResponse,
+)
 from idegym.client.operations.forwarding import ForwardingOperations
 from idegym.client.operations.utils import HTTPUtils, PollingConfig
 
@@ -63,3 +77,222 @@ class FileOperations:
             "POST", server_id, ToolsPath.PATCH_FILE, request, client_id, request_timeout, polling_config
         )
         return FileResult.model_validate(response_raw)
+
+    async def upload_chunk(
+        self,
+        server_id: int,
+        file_path: str,
+        data: bytes,
+        offset: int = 0,
+        truncate: bool = True,
+        client_id: Optional[UUID] = None,
+        request_timeout: Optional[int] = None,
+        polling_config: PollingConfig = PollingConfig(),
+    ) -> UploadFileChunkResponse:
+        """Write one chunk of raw bytes into a file on the server."""
+        request = UploadFileChunkRequest(
+            file_path=file_path,
+            content_base64=b64encode(data).decode("ascii"),
+            offset=offset,
+            truncate=truncate,
+        )
+        response_raw = await self._forward.forward_request(
+            "POST", server_id, ToolsPath.UPLOAD_FILE, request, client_id, request_timeout, polling_config
+        )
+        return UploadFileChunkResponse.model_validate(response_raw)
+
+    async def download_chunk(
+        self,
+        server_id: int,
+        file_path: str,
+        offset: int = 0,
+        length: int = DEFAULT_FILE_CHUNK_BYTES,
+        client_id: Optional[UUID] = None,
+        request_timeout: Optional[int] = None,
+        polling_config: PollingConfig = PollingConfig(),
+    ) -> DownloadFileChunkResponse:
+        """Read one chunk of raw bytes from a file on the server."""
+        request = DownloadFileChunkRequest(file_path=file_path, offset=offset, length=length)
+        response_raw = await self._forward.forward_request(
+            "POST", server_id, ToolsPath.DOWNLOAD_FILE, request, client_id, request_timeout, polling_config
+        )
+        return DownloadFileChunkResponse.model_validate(response_raw)
+
+    async def upload_bytes(
+        self,
+        server_id: int,
+        file_path: str,
+        data: bytes,
+        chunk_bytes: int = DEFAULT_FILE_CHUNK_BYTES,
+        client_id: Optional[UUID] = None,
+        request_timeout: Optional[int] = None,
+        polling_config: PollingConfig = PollingConfig(),
+    ) -> int:
+        """Upload ``data`` to ``file_path`` on the server and return the resulting file size."""
+
+        async def read_slice(offset: int) -> bytes:
+            return data[offset : offset + chunk_bytes]
+
+        return await self._upload_stream(
+            server_id=server_id,
+            file_path=file_path,
+            read_chunk_at=read_slice,
+            total=len(data),
+            chunk_bytes=chunk_bytes,
+            client_id=client_id,
+            request_timeout=request_timeout,
+            polling_config=polling_config,
+        )
+
+    async def upload_file(
+        self,
+        server_id: int,
+        local_path: Path | str,
+        file_path: str,
+        chunk_bytes: int = DEFAULT_FILE_CHUNK_BYTES,
+        client_id: Optional[UUID] = None,
+        request_timeout: Optional[int] = None,
+        polling_config: PollingConfig = PollingConfig(),
+    ) -> int:
+        """Upload a local file to ``file_path`` on the server and return the resulting file size.
+
+        The file is read one chunk at a time, so its size is bounded by the sandbox's disk rather
+        than by the client's memory.
+        """
+        source = Path(local_path)
+        total = await asyncio.to_thread(lambda: source.stat().st_size)
+        handle = await asyncio.to_thread(source.open, "rb")
+
+        async def read_file_at(offset: int) -> bytes:
+            return await asyncio.to_thread(_read_at, handle, offset, chunk_bytes)
+
+        try:
+            return await self._upload_stream(
+                server_id=server_id,
+                file_path=file_path,
+                read_chunk_at=read_file_at,
+                total=total,
+                chunk_bytes=chunk_bytes,
+                client_id=client_id,
+                request_timeout=request_timeout,
+                polling_config=polling_config,
+            )
+        finally:
+            await asyncio.to_thread(handle.close)
+
+    async def download_bytes(
+        self,
+        server_id: int,
+        file_path: str,
+        chunk_bytes: int = DEFAULT_FILE_CHUNK_BYTES,
+        client_id: Optional[UUID] = None,
+        request_timeout: Optional[int] = None,
+        polling_config: PollingConfig = PollingConfig(),
+    ) -> bytes:
+        """Download ``file_path`` from the server and return its bytes."""
+        collected = bytearray()
+        async for chunk in self._download_chunks(
+            server_id=server_id,
+            file_path=file_path,
+            chunk_bytes=chunk_bytes,
+            client_id=client_id,
+            request_timeout=request_timeout,
+            polling_config=polling_config,
+        ):
+            collected.extend(chunk)
+        return bytes(collected)
+
+    async def download_file(
+        self,
+        server_id: int,
+        file_path: str,
+        local_path: Path | str,
+        chunk_bytes: int = DEFAULT_FILE_CHUNK_BYTES,
+        client_id: Optional[UUID] = None,
+        request_timeout: Optional[int] = None,
+        polling_config: PollingConfig = PollingConfig(),
+    ) -> int:
+        """Download ``file_path`` from the server into ``local_path`` and return the byte count."""
+        destination = Path(local_path)
+        await asyncio.to_thread(destination.parent.mkdir, parents=True, exist_ok=True)
+        handle = await asyncio.to_thread(destination.open, "wb")
+        written = 0
+        try:
+            async for chunk in self._download_chunks(
+                server_id=server_id,
+                file_path=file_path,
+                chunk_bytes=chunk_bytes,
+                client_id=client_id,
+                request_timeout=request_timeout,
+                polling_config=polling_config,
+            ):
+                written += await asyncio.to_thread(handle.write, chunk)
+        finally:
+            await asyncio.to_thread(handle.close)
+        return written
+
+    async def _upload_stream(
+        self,
+        server_id: int,
+        file_path: str,
+        read_chunk_at: Callable[[int], Awaitable[bytes]],
+        total: int,
+        chunk_bytes: int,
+        client_id: Optional[UUID],
+        request_timeout: Optional[int],
+        polling_config: PollingConfig,
+    ) -> int:
+        if chunk_bytes < 1:
+            raise ValueError("chunk_bytes must be positive")
+
+        offset = 0
+        # An empty source still sends one request, otherwise the file would never be created.
+        while True:
+            response = await self.upload_chunk(
+                server_id=server_id,
+                file_path=file_path,
+                data=await read_chunk_at(offset),
+                offset=offset,
+                client_id=client_id,
+                request_timeout=request_timeout,
+                polling_config=polling_config,
+            )
+            offset += response.bytes_written
+            if offset >= total:
+                return response.size
+
+    async def _download_chunks(
+        self,
+        server_id: int,
+        file_path: str,
+        chunk_bytes: int,
+        client_id: Optional[UUID],
+        request_timeout: Optional[int],
+        polling_config: PollingConfig,
+    ) -> AsyncIterator[bytes]:
+        if chunk_bytes < 1:
+            raise ValueError("chunk_bytes must be positive")
+
+        offset = 0
+        while True:
+            response = await self.download_chunk(
+                server_id=server_id,
+                file_path=file_path,
+                offset=offset,
+                length=chunk_bytes,
+                client_id=client_id,
+                request_timeout=request_timeout,
+                polling_config=polling_config,
+            )
+            chunk = b64decode(response.content_base64, validate=True)
+            if chunk:
+                yield chunk
+            offset += len(chunk)
+            # `eof` ends a normal transfer; an empty chunk guards against a file shrinking mid-read.
+            if response.eof or not chunk:
+                return
+
+
+def _read_at(handle: BinaryIO, offset: int, length: int) -> bytes:
+    handle.seek(offset)
+    return handle.read(length)

--- a/client/src/idegym/client/server.py
+++ b/client/src/idegym/client/server.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any, Optional
 from uuid import UUID
 
@@ -13,7 +14,7 @@ from idegym.api.rewards.compilation import CompilationResult
 from idegym.api.rewards.setup import SetupResult
 from idegym.api.rewards.test import TestReport
 from idegym.api.tools.bash import DEFAULT_MAX_OUTPUT_BYTES, BashCommandResponse
-from idegym.api.tools.file import FileResult
+from idegym.api.tools.file import DEFAULT_FILE_CHUNK_BYTES, FileResult
 from idegym.client.operations.files import FileOperations
 from idegym.client.operations.forwarding import ForwardingOperations
 from idegym.client.operations.project import ProjectOperations
@@ -254,6 +255,84 @@ class IdeGYMServer:
             server_id=self.server_id,
             file_path=file_path,
             patch=patch,
+            client_id=self.client_id,
+            request_timeout=request_timeout,
+            polling_config=polling_config or self.polling_config,
+        )
+
+    async def upload_file(
+        self,
+        local_path: Path | str,
+        file_path: str,
+        chunk_bytes: int = DEFAULT_FILE_CHUNK_BYTES,
+        request_timeout: Optional[int] = None,
+        polling_config: Optional[PollingConfig] = None,
+    ) -> int:
+        """Upload a local file to the server byte-for-byte and return the resulting file size.
+
+        Chunks travel as base64 through the ordinary forwarding path rather than through the bash
+        tool, so binary content survives and the transfer is not bounded by a shell script's size.
+        """
+        return await self.files.upload_file(
+            server_id=self.server_id,
+            local_path=local_path,
+            file_path=file_path,
+            chunk_bytes=chunk_bytes,
+            client_id=self.client_id,
+            request_timeout=request_timeout,
+            polling_config=polling_config or self.polling_config,
+        )
+
+    async def upload_bytes(
+        self,
+        file_path: str,
+        data: bytes,
+        chunk_bytes: int = DEFAULT_FILE_CHUNK_BYTES,
+        request_timeout: Optional[int] = None,
+        polling_config: Optional[PollingConfig] = None,
+    ) -> int:
+        """Write raw bytes to a file on the server and return the resulting file size."""
+        return await self.files.upload_bytes(
+            server_id=self.server_id,
+            file_path=file_path,
+            data=data,
+            chunk_bytes=chunk_bytes,
+            client_id=self.client_id,
+            request_timeout=request_timeout,
+            polling_config=polling_config or self.polling_config,
+        )
+
+    async def download_file(
+        self,
+        file_path: str,
+        local_path: Path | str,
+        chunk_bytes: int = DEFAULT_FILE_CHUNK_BYTES,
+        request_timeout: Optional[int] = None,
+        polling_config: Optional[PollingConfig] = None,
+    ) -> int:
+        """Download a file from the server into ``local_path`` and return the byte count."""
+        return await self.files.download_file(
+            server_id=self.server_id,
+            file_path=file_path,
+            local_path=local_path,
+            chunk_bytes=chunk_bytes,
+            client_id=self.client_id,
+            request_timeout=request_timeout,
+            polling_config=polling_config or self.polling_config,
+        )
+
+    async def download_bytes(
+        self,
+        file_path: str,
+        chunk_bytes: int = DEFAULT_FILE_CHUNK_BYTES,
+        request_timeout: Optional[int] = None,
+        polling_config: Optional[PollingConfig] = None,
+    ) -> bytes:
+        """Read a file from the server and return its raw bytes."""
+        return await self.files.download_bytes(
+            server_id=self.server_id,
+            file_path=file_path,
+            chunk_bytes=chunk_bytes,
             client_id=self.client_id,
             request_timeout=request_timeout,
             polling_config=polling_config or self.polling_config,

--- a/e2e-tests/test_file_transfer.py
+++ b/e2e-tests/test_file_transfer.py
@@ -1,0 +1,72 @@
+"""Binary file transfer through the orchestrator, end to end.
+
+The forwarding path stores and replays a request as JSON *text*, so this suite works entirely
+with payloads that are not valid UTF-8: if any hop decoded them, the comparison would fail.
+"""
+
+import pytest
+from utils.constants import DEFAULT_SERVER_START_TIMEOUT
+from utils.idegym_utils import create_http_client
+
+BINARY = bytes(range(256)) * 64
+
+
+@pytest.mark.asyncio
+async def test_binary_round_trip_through_the_orchestrator(test_image, test_id, tmp_path):
+    async with (
+        create_http_client(name=f"transfer-{test_id}", nodes_count=0) as client,
+        client.with_server(
+            image_tag=test_image,
+            server_name=f"transfer-{test_id}",
+            runtime_class_name="gvisor",
+            run_as_root=True,
+            server_start_wait_timeout_in_seconds=DEFAULT_SERVER_START_TIMEOUT,
+        ) as server,
+    ):
+        size = await server.upload_bytes("/tmp/blob.bin", BINARY, chunk_bytes=4096)
+        assert size == len(BINARY)
+
+        assert await server.download_bytes("/tmp/blob.bin", chunk_bytes=4096) == BINARY
+
+        destination = tmp_path / "restored.bin"
+        written = await server.download_file("/tmp/blob.bin", destination, chunk_bytes=4096)
+        assert written == len(BINARY)
+        assert destination.read_bytes() == BINARY
+
+
+@pytest.mark.asyncio
+async def test_uploaded_file_is_visible_to_the_bash_tool(test_image, test_id, tmp_path):
+    source = tmp_path / "source.bin"
+    source.write_bytes(BINARY)
+
+    async with (
+        create_http_client(name=f"transfer-bash-{test_id}", nodes_count=0) as client,
+        client.with_server(
+            image_tag=test_image,
+            server_name=f"transfer-bash-{test_id}",
+            runtime_class_name="gvisor",
+            run_as_root=True,
+            server_start_wait_timeout_in_seconds=DEFAULT_SERVER_START_TIMEOUT,
+        ) as server,
+    ):
+        await server.upload_file(source, "/tmp/nested/source.bin", chunk_bytes=4096)
+
+        result = await server.execute_bash(script="wc -c < /tmp/nested/source.bin")
+        assert result.exit_code == 0
+        assert result.stdout.strip() == str(len(BINARY))
+
+
+@pytest.mark.asyncio
+async def test_downloading_a_missing_file_fails(test_image, test_id):
+    async with (
+        create_http_client(name=f"transfer-missing-{test_id}", nodes_count=0) as client,
+        client.with_server(
+            image_tag=test_image,
+            server_name=f"transfer-missing-{test_id}",
+            runtime_class_name="gvisor",
+            run_as_root=True,
+            server_start_wait_timeout_in_seconds=DEFAULT_SERVER_START_TIMEOUT,
+        ) as server,
+    ):
+        with pytest.raises(Exception, match="404"):
+            await server.download_bytes("/tmp/definitely-absent.bin")

--- a/tools/src/idegym/tools/file_manager.py
+++ b/tools/src/idegym/tools/file_manager.py
@@ -36,5 +36,35 @@ class FileManager:
         with open(full_file_path, "w", encoding="utf-8") as file:
             file.write(new_content)
 
+    def write_chunk(self, file_path: Path, data: bytes, offset: int = 0, truncate: bool = True) -> tuple[int, int]:
+        """Write ``data`` at ``offset`` and return ``(bytes_written, size_after_write)``.
+
+        Missing parent directories are created, and ``truncate`` cuts the file off at the end of
+        the chunk so re-uploading a shorter file cannot leave the previous tail behind. Writing
+        past the current end of the file leaves a hole of zero bytes, as ``lseek`` does.
+        """
+        full_file_path = Path(self._calculate_full_file_path(file_path))
+        full_file_path.parent.mkdir(parents=True, exist_ok=True)
+        # "r+b" refuses to create the file and "w+b" would discard an earlier chunk, so pick per call.
+        mode = "r+b" if full_file_path.exists() else "w+b"
+        with open(full_file_path, mode) as file:
+            file.seek(offset)
+            bytes_written = file.write(data)
+            if truncate:
+                file.truncate()
+        return bytes_written, full_file_path.stat().st_size
+
+    def read_chunk(self, file_path: Path, offset: int = 0, length: int = 1024 * 1024) -> tuple[bytes, int]:
+        """Read at most ``length`` bytes from ``offset`` and return them with the total file size."""
+        full_file_path = Path(self._calculate_full_file_path(file_path))
+        if not full_file_path.exists():
+            raise FileNotFoundError(f"File not found: {full_file_path}")
+        if full_file_path.is_dir():
+            raise IsADirectoryError(f"Path is a directory, not a file: {full_file_path}")
+        size = full_file_path.stat().st_size
+        with open(full_file_path, "rb") as file:
+            file.seek(offset)
+            return file.read(length), size
+
     def _calculate_full_file_path(self, file_path):
         return file_path if self.working_directory is None else self.working_directory / file_path

--- a/tools/src/idegym/tools/router.py
+++ b/tools/src/idegym/tools/router.py
@@ -6,11 +6,22 @@ implementation via ``app.dependency_overrides[_get_tool_service] = ...``
 before starting to serve requests.
 """
 
-from fastapi import APIRouter, Depends
+from binascii import Error as Base64Error
+
+from fastapi import APIRouter, Depends, HTTPException, status
 from idegym.api.paths import ToolsPath
 from idegym.api.status import Status
 from idegym.api.tools.bash import BashCommandRequest, BashCommandResponse
-from idegym.api.tools.file import CreateFileRequest, EditFileRequest, FileResult, PatchFileRequest
+from idegym.api.tools.file import (
+    CreateFileRequest,
+    DownloadFileChunkRequest,
+    DownloadFileChunkResponse,
+    EditFileRequest,
+    FileResult,
+    PatchFileRequest,
+    UploadFileChunkRequest,
+    UploadFileChunkResponse,
+)
 from idegym.tools.tool_service import FileToolActionName, ToolName, ToolService
 
 router = APIRouter()
@@ -89,3 +100,48 @@ async def patch_file(
     )
 
     return FileResult(status=Status.SUCCESS)
+
+
+@router.post(ToolsPath.UPLOAD_FILE)
+async def upload_file_chunk(
+    request: UploadFileChunkRequest,
+    service: ToolService = Depends(_get_tool_service),
+) -> UploadFileChunkResponse:
+    """Write one base64 chunk into a file, so binary survives the JSON forwarding path."""
+    try:
+        return await service.execute_tool(
+            tool_name=ToolName.FILE,
+            parameters={
+                "action": FileToolActionName.UPLOAD,
+                "path": request.file_path,
+                "content_base64": request.content_base64,
+                "offset": request.offset,
+                "truncate": request.truncate,
+            },
+        )
+    except Base64Error as ex:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid base64 content: {ex}") from ex
+    except (NotADirectoryError, IsADirectoryError) as ex:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(ex)) from ex
+
+
+@router.post(ToolsPath.DOWNLOAD_FILE)
+async def download_file_chunk(
+    request: DownloadFileChunkRequest,
+    service: ToolService = Depends(_get_tool_service),
+) -> DownloadFileChunkResponse:
+    """Read one base64 chunk of a file, so binary survives the JSON forwarding path."""
+    try:
+        return await service.execute_tool(
+            tool_name=ToolName.FILE,
+            parameters={
+                "action": FileToolActionName.DOWNLOAD,
+                "path": request.file_path,
+                "offset": request.offset,
+                "length": request.length,
+            },
+        )
+    except FileNotFoundError as ex:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(ex)) from ex
+    except IsADirectoryError as ex:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(ex)) from ex

--- a/tools/src/idegym/tools/tool_service.py
+++ b/tools/src/idegym/tools/tool_service.py
@@ -1,7 +1,13 @@
+from base64 import b64decode, b64encode
 from enum import StrEnum
 from typing import Any
 
 from idegym.api.tools.bash import DEFAULT_MAX_OUTPUT_BYTES
+from idegym.api.tools.file import (
+    DEFAULT_FILE_CHUNK_BYTES,
+    DownloadFileChunkResponse,
+    UploadFileChunkResponse,
+)
 from idegym.backend.utils.bash_executor import BashExecutor
 from idegym.tools.file_manager import FileManager
 
@@ -15,6 +21,8 @@ class FileToolActionName(StrEnum):
     CREATE = "create"
     EDIT = "edit"
     PATCH = "patch"
+    UPLOAD = "upload"
+    DOWNLOAD = "download"
 
 
 class ToolService:
@@ -68,6 +76,35 @@ class ToolService:
                         if not file_path or not patch:
                             raise ValueError("Missing 'path' or 'patch' in parameters for file patching")
                         self.file_manager.patch_file(file_path, patch)
+                    case FileToolActionName.UPLOAD:
+                        file_path = parameters.get("path")
+                        if not file_path:
+                            raise ValueError("Missing 'path' in parameters for file upload")
+                        bytes_written, size = self.file_manager.write_chunk(
+                            file_path,
+                            b64decode(parameters.get("content_base64", ""), validate=True),
+                            offset=parameters.get("offset", 0),
+                            truncate=parameters.get("truncate", True),
+                        )
+                        return UploadFileChunkResponse(file_path=file_path, bytes_written=bytes_written, size=size)
+                    case FileToolActionName.DOWNLOAD:
+                        file_path = parameters.get("path")
+                        if not file_path:
+                            raise ValueError("Missing 'path' in parameters for file download")
+                        offset = parameters.get("offset", 0)
+                        data, size = self.file_manager.read_chunk(
+                            file_path,
+                            offset=offset,
+                            length=parameters.get("length", DEFAULT_FILE_CHUNK_BYTES),
+                        )
+                        return DownloadFileChunkResponse(
+                            file_path=file_path,
+                            offset=offset,
+                            content_base64=b64encode(data).decode("ascii"),
+                            bytes_read=len(data),
+                            size=size,
+                            eof=offset + len(data) >= size,
+                        )
                     case _:
                         raise ValueError(f"Unsupported action '{action}' for file tool")
             case _:

--- a/unit-tests/test_file_transfer.py
+++ b/unit-tests/test_file_transfer.py
@@ -12,6 +12,7 @@ import pytest
 from idegym.api.paths import ToolsPath
 from idegym.api.tools.file import DownloadFileChunkRequest, UploadFileChunkRequest
 from idegym.client.operations.files import FileOperations
+from idegym.client.operations.utils import PollingConfig
 from idegym.tools.file_manager import FileManager
 from idegym.tools.tool_service import FileToolActionName, ToolName, ToolService
 from pydantic import ValidationError
@@ -236,6 +237,31 @@ async def test_upload_and_download_file_round_trip_on_disk(tmp_path) -> None:
 
     assert written == len(BINARY)
     assert destination.read_bytes() == BINARY
+
+
+async def test_upload_raises_instead_of_spinning_when_the_source_shrinks() -> None:
+    """A short read before `total` used to leave the loop sending empty chunks forever."""
+    sandbox = _FakeSandbox()
+    operations = _operations(sandbox)
+
+    async def shrinking_reader(offset: int) -> bytes:
+        # Serves the first chunk, then behaves like a file truncated under us.
+        return BINARY[:64] if offset == 0 else b""
+
+    with pytest.raises(RuntimeError, match="it shrank while"):
+        await operations._upload_stream(
+            server_id=1,
+            file_path="/work/blob.bin",
+            read_chunk_at=shrinking_reader,
+            total=len(BINARY),
+            chunk_bytes=64,
+            client_id=None,
+            request_timeout=None,
+            polling_config=PollingConfig(),
+        )
+
+    # One real chunk plus the one empty probe that detects the shrink, then it stops.
+    assert len(sandbox.calls) == 2
 
 
 @pytest.mark.parametrize("chunk_bytes", [0, -1])

--- a/unit-tests/test_file_transfer.py
+++ b/unit-tests/test_file_transfer.py
@@ -1,0 +1,261 @@
+"""Chunked binary file transfer: the server-side chunk primitives and the client-side loops.
+
+The point of the feature is that arbitrary bytes survive a path that is JSON text end to end,
+so every assertion here works on payloads that are not valid UTF-8.
+"""
+
+from base64 import b64decode, b64encode
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from idegym.api.paths import ToolsPath
+from idegym.api.tools.file import DownloadFileChunkRequest, UploadFileChunkRequest
+from idegym.client.operations.files import FileOperations
+from idegym.tools.file_manager import FileManager
+from idegym.tools.tool_service import FileToolActionName, ToolName, ToolService
+from pydantic import ValidationError
+
+BINARY = bytes(range(256)) * 4
+
+
+class _FakeSandbox:
+    """A stand-in server that keeps uploaded files in memory and speaks the chunk protocol."""
+
+    def __init__(self, files: dict[str, bytes] | None = None, max_chunk: int = 1_000_000):
+        self.files = dict(files or {})
+        self.max_chunk = max_chunk
+        self.calls: list[tuple[str, dict]] = []
+
+    async def forward_request(self, method, server_id, path, body, client_id, request_timeout, polling_config):
+        self.calls.append((path, body.model_dump()))
+        if path == ToolsPath.UPLOAD_FILE:
+            return self._upload(body)
+        if path == ToolsPath.DOWNLOAD_FILE:
+            return self._download(body)
+        raise AssertionError(f"unexpected path {path}")
+
+    def _upload(self, body: UploadFileChunkRequest) -> dict:
+        data = b64decode(body.content_base64, validate=True)
+        current = self.files.get(body.file_path, b"").ljust(body.offset, b"\0")
+        updated = current[: body.offset] + data
+        if not body.truncate:
+            updated += current[body.offset + len(data) :]
+        self.files[body.file_path] = updated
+        return {"file_path": body.file_path, "bytes_written": len(data), "size": len(updated)}
+
+    def _download(self, body: DownloadFileChunkRequest) -> dict:
+        content = self.files[body.file_path]
+        chunk = content[body.offset : body.offset + min(body.length, self.max_chunk)]
+        return {
+            "file_path": body.file_path,
+            "offset": body.offset,
+            "content_base64": b64encode(chunk).decode("ascii"),
+            "bytes_read": len(chunk),
+            "size": len(content),
+            "eof": body.offset + len(chunk) >= len(content),
+        }
+
+
+def _operations(sandbox: _FakeSandbox) -> FileOperations:
+    forward = AsyncMock()
+    forward.forward_request = AsyncMock(side_effect=sandbox.forward_request)
+    return FileOperations(utils=AsyncMock(), forward=forward)
+
+
+# --------------------------------------------------------------------------------------
+# FileManager chunk primitives
+# --------------------------------------------------------------------------------------
+
+
+def test_write_chunk_creates_missing_parents_and_reports_size(tmp_path) -> None:
+    manager = FileManager()
+    target = tmp_path / "nested" / "deep" / "blob.bin"
+
+    written, size = manager.write_chunk(target, BINARY)
+
+    assert (written, size) == (len(BINARY), len(BINARY))
+    assert target.read_bytes() == BINARY
+
+
+def test_write_chunk_appends_at_offset_without_losing_earlier_chunks(tmp_path) -> None:
+    manager = FileManager()
+    target = tmp_path / "blob.bin"
+
+    manager.write_chunk(target, BINARY[:100])
+    _written, size = manager.write_chunk(target, BINARY[100:], offset=100)
+
+    assert size == len(BINARY)
+    assert target.read_bytes() == BINARY
+
+
+def test_write_chunk_truncates_the_tail_of_a_longer_previous_file(tmp_path) -> None:
+    manager = FileManager()
+    target = tmp_path / "blob.bin"
+    target.write_bytes(b"\xff" * 500)
+
+    manager.write_chunk(target, b"\x00\x01")
+
+    assert target.read_bytes() == b"\x00\x01"
+
+
+def test_write_chunk_can_keep_the_tail_for_an_out_of_order_write(tmp_path) -> None:
+    manager = FileManager()
+    target = tmp_path / "blob.bin"
+    target.write_bytes(b"abcdef")
+
+    manager.write_chunk(target, b"XY", offset=2, truncate=False)
+
+    assert target.read_bytes() == b"abXYef"
+
+
+def test_read_chunk_returns_a_window_and_the_total_size(tmp_path) -> None:
+    manager = FileManager()
+    target = tmp_path / "blob.bin"
+    target.write_bytes(BINARY)
+
+    data, size = manager.read_chunk(target, offset=10, length=32)
+
+    assert data == BINARY[10:42]
+    assert size == len(BINARY)
+
+
+def test_read_chunk_rejects_a_missing_file_and_a_directory(tmp_path) -> None:
+    manager = FileManager()
+
+    with pytest.raises(FileNotFoundError):
+        manager.read_chunk(tmp_path / "absent.bin")
+    with pytest.raises(IsADirectoryError):
+        manager.read_chunk(tmp_path)
+
+
+def test_chunk_primitives_respect_the_working_directory(tmp_path) -> None:
+    manager = FileManager(working_directory=tmp_path)
+
+    manager.write_chunk(Path("relative.bin"), BINARY)
+
+    assert (tmp_path / "relative.bin").read_bytes() == BINARY
+    assert manager.read_chunk(Path("relative.bin"))[0] == BINARY
+
+
+# --------------------------------------------------------------------------------------
+# ToolService actions
+# --------------------------------------------------------------------------------------
+
+
+async def test_tool_service_round_trips_binary_through_base64(tmp_path) -> None:
+    service = ToolService(bash_executor=AsyncMock(), file_manager=FileManager())
+    target = str(tmp_path / "blob.bin")
+
+    uploaded = await service.execute_tool(
+        ToolName.FILE,
+        {
+            "action": FileToolActionName.UPLOAD,
+            "path": target,
+            "content_base64": b64encode(BINARY).decode("ascii"),
+        },
+    )
+    downloaded = await service.execute_tool(
+        ToolName.FILE,
+        {"action": FileToolActionName.DOWNLOAD, "path": target, "length": len(BINARY)},
+    )
+
+    assert uploaded.size == len(BINARY)
+    assert b64decode(downloaded.content_base64) == BINARY
+    assert downloaded.eof is True
+
+
+async def test_tool_service_download_reports_not_at_eof_for_a_partial_window(tmp_path) -> None:
+    service = ToolService(bash_executor=AsyncMock(), file_manager=FileManager())
+    target = tmp_path / "blob.bin"
+    target.write_bytes(BINARY)
+
+    response = await service.execute_tool(
+        ToolName.FILE,
+        {"action": FileToolActionName.DOWNLOAD, "path": str(target), "length": 16},
+    )
+
+    assert response.bytes_read == 16
+    assert response.size == len(BINARY)
+    assert response.eof is False
+
+
+# --------------------------------------------------------------------------------------
+# Client chunking loops
+# --------------------------------------------------------------------------------------
+
+
+async def test_upload_bytes_splits_into_chunks_and_reassembles_intact() -> None:
+    sandbox = _FakeSandbox()
+    operations = _operations(sandbox)
+
+    size = await operations.upload_bytes(server_id=1, file_path="/work/blob.bin", data=BINARY, chunk_bytes=100)
+
+    assert size == len(BINARY)
+    assert sandbox.files["/work/blob.bin"] == BINARY
+    assert len(sandbox.calls) == 11
+
+
+async def test_upload_of_empty_content_still_creates_the_file() -> None:
+    sandbox = _FakeSandbox()
+    operations = _operations(sandbox)
+
+    size = await operations.upload_bytes(server_id=1, file_path="/work/empty.bin", data=b"")
+
+    assert size == 0
+    assert sandbox.files["/work/empty.bin"] == b""
+    assert len(sandbox.calls) == 1
+
+
+async def test_download_bytes_follows_eof_across_chunks() -> None:
+    sandbox = _FakeSandbox({"/work/blob.bin": BINARY}, max_chunk=64)
+    operations = _operations(sandbox)
+
+    assert await operations.download_bytes(server_id=1, file_path="/work/blob.bin") == BINARY
+    assert len(sandbox.calls) == 16
+
+
+async def test_download_of_an_empty_file_returns_no_bytes() -> None:
+    sandbox = _FakeSandbox({"/work/empty.bin": b""})
+    operations = _operations(sandbox)
+
+    assert await operations.download_bytes(server_id=1, file_path="/work/empty.bin") == b""
+
+
+async def test_upload_and_download_file_round_trip_on_disk(tmp_path) -> None:
+    sandbox = _FakeSandbox(max_chunk=97)
+    operations = _operations(sandbox)
+    source = tmp_path / "source.bin"
+    source.write_bytes(BINARY)
+    destination = tmp_path / "restored" / "copy.bin"
+
+    await operations.upload_file(server_id=1, local_path=source, file_path="/work/blob.bin", chunk_bytes=97)
+    written = await operations.download_file(
+        server_id=1, file_path="/work/blob.bin", local_path=destination, chunk_bytes=97
+    )
+
+    assert written == len(BINARY)
+    assert destination.read_bytes() == BINARY
+
+
+@pytest.mark.parametrize("chunk_bytes", [0, -1])
+async def test_transfer_rejects_a_non_positive_chunk_size(chunk_bytes) -> None:
+    operations = _operations(_FakeSandbox({"/work/blob.bin": BINARY}))
+
+    with pytest.raises(ValueError, match="chunk_bytes"):
+        await operations.upload_bytes(server_id=1, file_path="/work/blob.bin", data=BINARY, chunk_bytes=chunk_bytes)
+    with pytest.raises(ValueError, match="chunk_bytes"):
+        await operations.download_bytes(server_id=1, file_path="/work/blob.bin", chunk_bytes=chunk_bytes)
+
+
+@pytest.mark.parametrize(
+    ("model", "kwargs"),
+    [
+        (UploadFileChunkRequest, {"content_base64": "", "offset": -1}),
+        (DownloadFileChunkRequest, {"offset": -1}),
+        (DownloadFileChunkRequest, {"length": 0}),
+    ],
+)
+def test_chunk_requests_reject_out_of_range_windows(model, kwargs) -> None:
+    with pytest.raises(ValidationError):
+        model(file_path="/work/blob.bin", **kwargs)

--- a/website/docs/architecture/rewards-tools.md
+++ b/website/docs/architecture/rewards-tools.md
@@ -19,6 +19,7 @@ flowchart TB
         cf("<b>create_file</b>"):::tool
         ef("<b>edit_file</b>"):::tool
         pf("<b>patch_file</b>"):::tool
+        xfer("<b>upload / download</b>"):::tool
         inspect("<b>IDE inspect</b>"):::tool
     end
 
@@ -41,6 +42,7 @@ flowchart TB
     click cf "https://github.com/JetBrains-Research/idegym/blob/main/tools/src/idegym/tools/file_manager.py" "View the file-manager source on GitHub."
     click ef "https://github.com/JetBrains-Research/idegym/blob/main/tools/src/idegym/tools/file_manager.py" "View the file-manager source on GitHub."
     click pf "https://github.com/JetBrains-Research/idegym/blob/main/tools/src/idegym/tools/file_manager.py" "View the file-manager source on GitHub."
+    click xfer "https://github.com/JetBrains-Research/idegym/blob/main/tools/src/idegym/tools/file_manager.py" "View the file-manager source on GitHub."
     click inspect "https://github.com/JetBrains-Research/idegym/blob/main/plugins/pycharm/src/idegym/plugins/pycharm/server.py" "View the IDE-inspection plugin source on GitHub."
     click comp "https://github.com/JetBrains-Research/idegym/blob/main/rewards/src/idegym/rewards/compilation_checker.py" "View the compilation-reward checker source on GitHub."
     click setup "https://github.com/JetBrains-Research/idegym/blob/main/rewards/src/idegym/rewards/setup_checker.py" "View the setup-reward checker source on GitHub."
@@ -57,8 +59,10 @@ Every server ships the **tools** plugin, available on all images:
 | Create file | `POST /api/tools/file/create` | Create a file with given content |
 | Edit file | `POST /api/tools/file/edit` | Replace a 1-indexed, inclusive line range |
 | Patch file | `POST /api/tools/file/patch` | Apply a unified diff |
+| Upload chunk | `POST /api/tools/file/upload` | Write one base64 chunk of raw bytes at an offset |
+| Download chunk | `POST /api/tools/file/download` | Read one base64 chunk of raw bytes from an offset |
 
-The three file tools are **also exposed as MCP tools** (`create_file`, `edit_file`,
+The three text file tools are **also exposed as MCP tools** (`create_file`, `edit_file`,
 `patch_file`) on the server's `/mcp` endpoint. With a JetBrains IDE plugin installed, an
 `inspect` endpoint runs the full IntelliJ static-analysis pipeline, and **mcp-steroid**
 exposes the IntelliJ Platform API (PSI, refactoring, debugger, VCS) as MCP tools. See the
@@ -70,9 +74,17 @@ complete output with `max_output_bytes=None`. A short marker reports omitted byt
 stream is truncated; the marker itself is outside the per-stream limit. Output is still
 drained until completion or the execution timeout, preventing subprocess pipe deadlocks.
 
+The two chunk endpoints are the binary channel. The orchestrator stores and replays a
+forwarded request as JSON text, so raw bytes cannot survive that round trip and base64 is what
+does. The client wraps them in `upload_file` / `upload_bytes` / `download_file` /
+`download_bytes`, which chunk the payload for you — use these rather than base64 through the
+bash tool, which is bounded by the size of a single shell script and puts the payload in the
+command log.
+
 ```python
 result = await server.execute_bash("python -m pytest -q")
 await server.patch_file("/home/devuser/project/main.py", patch="--- ...")
+await server.upload_file("./fixtures/repo.tar.gz", "/home/devuser/repo.tar.gz")
 ```
 
 ## Rewards — the evaluation signal

--- a/website/docs/reference/client.md
+++ b/website/docs/reference/client.md
@@ -233,6 +233,39 @@ result = await server.patch_file(
 )
 ```
 
+### Binary file transfer
+
+`create_file` and `patch_file` carry text. To move bytes — an archive, a wheel, a compiled
+artifact, a database fixture — use the transfer methods, which chunk the content as base64 over
+the ordinary forwarding path. That path stores and replays a request as JSON text, so base64 is
+what makes the round trip lossless; raw bytes would not survive it.
+
+```python
+# Upload a local file into the container, then read it back byte-for-byte.
+size = await server.upload_file("./fixtures/repo.tar.gz", "/root/work/repo.tar.gz")
+await server.download_file("/root/work/out/results.db", "./results.db")
+
+# In-memory variants for smaller payloads.
+await server.upload_bytes("/root/work/blob.bin", b"\x00\xff")
+blob = await server.download_bytes("/root/work/blob.bin")
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `upload_file(local_path, file_path, chunk_bytes=..., ...)` | `int` | Stream a local file into the container; returns the resulting size |
+| `upload_bytes(file_path, data, chunk_bytes=..., ...)` | `int` | Write bytes already in memory; returns the resulting size |
+| `download_file(file_path, local_path, chunk_bytes=..., ...)` | `int` | Stream a container file to disk; returns the byte count |
+| `download_bytes(file_path, chunk_bytes=..., ...)` | `bytes` | Read a container file into memory |
+
+`chunk_bytes` is the number of raw bytes per request and defaults to 1 MiB; base64 inflates that
+to roughly 1.4 MiB on the wire. The file-based variants read and write one chunk at a time, so a
+transfer is bounded by disk rather than by client memory. Uploads are sequential and each chunk
+truncates the file at its own end, so an interrupted upload leaves a short file rather than a
+file with a stale tail. Downloading a path that does not exist fails with a 404.
+
+Prefer these over base64 through the bash tool: they are not bounded by the size of a single
+shell script, and the payload never reaches the command log.
+
 ### `restart_server(...)`
 
 Restart the server pod (preserves the same image and configuration):

--- a/website/docs/reference/tools.md
+++ b/website/docs/reference/tools.md
@@ -153,6 +153,51 @@ Apply a unified diff patch to a file.
 | `file_path` | string | Absolute path to the file |
 | `patch` | string | Unified diff patch to apply |
 
+### Upload File Chunk
+
+Write one base64-encoded chunk of raw bytes into a file. This is the binary-safe way in: the
+orchestrator stores and replays a forwarded request as JSON text, so base64 is what survives the
+round trip.
+
+**Endpoint:** `POST /api/tools/file/upload`
+
+**Request:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `file_path` | string | — | Absolute path to write to; missing parent directories are created |
+| `content_base64` | string | — | Base64-encoded bytes to write at `offset` |
+| `offset` | int | 0 | Byte offset in the file at which to write this chunk |
+| `truncate` | bool | `true` | Cut the file off at the end of this chunk once written |
+
+**Response:** `file_path`, `bytes_written`, `size` (file size after the write).
+
+`truncate` is what keeps a re-upload honest: with it on, writing a shorter file cannot leave the
+tail of a longer previous one behind. Turn it off for an out-of-order write. Writing past the
+current end of the file leaves a hole of zero bytes, as `lseek` does.
+
+### Download File Chunk
+
+Read one base64-encoded chunk of raw bytes from a file.
+
+**Endpoint:** `POST /api/tools/file/download`
+
+**Request:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `file_path` | string | — | Absolute path to read from |
+| `offset` | int | 0 | Byte offset to read from |
+| `length` | int | 1048576 | Maximum number of raw bytes to read |
+
+**Response:** `file_path`, `offset`, `content_base64`, `bytes_read`, `size` (total file size),
+and `eof` (true when this chunk reaches the end). A missing path returns 404; a directory
+returns 400.
+
+**Via Python client:** the client wraps both endpoints in `upload_file` / `upload_bytes` /
+`download_file` / `download_bytes`, which do the chunking for you. See
+[Binary file transfer](client.md#binary-file-transfer).
+
 ---
 
 ## IDE Inspection (`inspect.sh`)


### PR DESCRIPTION
**Stack 2/8** — #289 ← **#290** ← #291 ← #292 ← #293 ← #294 ← #295 ← #296 (merge in order, oldest first).
Base: `…-01-…`. Branch: `vladimir.poliakov/jbres-10676-02-…`.

Improvement #6 of JBRes-10676. Sits above the bash-logging fix because that is what stops a large transfer from flooding the log; otherwise independent.

## What changed

Moving a binary file in or out of a sandbox meant base64 through the bash tool, chunked both ways: bounded on the way in by the 128 KiB ceiling on a single `execve` argument, and logged twice per chunk on the way out.

Two endpoints carry the bytes instead. `POST /api/tools/file/upload` writes one base64 chunk at an offset; `POST /api/tools/file/download` reads one back. They ride the **existing JSON forwarding path**, which is precisely what makes them binary-safe — the orchestrator stores and replays a forwarded request as JSON *text*, so raw bytes would not survive the round trip but base64 does.

On the client, `server.upload_file` / `upload_bytes` / `download_file` / `download_bytes` do the chunking, streaming through a thread so a large file is bounded by the sandbox's disk rather than by client memory.

```mermaid
flowchart LR
  c["client.upload_file (new)"] --> f["POST /api/forward/... (unchanged)"]
  f --> u["POST /api/tools/file/upload (new)"]
  u --> w["FileManager.write_chunk (new)"] --> disk[("file in sandbox")]
  disk --> r["FileManager.read_chunk (new)"] --> d["POST /api/tools/file/download (new)"]
  d --> f2["forwarding, JSON text (unchanged)"] --> c2["client.download_file (new)"]
  old["base64 via bash tool (was: only option)"] -.->|replaced| u
```

## How to verify

```
uv run pytest -m unit unit-tests/test_file_transfer.py
```

- `unit-tests/test_file_transfer.py` — chunk primitives, both tool-service actions, and the client loops against an in-memory sandbox. Every payload is deliberately non-UTF-8, so any hop that decoded it fails the comparison.
- `e2e-tests/test_file_transfer.py` — the same round trip through a real orchestrator, which is the hop the feature exists for. **Not run locally** (no cluster); collected only.

Full suite on this branch: **1192 passed, 2 skipped**; docs site builds.

Resolves: JBRes-10676 (partially — #6)
