### PR TITLE
[JBRes-10676] SDK: typed HTTP errors and opt-in tracing (stack 3/8)

### DIFF
--- a/client/src/idegym/client/__init__.py
+++ b/client/src/idegym/client/__init__.py
@@ -1,6 +1,16 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from idegym.client.client import IdeGYMClient
+from idegym.client.exceptions import (
+    IdeGYMAuthError,
+    IdeGYMBadRequestError,
+    IdeGYMBusyError,
+    IdeGYMCancelledError,
+    IdeGYMHTTPError,
+    IdeGYMNotFoundError,
+    IdeGYMServerError,
+    IdeGYMTimeoutError,
+)
 
 try:
     __version__ = version("idegym-client")
@@ -11,6 +21,14 @@ if __version__ == "0.0.0.dev0":
     __version__ = "latest"
 
 __all__ = (
+    "IdeGYMAuthError",
+    "IdeGYMBadRequestError",
+    "IdeGYMBusyError",
+    "IdeGYMCancelledError",
     "IdeGYMClient",
+    "IdeGYMHTTPError",
+    "IdeGYMNotFoundError",
+    "IdeGYMServerError",
+    "IdeGYMTimeoutError",
     "__version__",
 )

--- a/client/src/idegym/client/client.py
+++ b/client/src/idegym/client/client.py
@@ -37,6 +37,7 @@ from idegym.api.pod_spec import (
 )
 from idegym.api.resources import KubernetesResources
 from idegym.api.type import KubernetesNodeSelector, KubernetesObjectName, OCIImageName
+from idegym.client.exceptions import http_error
 from idegym.client.operations.clients import ClientOperations
 from idegym.client.operations.forwarding import ForwardingOperations
 from idegym.client.operations.jobs import JobOperations
@@ -362,7 +363,8 @@ class IdeGYMClient:
         """
         Start an IdeGYM server and return an :class:`IdeGYMServer` handle.
 
-        Raises ``RuntimeError`` if the orchestrator returns an error response.
+        Raises an :class:`~idegym.client.exceptions.IdeGYMHTTPError` subclass if the orchestrator
+        returns an error response.
         Prefer :meth:`with_server` for automatic cleanup.
         """
         logger.info(f"Starting IdeGYM server: name={server_name}, image={image_tag}")
@@ -392,8 +394,11 @@ class IdeGYMClient:
         )
 
         if isinstance(server_response, ErrorResponse):
-            # Branching on a response union, not validating an argument's type — RuntimeError is correct.
-            raise RuntimeError(f"Failed to start server: {server_response.model_dump()}")  # noqa: TRY004
+            raise http_error(
+                f"Failed to start server: {server_response.model_dump()}",
+                status_code=server_response.status_code,
+                body=server_response.body,
+            )
         elif isinstance(server_response, StartServerResponse) and server_response.server_id:
             return IdeGYMServer(
                 server_id=server_response.server_id,

--- a/client/src/idegym/client/client.py
+++ b/client/src/idegym/client/client.py
@@ -91,7 +91,8 @@ class IdeGYMClient:
             heartbeat_interval_in_seconds: Interval between heartbeat requests.
             request_timeout_in_seconds: Default timeout for every HTTP request.
             otel_config: OpenTelemetry configuration for tracing. Falls back to ``IDEGYM_OTEL_*``
-                environment variables when not provided.
+                environment variables when not provided. Tracing stays off unless an endpoint is
+                configured, either here or through ``IDEGYM_OTEL_TRACING_ENDPOINT``.
         """
         if orchestrator_url == "idegym.test":
             orchestrator_url = f"http://{orchestrator_url}"
@@ -120,10 +121,12 @@ class IdeGYMClient:
             ),
         )
 
+        # Tracing is opt-in: with no endpoint the exporter is never built, so a caller who
+        # does not know about OTEL cannot end up shipping telemetry off their infrastructure.
         otel_config = otel_config or OTELConfig(
             service_name=env.get("IDEGYM_OTEL_SERVICE_NAME", generate_service_name()),
             tracing=TracingConfig(
-                endpoint=env.get("IDEGYM_OTEL_TRACING_ENDPOINT", "https://tempo.labs.jb.gg/v1/traces"),
+                endpoint=env.get("IDEGYM_OTEL_TRACING_ENDPOINT", "").strip() or None,
                 timeout=int(env.get("IDEGYM_OTEL_TRACING_TIMEOUT", "10")),
                 auth=BasicAuth(
                     username=env.get("IDEGYM_OTEL_TRACING_AUTH_USERNAME"),

--- a/client/src/idegym/client/exceptions.py
+++ b/client/src/idegym/client/exceptions.py
@@ -1,0 +1,116 @@
+"""Typed failures for IdeGYM SDK calls.
+
+A retry policy has to tell "the sandbox is gone" from "the control plane is busy" from "the
+command timed out". Every failure used to arrive as a plain ``RuntimeError`` whose message
+embedded the status, which left callers parsing message text that changes whenever the format
+does. These exceptions carry the status code and the response body as attributes instead.
+
+They subclass ``RuntimeError`` as well as ``IdeGYMException`` so that code written against the
+old behaviour — including ``except RuntimeError`` around a client call — keeps working, and the
+messages are unchanged for the same reason.
+"""
+
+from http import HTTPStatus
+from typing import Optional
+
+from idegym.api.exceptions import IdeGYMException
+
+
+class IdeGYMHTTPError(IdeGYMException, RuntimeError):
+    """A call to the orchestrator, or to a server through it, failed.
+
+    ``status_code`` is the HTTP status the failure carried. It is ``None`` when the request
+    never produced one — a client-side timeout, for instance.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: Optional[int] = None,
+        body: Optional[str] = None,
+        method: Optional[str] = None,
+        url: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+        self.body = body
+        self.method = method
+        self.url = url
+
+
+class IdeGYMBadRequestError(IdeGYMHTTPError):
+    """The request was rejected as malformed or invalid. Retrying it unchanged will not help."""
+
+
+class IdeGYMAuthError(IdeGYMHTTPError):
+    """Credentials were missing, wrong, or insufficient for the resource."""
+
+
+class IdeGYMNotFoundError(IdeGYMHTTPError):
+    """The addressed client, server, or operation does not exist any more.
+
+    Also raised for ``410 Gone``, which is what the orchestrator returns when it cannot reach
+    the pod: from the caller's side the sandbox is equally gone either way.
+    """
+
+
+class IdeGYMTimeoutError(IdeGYMHTTPError):
+    """The call did not complete in time. Safe to retry if the operation is idempotent."""
+
+
+class IdeGYMBusyError(IdeGYMHTTPError):
+    """The control plane is rate-limiting or temporarily out of capacity. Retry with backoff."""
+
+
+class IdeGYMCancelledError(IdeGYMHTTPError):
+    """The operation was cancelled before it finished, usually by a disconnect."""
+
+
+class IdeGYMServerError(IdeGYMHTTPError):
+    """The orchestrator or the sandbox failed while handling the request."""
+
+
+# 499 is nginx's non-standard "client closed request"; the orchestrator reuses it for a
+# cancelled background operation, so it has no HTTPStatus member to name it by.
+_CLIENT_CLOSED_REQUEST = 499
+
+_ERROR_BY_STATUS: dict[int, type[IdeGYMHTTPError]] = {
+    HTTPStatus.BAD_REQUEST: IdeGYMBadRequestError,
+    HTTPStatus.UNPROCESSABLE_ENTITY: IdeGYMBadRequestError,
+    HTTPStatus.UNAUTHORIZED: IdeGYMAuthError,
+    HTTPStatus.FORBIDDEN: IdeGYMAuthError,
+    HTTPStatus.NOT_FOUND: IdeGYMNotFoundError,
+    HTTPStatus.GONE: IdeGYMNotFoundError,
+    HTTPStatus.REQUEST_TIMEOUT: IdeGYMTimeoutError,
+    HTTPStatus.GATEWAY_TIMEOUT: IdeGYMTimeoutError,
+    HTTPStatus.TOO_MANY_REQUESTS: IdeGYMBusyError,
+    HTTPStatus.SERVICE_UNAVAILABLE: IdeGYMBusyError,
+    _CLIENT_CLOSED_REQUEST: IdeGYMCancelledError,
+}
+
+
+def error_class_for_status(status_code: Optional[int]) -> type[IdeGYMHTTPError]:
+    """Pick the exception type for a status code, falling back by class of status."""
+    if status_code is None:
+        return IdeGYMHTTPError
+    if (specific := _ERROR_BY_STATUS.get(status_code)) is not None:
+        return specific
+    if status_code >= HTTPStatus.INTERNAL_SERVER_ERROR:
+        return IdeGYMServerError
+    if status_code >= HTTPStatus.BAD_REQUEST:
+        return IdeGYMBadRequestError
+    return IdeGYMHTTPError
+
+
+def http_error(
+    message: str,
+    *,
+    status_code: Optional[int] = None,
+    body: Optional[str] = None,
+    method: Optional[str] = None,
+    url: Optional[str] = None,
+) -> IdeGYMHTTPError:
+    """Build the most specific exception for ``status_code``, ready to raise."""
+    return error_class_for_status(status_code)(message, status_code=status_code, body=body, method=method, url=url)

--- a/client/src/idegym/client/operations/forwarding.py
+++ b/client/src/idegym/client/operations/forwarding.py
@@ -7,6 +7,7 @@ from idegym.api.exceptions import InspectionsNotReadyException
 from idegym.api.orchestrator.operations import ForwardRequestResponse
 from idegym.api.orchestrator.servers import ErrorResponse
 from idegym.api.paths import API_BASE_PATH
+from idegym.client.exceptions import http_error
 from idegym.client.operations.utils import HTTPUtils, PollingConfig
 from pydantic import BaseModel
 
@@ -56,5 +57,12 @@ class ForwardingOperations:
             if response.status_code == HTTPStatus.TOO_EARLY.value:
                 raise InspectionsNotReadyException()
 
-            # Branching on a response union, not validating an argument's type — RuntimeError is correct.
-            raise RuntimeError(f"Failed to forward request {method} {url}: {response.model_dump()}")  # noqa: TRY004
+            # The message is deliberately unchanged: it predates the typed exceptions and
+            # callers parse it. New code should read `status_code` and `body` instead.
+            raise http_error(
+                f"Failed to forward request {method} {url}: {response.model_dump()}",
+                status_code=response.status_code,
+                body=response.body,
+                method=method,
+                url=url,
+            )

--- a/client/src/idegym/client/operations/utils.py
+++ b/client/src/idegym/client/operations/utils.py
@@ -6,11 +6,12 @@ from json import JSONDecodeError, loads
 from typing import Any, Optional, TypeVar
 from uuid import UUID
 
-from httpx import AsyncClient, HTTPStatusError
+from httpx import AsyncClient, HTTPStatusError, TimeoutException
 from idegym.api.orchestrator.operations import (
     AsyncOperationStatus,
     AsyncOperationStatusResponse,
 )
+from idegym.client.exceptions import IdeGYMTimeoutError, http_error
 from idegym.utils.logging import get_logger
 from pydantic import BaseModel, Field
 
@@ -122,7 +123,14 @@ class HTTPUtils:
             logger.warning(f"Request cancelled: url={url}")
             raise
 
+        except TimeoutException as ex:
+            message = f"Request timed out: url={url} error='{ex}'"
+            logger.error(message)
+            raise IdeGYMTimeoutError(message, method=method, url=url)
+
         except HTTPStatusError as ex:
+            # The message is deliberately unchanged: it predates the typed exceptions and
+            # callers parse it. New code should read `status_code` and `body` instead.
             message = (
                 f"Request failed: url={url} "
                 f"status={ex.response.status_code} "
@@ -130,7 +138,13 @@ class HTTPUtils:
                 f"data='{ex.response.text}'"
             )
             logger.error(message)
-            raise RuntimeError(message)
+            raise http_error(
+                message,
+                status_code=ex.response.status_code,
+                body=ex.response.text,
+                method=method,
+                url=url,
+            )
 
         except JSONDecodeError:
             logger.exception(f"Failed to parse JSON response: url={url} data={response.text!r}")

--- a/unit-tests/test_client_exceptions.py
+++ b/unit-tests/test_client_exceptions.py
@@ -1,0 +1,132 @@
+"""Typed HTTP failures raised by the client.
+
+Two things are pinned here: the mapping from status code to exception type, which is what a
+retry policy branches on, and the fact that the change stayed backwards compatible — the
+messages and the ``RuntimeError`` base are what existing callers already depend on.
+"""
+
+import httpx
+import pytest
+from idegym.api.exceptions import IdeGYMException
+from idegym.api.orchestrator.servers import ErrorResponse
+from idegym.client.exceptions import (
+    IdeGYMAuthError,
+    IdeGYMBadRequestError,
+    IdeGYMBusyError,
+    IdeGYMCancelledError,
+    IdeGYMHTTPError,
+    IdeGYMNotFoundError,
+    IdeGYMServerError,
+    IdeGYMTimeoutError,
+    error_class_for_status,
+    http_error,
+)
+from idegym.client.operations.forwarding import ForwardingOperations
+from idegym.client.operations.utils import HTTPUtils
+
+
+def _utils(handler) -> HTTPUtils:
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport, base_url="http://idegym.test")
+    return HTTPUtils(http_client=client, current_namespace="idegym", current_client_id=None)
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected"),
+    [
+        (400, IdeGYMBadRequestError),
+        (422, IdeGYMBadRequestError),
+        (401, IdeGYMAuthError),
+        (403, IdeGYMAuthError),
+        (404, IdeGYMNotFoundError),
+        (410, IdeGYMNotFoundError),
+        (408, IdeGYMTimeoutError),
+        (504, IdeGYMTimeoutError),
+        (429, IdeGYMBusyError),
+        (503, IdeGYMBusyError),
+        (499, IdeGYMCancelledError),
+        (500, IdeGYMServerError),
+        (502, IdeGYMServerError),
+        (418, IdeGYMBadRequestError),
+        (None, IdeGYMHTTPError),
+    ],
+)
+def test_status_code_selects_the_exception_type(status_code, expected) -> None:
+    assert error_class_for_status(status_code) is expected
+
+
+def test_every_typed_error_stays_catchable_as_before() -> None:
+    error = http_error("boom", status_code=404, body="gone", method="GET", url="/api/x")
+
+    assert isinstance(error, IdeGYMNotFoundError)
+    assert isinstance(error, IdeGYMHTTPError)
+    assert isinstance(error, IdeGYMException)
+    assert isinstance(error, RuntimeError)
+    assert (error.status_code, error.body, error.method, error.url) == (404, "gone", "GET", "/api/x")
+    assert str(error) == "boom"
+
+
+async def test_make_request_raises_the_typed_error_with_the_original_message() -> None:
+    utils = _utils(lambda request: httpx.Response(429, text="slow down"))
+
+    with pytest.raises(IdeGYMBusyError) as caught:
+        await utils.make_request("GET", "/api/idegym-servers")
+
+    assert caught.value.status_code == 429
+    assert caught.value.body == "slow down"
+    assert caught.value.url == "/api/idegym-servers"
+    assert "Request failed: url=/api/idegym-servers status=429" in str(caught.value)
+
+
+async def test_make_request_reports_a_client_side_timeout_as_a_timeout() -> None:
+    def time_out(request):
+        raise httpx.ReadTimeout("read timed out", request=request)
+
+    utils = _utils(time_out)
+
+    with pytest.raises(IdeGYMTimeoutError) as caught:
+        await utils.make_request("GET", "/api/idegym-servers")
+
+    assert caught.value.status_code is None
+
+
+async def test_a_gone_sandbox_is_distinguishable_from_a_busy_control_plane() -> None:
+    gone = _utils(lambda request: httpx.Response(410, text="pod unreachable"))
+    busy = _utils(lambda request: httpx.Response(429, text="quota"))
+
+    with pytest.raises(IdeGYMNotFoundError):
+        await gone.make_request("GET", "/api/idegym-servers/1/capabilities")
+    with pytest.raises(IdeGYMBusyError):
+        await busy.make_request("POST", "/api/idegym-servers")
+
+
+async def test_forwarding_failure_carries_the_forwarded_status_and_body(mocker) -> None:
+    utils = mocker.MagicMock()
+    utils.validate_client_id.side_effect = lambda client_id: client_id
+    utils.make_request = mocker.AsyncMock(return_value={"async_operation_id": 5})
+    utils.parse_response.side_effect = lambda response_raw, model_class: model_class.model_validate(response_raw)
+    utils.wait_for_async_operation_to_end = mocker.AsyncMock(
+        return_value=ErrorResponse(status_code=404, body="server 9 not found")
+    )
+    operations = ForwardingOperations(utils=utils)
+
+    with pytest.raises(IdeGYMNotFoundError) as caught:
+        await operations.forward_request("POST", 9, "tools/bash", client_id="c")
+
+    assert caught.value.status_code == 404
+    assert caught.value.body == "server 9 not found"
+    assert "Failed to forward request POST" in str(caught.value)
+
+
+async def test_start_server_failure_is_typed(mocker) -> None:
+    from idegym.client.client import IdeGYMClient
+
+    client = IdeGYMClient.__new__(IdeGYMClient)
+    client._utils = mocker.MagicMock(current_client_id="c")
+    client.server = mocker.MagicMock()
+    client.server.start_server = mocker.AsyncMock(return_value=ErrorResponse(status_code=503, body="no capacity"))
+
+    with pytest.raises(IdeGYMBusyError) as caught:
+        await client.start_server(image_tag="registry.test/env:latest")
+
+    assert caught.value.status_code == 503

--- a/unit-tests/test_client_tracing.py
+++ b/unit-tests/test_client_tracing.py
@@ -1,0 +1,72 @@
+"""Tracing is opt-in.
+
+The failure this guards against is silent: a client built with no OTEL configuration used to
+export spans to a hardcoded remote collector, which nobody sees until they look at egress.
+"""
+
+import pytest
+from idegym.api.auth import BasicAuth
+from idegym.api.config import OTELConfig, TracingConfig
+from idegym.client.client import IdeGYMClient
+
+CREDENTIALS = {"IDEGYM_AUTH_USERNAME": "user", "IDEGYM_AUTH_PASSWORD": "secret"}
+
+
+@pytest.fixture
+def instrumented(mocker):
+    """Capture the config the client hands to ``instrument`` without touching OTEL itself."""
+    return mocker.patch("idegym.client.client.instrument")
+
+
+def _set_environment(monkeypatch, **values) -> None:
+    for name in (
+        "IDEGYM_OTEL_TRACING_ENDPOINT",
+        "IDEGYM_OTEL_SERVICE_NAME",
+        "IDEGYM_OTEL_TRACING_TIMEOUT",
+        "IDEGYM_OTEL_TRACING_AUTH_USERNAME",
+        "IDEGYM_OTEL_TRACING_AUTH_PASSWORD",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    for name, value in {**CREDENTIALS, **values}.items():
+        monkeypatch.setenv(name, value)
+
+
+def test_tracing_is_off_without_any_configuration(monkeypatch, instrumented) -> None:
+    _set_environment(monkeypatch)
+
+    IdeGYMClient(orchestrator_url="idegym.test", name="c", namespace="idegym")
+
+    config = instrumented.call_args.kwargs["config"]
+    assert config.tracing.endpoint is None
+    assert config.tracing.enabled is False
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_a_blank_endpoint_variable_does_not_enable_tracing(monkeypatch, instrumented, blank) -> None:
+    _set_environment(monkeypatch, IDEGYM_OTEL_TRACING_ENDPOINT=blank)
+
+    IdeGYMClient(orchestrator_url="idegym.test", name="c", namespace="idegym")
+
+    assert instrumented.call_args.kwargs["config"].tracing.enabled is False
+
+
+def test_an_endpoint_from_the_environment_enables_tracing(monkeypatch, instrumented) -> None:
+    _set_environment(monkeypatch, IDEGYM_OTEL_TRACING_ENDPOINT="https://collector.internal/v1/traces")
+
+    IdeGYMClient(orchestrator_url="idegym.test", name="c", namespace="idegym")
+
+    config = instrumented.call_args.kwargs["config"]
+    assert config.tracing.enabled is True
+    assert str(config.tracing.endpoint) == "https://collector.internal/v1/traces"
+
+
+def test_an_explicit_config_still_wins(monkeypatch, instrumented) -> None:
+    _set_environment(monkeypatch, IDEGYM_OTEL_TRACING_ENDPOINT="https://ignored.example/v1/traces")
+    explicit = OTELConfig(
+        service_name="explicit",
+        tracing=TracingConfig(endpoint="https://chosen.internal/v1/traces", auth=BasicAuth()),
+    )
+
+    IdeGYMClient(orchestrator_url="idegym.test", name="c", namespace="idegym", otel_config=explicit)
+
+    assert instrumented.call_args.kwargs["config"] is explicit

--- a/website/docs/reference/client.md
+++ b/website/docs/reference/client.md
@@ -494,17 +494,40 @@ env_client = MyOpenEnvClient(base_url=url)
 
 ## Error Handling
 
-All client methods raise `RuntimeError` on failure (server start failed, build job failed, etc.).
-HTTP errors from the orchestrator are surfaced as exceptions with the response details included in
-the message.
+An HTTP failure raises a subclass of `IdeGYMHTTPError`, chosen by status code. The exception
+carries `status_code`, `body`, `method` and `url` as attributes, so a retry policy can branch on
+the failure instead of parsing the message.
 
 ```python
+from idegym.client import IdeGYMBusyError, IdeGYMHTTPError, IdeGYMNotFoundError
+
 try:
-    async with client.with_server(image_tag="nonexistent:latest") as server:
+    async with client.with_server(image_tag="registry.example.com/my-env:latest") as server:
         ...
-except RuntimeError as e:
-    print(f"Failed: {e}")
+except IdeGYMNotFoundError:
+    ...  # the sandbox is gone — start a new one
+except IdeGYMBusyError as e:
+    ...  # the control plane is rate-limiting — back off and retry
+except IdeGYMHTTPError as e:
+    print(f"Failed with {e.status_code}: {e.body}")
 ```
+
+| Exception | Statuses | What it means for a retry |
+|-----------|----------|---------------------------|
+| `IdeGYMBadRequestError` | 400, 422, other 4xx | The request is wrong; retrying it unchanged will not help |
+| `IdeGYMAuthError` | 401, 403 | Credentials are missing, wrong, or insufficient |
+| `IdeGYMNotFoundError` | 404, 410 | The client, server, or operation is gone — including a pod the orchestrator can no longer reach |
+| `IdeGYMTimeoutError` | 408, 504, client-side timeout | Safe to retry if the operation is idempotent |
+| `IdeGYMBusyError` | 429, 503 | Rate-limited or out of capacity; retry with backoff |
+| `IdeGYMCancelledError` | 499 | Cancelled before finishing, usually by a disconnect |
+| `IdeGYMServerError` | 5xx | The orchestrator or the sandbox failed |
+
+All of them subclass `IdeGYMHTTPError`, which subclasses both `IdeGYMException` and
+`RuntimeError`, and the message text is unchanged from before the typed exceptions existed — so
+an existing `except RuntimeError` still catches everything it used to.
+
+A `IdeGYMTimeoutError` with `status_code is None` is a client-side timeout: the request never
+reached a status. That is the case to distinguish from a 504, where the orchestrator answered.
 
 ---
 

--- a/website/docs/reference/client.md
+++ b/website/docs/reference/client.md
@@ -485,10 +485,33 @@ env_client = MyOpenEnvClient(base_url=url)
 | `IDEGYM_AUTH_USERNAME` | Orchestrator username | — |
 | `IDEGYM_AUTH_PASSWORD` | Orchestrator password | — |
 | `IDEGYM_OTEL_SERVICE_NAME` | OpenTelemetry service name for traces | auto-generated |
-| `IDEGYM_OTEL_TRACING_ENDPOINT` | OTLP trace export endpoint | JetBrains internal Tempo |
+| `IDEGYM_OTEL_TRACING_ENDPOINT` | OTLP trace export endpoint | — (tracing off) |
 | `IDEGYM_OTEL_TRACING_TIMEOUT` | Trace export timeout in seconds | `10` |
 | `IDEGYM_OTEL_TRACING_AUTH_USERNAME` | Trace export auth username | — |
 | `IDEGYM_OTEL_TRACING_AUTH_PASSWORD` | Trace export auth password | — |
+
+### Tracing
+
+Tracing is off unless you give it an endpoint — there is no default collector, so a client
+constructed with no OpenTelemetry configuration exports nothing. Turn it on with the environment
+variable above, or with an explicit config:
+
+```python
+from idegym.api.config import OTELConfig, TracingConfig
+
+client = IdeGYMClient(
+    orchestrator_url="https://idegym.yourdomain.com",
+    name="my-training-run",
+    namespace="idegym",
+    otel_config=OTELConfig(
+        service_name="my-training-run",
+        tracing=TracingConfig(endpoint="https://collector.internal/v1/traces"),
+    ),
+)
+```
+
+An explicit `otel_config` is used as given; the environment variables are only consulted when
+none is passed.
 
 ---
 

--- a/website/docs/reference/http_error_codes.md
+++ b/website/docs/reference/http_error_codes.md
@@ -5,6 +5,19 @@ the **Orchestrator** (Kubernetes orchestration service) and the **IdeGYM Server*
 
 ---
 
+## Reading these codes from the Python client
+
+The client turns each of these into a typed exception rather than a bare `RuntimeError`:
+`IdeGYMNotFoundError` for 404 and 410, `IdeGYMBusyError` for 429 and 503, `IdeGYMTimeoutError`
+for 408 and 504, and so on. The status and body are attributes on the exception. The full
+mapping is in [Client Library — Error Handling](client.md#error-handling).
+
+A failure reported through an async operation's `result.status_code` is mapped the same way, so
+`429` on a background start-server operation raises the same `IdeGYMBusyError` as `429` on the
+synchronous request would.
+
+---
+
 ## Async Operation Pattern (Orchestrator)
 
 Most orchestrator endpoints that trigger long-running work are **asynchronous**: the HTTP response is returned immediately with `202 Accepted` and an `operation_id`, while the actual work runs in the background. The final outcome is retrieved by polling:


### PR DESCRIPTION
**Stack 3/8** — #289 ← #290 ← **#291** ← #292 ← #293 ← #294 ← #295 ← #296 (merge in order, oldest first).
Base: `…-02-…`. Branch: `vladimir.poliakov/jbres-10676-03-…`.

Improvements #11 and #15 of JBRes-10676 — the two High-priority SDK items. Grouped because both change what `IdeGYMClient` does by default. #11 is the foundation the later SDK PRs build on (#6 in this stack raises these exceptions), so it sits low.

## What changed

**Typed HTTP errors** (#11, flagged in the ticket as the single highest-value SDK change). Every HTTP failure surfaced as a plain `RuntimeError` whose message embedded the status in one of two shapes, so a caller distinguishing "the sandbox is gone" from "the control plane is busy" from "the command timed out" had to parse that message — and would break the day either string changed.

`IdeGYMHTTPError` now carries `status_code`, `body`, `method` and `url`, with subclasses for the distinctions retry policy turns on: `IdeGYMNotFoundError` (404 **and** 410 — a pod the orchestrator cannot reach is gone from the caller's side), `IdeGYMBusyError` (429, 503), `IdeGYMTimeoutError` (408, 504, and a client-side httpx timeout), plus Auth, BadRequest, Cancelled and ServerError.

**Tracing is opt-in** (#15). Constructing a client without an explicit `OTELConfig` fell back to a hardcoded remote collector, exporting telemetry off the user's infrastructure silently. The endpoint now comes only from `IDEGYM_OTEL_TRACING_ENDPOINT` or an explicit config.

## Backwards compatibility

Deliberately non-breaking: the exceptions also subclass `RuntimeError` and the message text is byte-identical, so existing `except RuntimeError` keeps working. There is a test for exactly that.

## How to verify

```
uv run pytest -m unit unit-tests/test_client_exceptions.py unit-tests/test_client_tracing.py
```

- `test_client_exceptions.py` — every mapped status plus both fallbacks; two raise sites driven through a real `httpx.MockTransport`; the compatibility properties above.
- `test_client_tracing.py` — default-off, both ways to turn it on, and a blank env var (pydantic rejects it as a URL, so it must read as "unset").

Full suite on this branch: **1218 passed, 2 skipped**; docs site builds.

Resolves: JBRes-10676 (partially — #11, #15)
