### PR TITLE
[JBRes-10676] Bash tool: per-command context, script size, init semantics (stack 4/8)

### DIFF
--- a/api/src/idegym/api/tools/bash.py
+++ b/api/src/idegym/api/tools/bash.py
@@ -7,6 +7,31 @@ DEFAULT_MAX_OUTPUT_BYTES = 1024 * 1024
 
 class BashCommandRequest(BaseModel):
     command: str = Field(description="Command to execute as a bash script")
+    cwd: Optional[str] = Field(
+        default=None,
+        description=(
+            "Working directory for the command. Defaults to the server's project directory. "
+            "A relative path is resolved against it."
+        ),
+        examples=["/root/work", "src"],
+    )
+    env: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Environment variables added to the command's environment, overriding inherited ones. "
+            "Prefer this over writing 'export' lines into the script: the values never enter the "
+            "command text, so they are not logged with it."
+        ),
+        examples=[{"CI": "1"}],
+    )
+    user: Optional[str] = Field(
+        default=None,
+        description=(
+            "Run the command as this user via 'runuser'. Requires the server to run as root; "
+            "leave unset to run as the server's own user."
+        ),
+        examples=["devuser"],
+    )
     timeout: float = Field(default=600.0, description="Timeout for the command execution in seconds")
     graceful_termination_timeout: float = Field(
         default=2.0, description="Timeout in seconds for graceful process termination"

--- a/backend-utils/src/idegym/backend/utils/bash_executor.py
+++ b/backend-utils/src/idegym/backend/utils/bash_executor.py
@@ -1,8 +1,9 @@
 import asyncio
+import contextlib
 import os
 import re
-import shlex
 import signal
+import tempfile
 from asyncio.subprocess import Process
 from collections import deque
 from importlib.resources import files
@@ -186,16 +187,43 @@ def _command_excerpt(command: str) -> str:
     return _log_excerpt(_redact_exports(command))
 
 
-def _shell_invocation(bash_command: str, user: Optional[str]) -> str:
-    """Build the shell line that runs the script, optionally dropping to another user.
+def _process_argv(script_path: str, user: Optional[str]) -> list[str]:
+    """Build the argv that runs the script file, optionally dropping to another user.
 
     ``runuser`` is used rather than ``su`` because it does not authenticate and keeps the
     caller's environment, which is what the ``env`` argument has already been merged into.
     """
-    invocation = f"bash -c {shlex.quote(bash_command)}"
+    invocation = ["bash", script_path]
     if user is None:
         return invocation
-    return f"runuser --preserve-environment -u {shlex.quote(user)} -- {invocation}"
+    return ["runuser", "--preserve-environment", "-u", user, "--", *invocation]
+
+
+def _write_script(script: str, readable_by_other_user: bool) -> str:
+    """Write the script to a temp file and return its path.
+
+    Passing the script as a ``bash -c`` argument capped it at Linux's ``MAX_ARG_STRLEN``
+    (128 KiB), and an oversized script failed with a bare ``E2BIG`` rather than anything a
+    caller could act on. A file has no such ceiling, and unlike feeding bash on stdin it leaves
+    the command's own stdin alone — a script read from stdin is consumed incrementally, so any
+    command inside it that reads stdin would swallow the rest of the script.
+    """
+    descriptor, path = tempfile.mkstemp(prefix="idegym-bash-", suffix=".sh")
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(script)
+        if readable_by_other_user:
+            # mkstemp creates 0600, which the target user of `runuser` could not read.
+            os.chmod(path, 0o644)
+    except BaseException:
+        _remove_script(path)
+        raise
+    return path
+
+
+def _remove_script(path: str) -> None:
+    with contextlib.suppress(OSError):
+        os.unlink(path)
 
 
 def _signal_process_group(process: Process, requested_signal: signal.Signals) -> bool:
@@ -295,7 +323,8 @@ class BashExecutor:
         to run as root, since it shells out through ``runuser``.
 
         Output is returned verbatim unless ``strip_output`` asks for surrounding
-        whitespace to be trimmed.
+        whitespace to be trimmed. The script itself is written to a temp file and run as
+        ``bash <file>``, so its size is not capped by the kernel's argument limit.
 
         Returns a tuple of (stdout, stderr, exit_code).
         Raises BashCommandExecutionTimeoutError if the timeout is exceeded.
@@ -313,14 +342,19 @@ class BashExecutor:
         logger.debug("Bash command", command=_command_excerpt(command))
 
         bash_command = f"source {__BASH_INIT_FILEPATH__} && {command}"
-        process = await asyncio.create_subprocess_shell(
-            cmd=_shell_invocation(bash_command, user),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=working_directory,
-            preexec_fn=os.setsid,
-            env=cleanenv() | (env or {}),
-        )
+        script_path = await asyncio.to_thread(_write_script, bash_command, user is not None)
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *_process_argv(script_path, user),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=working_directory,
+                preexec_fn=os.setsid,
+                env=cleanenv() | (env or {}),
+            )
+        except BaseException:
+            _remove_script(script_path)
+            raise
 
         communication_task = asyncio.create_task(
             _communicate_bounded(process, stdout_collector, stderr_collector),
@@ -345,6 +379,7 @@ class BashExecutor:
             await _finish_output_drain(process, communication_task)
             _close_output_pipes(process)
             await _reap_process(process)
+            _remove_script(script_path)
 
         if timed_out:
             logger.warning(

--- a/backend-utils/src/idegym/backend/utils/bash_executor.py
+++ b/backend-utils/src/idegym/backend/utils/bash_executor.py
@@ -186,6 +186,18 @@ def _command_excerpt(command: str) -> str:
     return _log_excerpt(_redact_exports(command))
 
 
+def _shell_invocation(bash_command: str, user: Optional[str]) -> str:
+    """Build the shell line that runs the script, optionally dropping to another user.
+
+    ``runuser`` is used rather than ``su`` because it does not authenticate and keeps the
+    caller's environment, which is what the ``env`` argument has already been merged into.
+    """
+    invocation = f"bash -c {shlex.quote(bash_command)}"
+    if user is None:
+        return invocation
+    return f"runuser --preserve-environment -u {shlex.quote(user)} -- {invocation}"
+
+
 def _signal_process_group(process: Process, requested_signal: signal.Signals) -> bool:
     """Signal a process group, tolerating races after its leader has exited."""
     try:
@@ -245,6 +257,19 @@ class BashExecutor:
     def __init__(self, working_directory: Optional[Path] = None):
         self.working_directory = working_directory
 
+    def resolve_working_directory(self, cwd: Optional[str]) -> Optional[Path]:
+        """Resolve a per-command ``cwd`` against the executor's directory.
+
+        An absolute path is used as given; a relative one is taken from the executor's working
+        directory, which is the server's project root.
+        """
+        if cwd is None:
+            return self.working_directory
+        requested = Path(cwd)
+        if requested.is_absolute() or self.working_directory is None:
+            return requested
+        return self.working_directory / requested
+
     async def execute_bash_command(
         self,
         command: str,
@@ -252,6 +277,9 @@ class BashExecutor:
         graceful_termination_timeout: float = 2.0,
         max_output_bytes: Optional[int] = None,
         strip_output: bool = False,
+        cwd: Optional[str] = None,
+        env: Optional[dict[str, str]] = None,
+        user: Optional[str] = None,
     ) -> tuple[str, str, int]:
         """
         Execute a bash command asynchronously.
@@ -261,6 +289,11 @@ class BashExecutor:
         variables stripped. The process is started in its own process group so the
         entire group can be killed on timeout.
 
+        ``cwd``, ``env`` and ``user`` give a caller per-command context without having to
+        synthesize it into the script — an environment variable set through ``env`` never
+        enters the command text, so it is not logged with it. ``user`` requires the executor
+        to run as root, since it shells out through ``runuser``.
+
         Output is returned verbatim unless ``strip_output`` asks for surrounding
         whitespace to be trimmed.
 
@@ -269,17 +302,24 @@ class BashExecutor:
         """
         stdout_collector = _OutputCollector(max_output_bytes)
         stderr_collector = _OutputCollector(max_output_bytes)
-        logger.info("Executing bash command", command_chars=len(command))
+        working_directory = self.resolve_working_directory(cwd)
+        logger.info(
+            "Executing bash command",
+            command_chars=len(command),
+            cwd=str(working_directory) if working_directory else None,
+            env_names=sorted(env) if env else [],
+            user=user,
+        )
         logger.debug("Bash command", command=_command_excerpt(command))
 
         bash_command = f"source {__BASH_INIT_FILEPATH__} && {command}"
         process = await asyncio.create_subprocess_shell(
-            cmd=f"bash -c {shlex.quote(bash_command)}",
+            cmd=_shell_invocation(bash_command, user),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            cwd=self.working_directory,
+            cwd=working_directory,
             preexec_fn=os.setsid,
-            env=cleanenv(),
+            env=cleanenv() | (env or {}),
         )
 
         communication_task = asyncio.create_task(

--- a/backend-utils/src/idegym/backend/utils/bash_executor.py
+++ b/backend-utils/src/idegym/backend/utils/bash_executor.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import os
 import re
+import shlex
 import signal
 import tempfile
 from asyncio.subprocess import Process
@@ -187,6 +188,18 @@ def _command_excerpt(command: str) -> str:
     return _log_excerpt(_redact_exports(command))
 
 
+def _prepend_bash_integration(command: str) -> str:
+    """Prefix the caller's script with the bundled bash-integration init.
+
+    The two are joined with ``;`` rather than ``&&``. With ``&&`` only the script's *first*
+    statement was conditional on the init succeeding and the rest ran regardless, so
+    ``a; b; c`` did not mean what the caller wrote — clients defended by wrapping every script
+    in a brace group. Keeping the prefix on the same line also keeps the caller's line numbers
+    intact, so a bash error still points at the right line of their script.
+    """
+    return f"source {shlex.quote(str(__BASH_INIT_FILEPATH__))} ; {command}"
+
+
 def _process_argv(script_path: str, user: Optional[str]) -> list[str]:
     """Build the argv that runs the script file, optionally dropping to another user.
 
@@ -341,7 +354,7 @@ class BashExecutor:
         )
         logger.debug("Bash command", command=_command_excerpt(command))
 
-        bash_command = f"source {__BASH_INIT_FILEPATH__} && {command}"
+        bash_command = _prepend_bash_integration(command)
         script_path = await asyncio.to_thread(_write_script, bash_command, user is not None)
         try:
             process = await asyncio.create_subprocess_exec(

--- a/backend-utils/src/idegym/backend/utils/bash_executor.py
+++ b/backend-utils/src/idegym/backend/utils/bash_executor.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import os
+import pwd
 import re
 import shlex
 import signal
@@ -34,6 +35,14 @@ class BashExecutorError(Exception):
 
 class BashCommandExecutionTimeoutError(BashExecutorError):
     pass
+
+
+class BashExecutorUnknownUserError(BashExecutorError):
+    """The requested ``user`` does not exist in the container."""
+
+
+class BashExecutorWorkingDirectoryError(BashExecutorError):
+    """The requested ``cwd`` does not exist or is not a directory."""
 
 
 class _OutputCollector:
@@ -197,7 +206,28 @@ def _prepend_bash_integration(command: str) -> str:
     in a brace group. Keeping the prefix on the same line also keeps the caller's line numbers
     intact, so a bash error still points at the right line of their script.
     """
-    return f"source {shlex.quote(str(__BASH_INIT_FILEPATH__))} ; {command}"
+    init = shlex.quote(str(__BASH_INIT_FILEPATH__))
+    # `;` rather than `&&` so the caller's script keeps its own semantics, but the init is still
+    # guarded: without this a missing or unreadable init left the script running in an
+    # unconfigured shell and failing later as "command not found", with the caller's exit code.
+    guard = f'source {init} || {{ echo "IdeGYM: failed to source the bash integration at {init}" >&2 ; exit 1 ; }}'
+    return f"{guard} ; {command}"
+
+
+def _user_environment(user: str) -> dict[str, str]:
+    """Identity variables for ``user``, which ``runuser --preserve-environment`` does not set.
+
+    ``-p`` keeps the whole environment on purpose — that is how the caller's ``env`` and the
+    cleaned server environment survive — but it therefore also keeps *root's* ``HOME``. The
+    bundled init sources ``~/.bashrc``, so without these the script would load root's shell
+    configuration and miss anything installed in the target user's home (SDKMAN, pyenv, nvm),
+    while writes to ``~`` would land in a directory the user cannot write.
+    """
+    try:
+        entry = pwd.getpwnam(user)
+    except KeyError:
+        raise BashExecutorUnknownUserError(f"No such user in this container: {user}") from None
+    return {"HOME": entry.pw_dir, "USER": user, "LOGNAME": user, "SHELL": entry.pw_shell or "/bin/bash"}
 
 
 def _process_argv(script_path: str, user: Optional[str]) -> list[str]:
@@ -227,6 +257,10 @@ def _write_script(script: str, readable_by_other_user: bool) -> str:
             handle.write(script)
         if readable_by_other_user:
             # mkstemp creates 0600, which the target user of `runuser` could not read.
+            # TODO: 0644 also exposes the script to any co-tenant process for the duration of the
+            # run, which matters because callers do put credentials in scripts (see
+            # `_redact_exports`). Prefer `os.chown(path, uid, -1)` with 0600, or a directory only
+            # the target user can traverse.
             os.chmod(path, 0o644)
     except BaseException:
         _remove_script(path)
@@ -307,9 +341,15 @@ class BashExecutor:
         if cwd is None:
             return self.working_directory
         requested = Path(cwd)
-        if requested.is_absolute() or self.working_directory is None:
-            return requested
-        return self.working_directory / requested
+        if not requested.is_absolute() and self.working_directory is not None:
+            requested = self.working_directory / requested
+        # `cwd` is caller-supplied, so check it here: otherwise the child's chdir fails and
+        # asyncio raises a bare FileNotFoundError that the router turns into a 500.
+        if not requested.is_dir():
+            raise BashExecutorWorkingDirectoryError(
+                f"Working directory does not exist or is not a directory: {requested}"
+            )
+        return requested
 
     async def execute_bash_command(
         self,
@@ -345,6 +385,8 @@ class BashExecutor:
         stdout_collector = _OutputCollector(max_output_bytes)
         stderr_collector = _OutputCollector(max_output_bytes)
         working_directory = self.resolve_working_directory(cwd)
+        # The user's identity goes on before the caller's env, so an explicit HOME still wins.
+        environment = cleanenv() | (_user_environment(user) if user is not None else {}) | (env or {})
         logger.info(
             "Executing bash command",
             command_chars=len(command),
@@ -363,7 +405,7 @@ class BashExecutor:
                 stderr=asyncio.subprocess.PIPE,
                 cwd=working_directory,
                 preexec_fn=os.setsid,
-                env=cleanenv() | (env or {}),
+                env=environment,
             )
         except BaseException:
             _remove_script(script_path)

--- a/client/src/idegym/client/operations/tools.py
+++ b/client/src/idegym/client/operations/tools.py
@@ -25,12 +25,20 @@ class ToolsOperations:
         request_timeout: Optional[int] = None,
         polling_config: PollingConfig = PollingConfig(),
         max_output_bytes: Optional[int] = DEFAULT_MAX_OUTPUT_BYTES,
+        strip_output: bool = False,
+        cwd: Optional[str] = None,
+        env: Optional[dict[str, str]] = None,
+        user: Optional[str] = None,
     ) -> BashCommandResponse:
         request = BashCommandRequest(
             command=script,
             timeout=command_timeout,
             graceful_termination_timeout=graceful_termination_timeout,
             max_output_bytes=max_output_bytes,
+            strip_output=strip_output,
+            cwd=cwd,
+            env=env or {},
+            user=user,
         )
         response_raw = await self._forward.forward_request(
             "POST", server_id, ToolsPath.BASH, request, client_id, request_timeout, polling_config

--- a/client/src/idegym/client/server.py
+++ b/client/src/idegym/client/server.py
@@ -192,8 +192,16 @@ class IdeGYMServer:
         request_timeout: Optional[int] = None,
         polling_config: Optional[PollingConfig] = None,
         max_output_bytes: Optional[int] = DEFAULT_MAX_OUTPUT_BYTES,
+        strip_output: bool = False,
+        cwd: Optional[str] = None,
+        env: Optional[dict[str, str]] = None,
+        user: Optional[str] = None,
     ) -> BashCommandResponse:
-        """Execute a bash script on the server."""
+        """Execute a bash script on the server.
+
+        ``cwd``, ``env`` and ``user`` set per-command context without synthesizing it into the
+        script, which keeps values out of the command log and off the script's size budget.
+        """
         return await self.tools.execute_bash(
             server_id=self.server_id,
             script=script,
@@ -203,6 +211,10 @@ class IdeGYMServer:
             request_timeout=request_timeout,
             polling_config=polling_config or self.polling_config,
             max_output_bytes=max_output_bytes,
+            strip_output=strip_output,
+            cwd=cwd,
+            env=env,
+            user=user,
         )
 
     async def create_file(

--- a/integration-tests/docker_tests/test_bash_executor.py
+++ b/integration-tests/docker_tests/test_bash_executor.py
@@ -80,14 +80,43 @@ class TestBashExecutor:
         assert exit_code != 0
 
     @pytest.mark.asyncio
-    async def test_empty_command(self):
-        """Test executing an empty command."""
+    async def test_empty_command_is_a_no_op(self):
+        """An empty script runs the init prefix and nothing else, rather than failing to parse."""
         executor = BashExecutor()
         stdout, stderr, exit_code = await executor.execute_bash_command("")
 
         assert stdout == ""
-        assert "syntax error" in stderr.lower()
+        assert stderr == ""
+        assert exit_code == 0
+
+    @pytest.mark.asyncio
+    async def test_every_statement_runs_not_just_the_first(self):
+        """`source ... && a; b; c` used to make only `a` conditional; all three must run now."""
+        executor = BashExecutor()
+
+        stdout, _stderr, exit_code = await executor.execute_bash_command(
+            "printf a; printf b; printf c", strip_output=True
+        )
+
+        assert (stdout, exit_code) == ("abc", 0)
+
+    @pytest.mark.asyncio
+    async def test_a_failing_first_statement_still_short_circuits_the_callers_own_chain(self):
+        """The caller's own `&&` must keep working — only the injected one is gone."""
+        executor = BashExecutor()
+
+        stdout, _stderr, exit_code = await executor.execute_bash_command("false && printf 'unreachable'")
+
+        assert stdout == ""
         assert exit_code != 0
+
+    @pytest.mark.asyncio
+    async def test_bash_reports_errors_at_the_callers_own_line_numbers(self):
+        executor = BashExecutor()
+
+        _stdout, stderr, _exit_code = await executor.execute_bash_command("true\ntrue\nthis-command-does-not-exist")
+
+        assert "line 3" in stderr
 
     @pytest.mark.asyncio
     async def test_execute_command_with_working_directory(self):

--- a/integration-tests/docker_tests/test_bash_executor.py
+++ b/integration-tests/docker_tests/test_bash_executor.py
@@ -137,6 +137,46 @@ class TestBashExecutor:
         assert exit_code == 3
 
     @pytest.mark.asyncio
+    async def test_cwd_overrides_the_executor_directory_for_one_command(self, tmp_path):
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        executor = BashExecutor(working_directory=tmp_path)
+
+        relative, _stderr, _code = await executor.execute_bash_command("pwd", cwd="nested", strip_output=True)
+        absolute, _stderr, _code = await executor.execute_bash_command("pwd", cwd=str(nested), strip_output=True)
+        default, _stderr, _code = await executor.execute_bash_command("pwd", strip_output=True)
+
+        assert Path(relative).resolve() == nested.resolve()
+        assert Path(absolute).resolve() == nested.resolve()
+        assert Path(default).resolve() == tmp_path.resolve()
+
+    @pytest.mark.asyncio
+    async def test_env_reaches_the_command_without_entering_the_script(self):
+        executor = BashExecutor()
+
+        with capture_logs() as logs:
+            stdout, _stderr, exit_code = await executor.execute_bash_command(
+                'printf "%s" "$SECRET_TOKEN"', env={"SECRET_TOKEN": "s3cr3t"}
+            )
+
+        assert (stdout, exit_code) == ("s3cr3t", 0)
+        command_log = next(entry for entry in logs if entry["event"] == "Bash command")
+        assert "s3cr3t" not in command_log["command"]
+        start_log = next(entry for entry in logs if entry["event"] == "Executing bash command")
+        assert start_log["env_names"] == ["SECRET_TOKEN"]
+
+    @pytest.mark.asyncio
+    async def test_env_overrides_an_inherited_variable(self, monkeypatch):
+        monkeypatch.setenv("IDEGYM_TEST_MARKER", "inherited")
+        executor = BashExecutor()
+
+        stdout, _stderr, _code = await executor.execute_bash_command(
+            'printf "%s" "$IDEGYM_TEST_MARKER"', env={"IDEGYM_TEST_MARKER": "overridden"}
+        )
+
+        assert stdout == "overridden"
+
+    @pytest.mark.asyncio
     async def test_command_with_timeout(self):
         """Test that a command with a timeout raises the appropriate exception."""
         executor = BashExecutor()

--- a/integration-tests/docker_tests/test_bash_executor.py
+++ b/integration-tests/docker_tests/test_bash_executor.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import psutil
 import pytest
+from idegym.backend.utils import bash_executor as bash_executor_module
 from idegym.backend.utils.bash_executor import BashCommandExecutionTimeoutError, BashExecutor
 from structlog.testing import capture_logs
 
@@ -175,6 +176,62 @@ class TestBashExecutor:
         )
 
         assert stdout == "overridden"
+
+    @pytest.mark.asyncio
+    async def test_a_script_far_larger_than_the_argument_limit_runs(self):
+        """MAX_ARG_STRLEN is 128 KiB; this script is well past it and used to fail with E2BIG."""
+        executor = BashExecutor()
+        payload = "x" * (512 * 1024)
+        script = f'PAYLOAD={payload}\nprintf "%s" "${{#PAYLOAD}}"'
+
+        stdout, stderr, exit_code = await executor.execute_bash_command(script)
+
+        assert (stdout, exit_code) == (str(len(payload)), 0)
+        assert stderr == ""
+
+    @pytest.mark.asyncio
+    async def test_the_script_file_is_removed_after_the_command(self, monkeypatch):
+        executor = BashExecutor()
+        written: list[str] = []
+        original = bash_executor_module._write_script
+
+        def record(script, readable_by_other_user):
+            path = original(script, readable_by_other_user)
+            written.append(path)
+            return path
+
+        monkeypatch.setattr(bash_executor_module, "_write_script", record)
+
+        await executor.execute_bash_command("true")
+
+        assert written and not Path(written[0]).exists()
+
+    @pytest.mark.asyncio
+    async def test_the_script_file_is_removed_after_a_timeout(self, monkeypatch):
+        executor = BashExecutor()
+        written: list[str] = []
+        original = bash_executor_module._write_script
+
+        def record(script, readable_by_other_user):
+            path = original(script, readable_by_other_user)
+            written.append(path)
+            return path
+
+        monkeypatch.setattr(bash_executor_module, "_write_script", record)
+
+        with pytest.raises(BashCommandExecutionTimeoutError):
+            await executor.execute_bash_command("sleep 10", timeout=0.2, graceful_termination_timeout=0.1)
+
+        assert written and not Path(written[0]).exists()
+
+    @pytest.mark.asyncio
+    async def test_a_command_reading_stdin_does_not_consume_the_rest_of_the_script(self):
+        """A script fed to bash on stdin would be eaten by `cat`; running it from a file is safe."""
+        executor = BashExecutor()
+
+        stdout, _stderr, exit_code = await executor.execute_bash_command("cat > /dev/null\nprintf 'still here'")
+
+        assert (stdout, exit_code) == ("still here", 0)
 
     @pytest.mark.asyncio
     async def test_command_with_timeout(self):

--- a/integration-tests/docker_tests/test_bash_executor_in_docker.py
+++ b/integration-tests/docker_tests/test_bash_executor_in_docker.py
@@ -37,7 +37,7 @@ class TestBashExecutorInDocker:
 
     def test_empty_command_in_docker(self):
         """Test executing an empty command in a Docker container."""
-        self._run_test("test_empty_command")
+        self._run_test("test_empty_command_is_a_no_op")
 
     def test_execute_command_with_working_directory_in_docker(self):
         """Test executing a command with a working directory in a Docker container."""

--- a/integration-tests/test_tool_service.py
+++ b/integration-tests/test_tool_service.py
@@ -40,6 +40,9 @@ class TestToolService(IsolatedAsyncioTestCase):
             graceful_termination_timeout=3.0,
             max_output_bytes=None,
             strip_output=False,
+            cwd=None,
+            env=None,
+            user=None,
         )
 
     async def test_execute_bash_tool_forwards_strip_request(self):
@@ -75,6 +78,9 @@ class TestToolService(IsolatedAsyncioTestCase):
                 "graceful_termination_timeout": 2.0,
                 "max_output_bytes": None,
                 "strip_output": False,
+                "cwd": None,
+                "env": {},
+                "user": None,
             },
         )
 

--- a/tools/src/idegym/tools/router.py
+++ b/tools/src/idegym/tools/router.py
@@ -22,6 +22,10 @@ from idegym.api.tools.file import (
     UploadFileChunkRequest,
     UploadFileChunkResponse,
 )
+from idegym.backend.utils.bash_executor import (
+    BashExecutorUnknownUserError,
+    BashExecutorWorkingDirectoryError,
+)
 from idegym.tools.tool_service import FileToolActionName, ToolName, ToolService
 
 router = APIRouter()
@@ -37,19 +41,23 @@ async def execute_bash_script(
     request: BashCommandRequest,
     service: ToolService = Depends(_get_tool_service),
 ):
-    stdout, stderr, exit_code = await service.execute_tool(
-        tool_name=ToolName.BASH,
-        parameters={
-            "command": request.command,
-            "timeout": request.timeout,
-            "graceful_termination_timeout": request.graceful_termination_timeout,
-            "max_output_bytes": request.max_output_bytes,
-            "strip_output": request.strip_output,
-            "cwd": request.cwd,
-            "env": request.env,
-            "user": request.user,
-        },
-    )
+    try:
+        stdout, stderr, exit_code = await service.execute_tool(
+            tool_name=ToolName.BASH,
+            parameters={
+                "command": request.command,
+                "timeout": request.timeout,
+                "graceful_termination_timeout": request.graceful_termination_timeout,
+                "max_output_bytes": request.max_output_bytes,
+                "strip_output": request.strip_output,
+                "cwd": request.cwd,
+                "env": request.env,
+                "user": request.user,
+            },
+        )
+    # `cwd` and `user` are caller-supplied, so a bad value is a bad request, not a server fault.
+    except (BashExecutorWorkingDirectoryError, BashExecutorUnknownUserError) as ex:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(ex)) from ex
 
     return BashCommandResponse(stdout=stdout, stderr=stderr, exit_code=exit_code)
 

--- a/tools/src/idegym/tools/router.py
+++ b/tools/src/idegym/tools/router.py
@@ -45,6 +45,9 @@ async def execute_bash_script(
             "graceful_termination_timeout": request.graceful_termination_timeout,
             "max_output_bytes": request.max_output_bytes,
             "strip_output": request.strip_output,
+            "cwd": request.cwd,
+            "env": request.env,
+            "user": request.user,
         },
     )
 

--- a/tools/src/idegym/tools/tool_service.py
+++ b/tools/src/idegym/tools/tool_service.py
@@ -46,6 +46,9 @@ class ToolService:
                     graceful_termination_timeout=graceful_termination_timeout,
                     max_output_bytes=max_output_bytes,
                     strip_output=strip_output,
+                    cwd=parameters.get("cwd"),
+                    env=parameters.get("env"),
+                    user=parameters.get("user"),
                 )
                 return stdout, stderr, exit_code
             case ToolName.FILE:

--- a/unit-tests/test_bash_executor.py
+++ b/unit-tests/test_bash_executor.py
@@ -1,4 +1,5 @@
 import asyncio
+from pathlib import Path
 
 import pytest
 from idegym.api.tools.bash import BashCommandRequest
@@ -173,3 +174,46 @@ def test_bash_request_supports_explicit_unlimited_output() -> None:
 
 def test_bash_request_keeps_output_verbatim_by_default() -> None:
     assert BashCommandRequest(command="echo hello").strip_output is False
+
+
+# --------------------------------------------------------------------------------------
+# Per-command context: cwd, env, user
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("base", "requested", "expected"),
+    [
+        (None, None, None),
+        (Path("/root/work"), None, Path("/root/work")),
+        (Path("/root/work"), "src", Path("/root/work/src")),
+        (Path("/root/work"), "/etc", Path("/etc")),
+        (None, "src", Path("src")),
+    ],
+)
+def test_resolve_working_directory_treats_relative_paths_as_project_relative(base, requested, expected) -> None:
+    executor = bash_executor.BashExecutor(working_directory=base)
+
+    assert executor.resolve_working_directory(requested) == expected
+
+
+def test_shell_invocation_runs_directly_when_no_user_is_requested() -> None:
+    assert bash_executor._shell_invocation("echo hi", None) == "bash -c 'echo hi'"
+
+
+def test_shell_invocation_drops_to_a_user_without_re_authenticating() -> None:
+    invocation = bash_executor._shell_invocation("echo hi", "devuser")
+
+    assert invocation == "runuser --preserve-environment -u devuser -- bash -c 'echo hi'"
+
+
+def test_shell_invocation_quotes_a_hostile_user_name() -> None:
+    invocation = bash_executor._shell_invocation("echo hi", "dev; rm -rf /")
+
+    assert "'dev; rm -rf /'" in invocation
+
+
+def test_bash_request_defaults_to_no_per_command_context() -> None:
+    request = BashCommandRequest(command="echo hello")
+
+    assert (request.cwd, request.env, request.user) == (None, {}, None)

--- a/unit-tests/test_bash_executor.py
+++ b/unit-tests/test_bash_executor.py
@@ -197,20 +197,43 @@ def test_resolve_working_directory_treats_relative_paths_as_project_relative(bas
     assert executor.resolve_working_directory(requested) == expected
 
 
-def test_shell_invocation_runs_directly_when_no_user_is_requested() -> None:
-    assert bash_executor._shell_invocation("echo hi", None) == "bash -c 'echo hi'"
+def test_argv_runs_the_script_file_directly_when_no_user_is_requested() -> None:
+    assert bash_executor._process_argv("/tmp/script.sh", None) == ["bash", "/tmp/script.sh"]
 
 
-def test_shell_invocation_drops_to_a_user_without_re_authenticating() -> None:
-    invocation = bash_executor._shell_invocation("echo hi", "devuser")
+def test_argv_drops_to_a_user_without_re_authenticating() -> None:
+    argv = bash_executor._process_argv("/tmp/script.sh", "devuser")
 
-    assert invocation == "runuser --preserve-environment -u devuser -- bash -c 'echo hi'"
+    assert argv == ["runuser", "--preserve-environment", "-u", "devuser", "--", "bash", "/tmp/script.sh"]
 
 
-def test_shell_invocation_quotes_a_hostile_user_name() -> None:
-    invocation = bash_executor._shell_invocation("echo hi", "dev; rm -rf /")
+def test_argv_passes_a_hostile_user_name_as_one_argument() -> None:
+    """No shell parses this argv, so a name with metacharacters is inert rather than quoted."""
+    argv = bash_executor._process_argv("/tmp/script.sh", "dev; rm -rf /")
 
-    assert "'dev; rm -rf /'" in invocation
+    assert "dev; rm -rf /" in argv
+
+
+def test_script_file_is_private_unless_another_user_must_read_it() -> None:
+    private = bash_executor._write_script("echo hi", readable_by_other_user=False)
+    shared = bash_executor._write_script("echo hi", readable_by_other_user=True)
+
+    try:
+        assert Path(private).read_text() == "echo hi"
+        assert Path(private).stat().st_mode & 0o777 == 0o600
+        assert Path(shared).stat().st_mode & 0o777 == 0o644
+    finally:
+        bash_executor._remove_script(private)
+        bash_executor._remove_script(shared)
+
+
+def test_removing_the_script_twice_is_not_an_error() -> None:
+    path = bash_executor._write_script("echo hi", readable_by_other_user=False)
+
+    bash_executor._remove_script(path)
+    bash_executor._remove_script(path)
+
+    assert not Path(path).exists()
 
 
 def test_bash_request_defaults_to_no_per_command_context() -> None:

--- a/unit-tests/test_bash_executor.py
+++ b/unit-tests/test_bash_executor.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from pathlib import Path
 
 import pytest
@@ -182,19 +183,68 @@ def test_bash_request_keeps_output_verbatim_by_default() -> None:
 
 
 @pytest.mark.parametrize(
-    ("base", "requested", "expected"),
+    ("with_base", "requested", "expected"),
     [
-        (None, None, None),
-        (Path("/root/work"), None, Path("/root/work")),
-        (Path("/root/work"), "src", Path("/root/work/src")),
-        (Path("/root/work"), "/etc", Path("/etc")),
-        (None, "src", Path("src")),
+        # An unset cwd passes the executor's own directory through untouched, unvalidated.
+        (False, None, None),
+        (True, None, "base"),
+        # A relative path is project-relative; an absolute one is taken as given.
+        (True, "src", "base/src"),
+        (True, "@absolute", "absolute"),
+        (False, "@absolute", "absolute"),
     ],
 )
-def test_resolve_working_directory_treats_relative_paths_as_project_relative(base, requested, expected) -> None:
-    executor = bash_executor.BashExecutor(working_directory=base)
+def test_resolve_working_directory_treats_relative_paths_as_project_relative(
+    tmp_path, with_base, requested, expected
+) -> None:
+    base = tmp_path / "base"
+    (base / "src").mkdir(parents=True)
+    absolute = tmp_path / "absolute"
+    absolute.mkdir()
+    if requested == "@absolute":
+        requested = str(absolute)
 
-    assert executor.resolve_working_directory(requested) == expected
+    executor = bash_executor.BashExecutor(working_directory=base if with_base else None)
+    resolved = executor.resolve_working_directory(requested)
+
+    assert resolved == (None if expected is None else tmp_path / expected)
+
+
+def test_resolve_working_directory_rejects_a_path_that_is_not_a_directory(tmp_path) -> None:
+    """A caller-supplied cwd must fail as a bad request, not as the child's bare chdir error."""
+    executor = bash_executor.BashExecutor(working_directory=tmp_path)
+    (tmp_path / "a-file").write_text("")
+
+    with pytest.raises(bash_executor.BashExecutorWorkingDirectoryError, match="does not exist"):
+        executor.resolve_working_directory("absent")
+    with pytest.raises(bash_executor.BashExecutorWorkingDirectoryError, match="not a directory"):
+        executor.resolve_working_directory("a-file")
+
+
+def test_user_environment_carries_the_target_users_identity() -> None:
+    """`runuser -p` keeps root's HOME, so the init would source the wrong user's rc file."""
+    import pwd as pwd_module
+
+    current = pwd_module.getpwuid(os.getuid())
+    environment = bash_executor._user_environment(current.pw_name)
+
+    assert environment["HOME"] == current.pw_dir
+    assert environment["USER"] == current.pw_name
+    assert environment["LOGNAME"] == current.pw_name
+
+
+def test_user_environment_rejects_an_unknown_user() -> None:
+    with pytest.raises(bash_executor.BashExecutorUnknownUserError, match="No such user"):
+        bash_executor._user_environment("definitely-not-a-user-here")
+
+
+def test_init_prefix_aborts_when_the_integration_cannot_be_sourced() -> None:
+    """Init failure used to be undetectable: the script ran on regardless with its own status."""
+    prefixed = bash_executor._prepend_bash_integration("echo hi")
+
+    assert "|| {" in prefixed
+    assert "exit 1" in prefixed
+    assert prefixed.endswith(" ; echo hi")
 
 
 def test_argv_runs_the_script_file_directly_when_no_user_is_requested() -> None:

--- a/unit-tests/test_bash_executor.py
+++ b/unit-tests/test_bash_executor.py
@@ -240,3 +240,17 @@ def test_bash_request_defaults_to_no_per_command_context() -> None:
     request = BashCommandRequest(command="echo hello")
 
     assert (request.cwd, request.env, request.user) == (None, {}, None)
+
+
+def test_init_prefix_uses_a_separator_so_it_cannot_gate_the_script() -> None:
+    prefixed = bash_executor._prepend_bash_integration("a; b; c")
+
+    assert "&&" not in prefixed
+    assert prefixed.endswith(" ; a; b; c")
+    assert "\n" not in prefixed
+
+
+def test_init_prefix_quotes_the_init_path() -> None:
+    prefixed = bash_executor._prepend_bash_integration("true")
+
+    assert str(bash_executor.__BASH_INIT_FILEPATH__) in prefixed.replace("'", "")

--- a/unit-tests/test_client.py
+++ b/unit-tests/test_client.py
@@ -100,7 +100,22 @@ def test_execute_bash_propagates_unlimited_output_without_shifting_existing_argu
         request_timeout=45,
         polling_config=polling,
         max_output_bytes=None,
+        strip_output=False,
+        cwd=None,
+        env=None,
+        user=None,
     )
+
+
+def test_execute_bash_forwards_per_command_context():
+    server = _make_server(server_id=7)
+    server.tools = MagicMock()
+    server.tools.execute_bash = AsyncMock(return_value=MagicMock())
+
+    asyncio.run(server.execute_bash("pwd", cwd="src", env={"CI": "1"}, user="devuser"))
+
+    call = server.tools.execute_bash.await_args.kwargs
+    assert (call["cwd"], call["env"], call["user"]) == ("src", {"CI": "1"}, "devuser")
 
 
 def test_tools_operations_puts_output_limit_in_forwarded_request():

--- a/unit-tests/test_orchestrator_mcp.py
+++ b/unit-tests/test_orchestrator_mcp.py
@@ -168,7 +168,7 @@ async def test_run_bash_command_mcp_tool_calls_forwarding_endpoint(mocker):
     assert isinstance(endpoint.await_args.kwargs["headers"], Headers)
     assert endpoint.await_args.kwargs["headers"]["content-type"] == "application/json"
     assert endpoint.await_args.kwargs["body"] == (
-        '{"command":"echo hello","timeout":600.0,"graceful_termination_timeout":2.0,"max_output_bytes":1048576,"strip_output":false}'
+        '{"command":"echo hello","cwd":null,"env":{},"user":null,"timeout":600.0,"graceful_termination_timeout":2.0,"max_output_bytes":1048576,"strip_output":false}'
     )
     assert result.structured_content == {"async_operation_id": 43}
 

--- a/website/docs/reference/client.md
+++ b/website/docs/reference/client.md
@@ -194,9 +194,9 @@ want surrounding whitespace trimmed.
 ```python
 result = await server.execute_bash(
     "python -m pytest -q",
-    cwd="tests",                  # relative paths resolve against the project directory
+    cwd="tests",  # relative paths resolve against the project directory
     env={"PYTHONHASHSEED": "0"},  # merged over the server's cleaned environment
-    user="devuser",               # requires the server to run as root
+    user="devuser",  # requires the server to run as root
 )
 ```
 

--- a/website/docs/reference/client.md
+++ b/website/docs/reference/client.md
@@ -185,7 +185,24 @@ print(result.stderr)  # ""
 
 The default retains the beginning and end of stdout and stderr independently and inserts a
 marker when bytes are omitted. Use `max_output_bytes=None` when a caller must parse complete,
-trusted output.
+trusted output. Output is returned verbatim within that window; pass `strip_output=True` if you
+want surrounding whitespace trimmed.
+
+`cwd`, `env` and `user` set per-command context, so you do not have to build `cd`, `export` and
+`runuser` into the script yourself:
+
+```python
+result = await server.execute_bash(
+    "python -m pytest -q",
+    cwd="tests",                  # relative paths resolve against the project directory
+    env={"PYTHONHASHSEED": "0"},  # merged over the server's cleaned environment
+    user="devuser",               # requires the server to run as root
+)
+```
+
+Values passed through `env` never enter the command text, so they are not written to the
+command log — prefer it to an `export` line for anything sensitive. See
+[Tools — Per-command context](tools.md#per-command-context).
 
 ### `reset_project(...)`
 

--- a/website/docs/reference/tools.md
+++ b/website/docs/reference/tools.md
@@ -50,6 +50,19 @@ is outside the configured limit. Set `max_output_bytes` to `null` only when comp
 is required and its size is trusted. IdeGYM still drains all produced output until the command
 finishes or reaches its execution timeout so subprocess pipes cannot deadlock.
 
+#### How the script is run
+
+The script is written to a temp file inside the container and executed as `bash <file>`. There
+is no practical size limit: passing it as a `bash -c` argument used to cap it at the kernel's
+`MAX_ARG_STRLEN` of 128 KiB, and an oversized script failed with a bare `E2BIG`.
+
+A file rather than bash's stdin is deliberate. A script read from stdin is consumed
+incrementally, so any command inside it that reads stdin — `cat`, `read`, an interactive
+installer — would swallow the rest of the script. Running from a file leaves the command's own
+stdin alone.
+
+The temp file is removed once the command finishes, including when it times out.
+
 #### Per-command context
 
 Without `cwd`, `env` and `user` the only way to set context is to write it into the script —

--- a/website/docs/reference/tools.md
+++ b/website/docs/reference/tools.md
@@ -63,6 +63,12 @@ stdin alone.
 
 The temp file is removed once the command finishes, including when it times out.
 
+Before the script, IdeGYM sources a bundled init file that sets up the shell environment. It is
+joined to your script with `;`, not `&&`, so it cannot change what your script means: every
+statement runs exactly as written, and your own `&&` and `||` behave normally. The prefix stays
+on the same line, so a bash error still reports the line number you wrote. An empty script is a
+no-op that exits 0.
+
 #### Per-command context
 
 Without `cwd`, `env` and `user` the only way to set context is to write it into the script —

--- a/website/docs/reference/tools.md
+++ b/website/docs/reference/tools.md
@@ -59,9 +59,9 @@ have to generate correctly, and which spends the script's own size budget.
 ```python
 result = await server.execute_bash(
     "python -m pytest -q",
-    cwd="tests",                 # relative to the project directory
-    env={"PYTHONHASHSEED": "0"}, # merged over the cleaned environment
-    user="devuser",              # requires the server to run as root
+    cwd="tests",  # relative to the project directory
+    env={"PYTHONHASHSEED": "0"},  # merged over the cleaned environment
+    user="devuser",  # requires the server to run as root
 )
 ```
 

--- a/website/docs/reference/tools.md
+++ b/website/docs/reference/tools.md
@@ -28,6 +28,9 @@ Execute a bash script inside the container.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `command` | string | — | Bash script to execute |
+| `cwd` | string or null | `null` | Working directory; a relative path resolves against the project directory |
+| `env` | object | `{}` | Environment variables added to the command's environment |
+| `user` | string or null | `null` | Run the command as this user via `runuser` |
 | `timeout` | float | 600.0 | Maximum execution time in seconds |
 | `graceful_termination_timeout` | float | 2.0 | Seconds to wait for graceful process exit before SIGKILL |
 | `max_output_bytes` | integer or null | 1048576 | Maximum retained bytes per stream; `null` retains complete output |
@@ -46,6 +49,29 @@ beginning and end and includes a marker with the number of omitted bytes; the ma
 is outside the configured limit. Set `max_output_bytes` to `null` only when complete output
 is required and its size is trusted. IdeGYM still drains all produced output until the command
 finishes or reaches its execution timeout so subprocess pipes cannot deadlock.
+
+#### Per-command context
+
+Without `cwd`, `env` and `user` the only way to set context is to write it into the script —
+`cd -- … || exit 1`, one `export` per variable, a `runuser` wrapper — which every client would
+have to generate correctly, and which spends the script's own size budget.
+
+```python
+result = await server.execute_bash(
+    "python -m pytest -q",
+    cwd="tests",                 # relative to the project directory
+    env={"PYTHONHASHSEED": "0"}, # merged over the cleaned environment
+    user="devuser",              # requires the server to run as root
+)
+```
+
+The environment the command starts from is the server's own, with IdeGYM-internal entries
+stripped; `env` is merged over it, so a name that already exists is overridden. Values passed
+this way never enter the command text, which means they are not written to the command log —
+prefer it to an `export` line for anything sensitive.
+
+`user` runs the script through `runuser --preserve-environment`, so it needs the server
+container to be running as root. Without it the command runs as the server's own user.
 
 #### Output fidelity
 


### PR DESCRIPTION
**Stack 4/8** — #289 ← #290 ← #291 ← **#292** ← #293 ← #294 ← #295 ← #296 (merge in order, oldest first).
Base: `…-03-…`. Branch: `vladimir.poliakov/jbres-10676-04-…`.

Improvements #3, #4 and #5 of JBRes-10676 — the three Medium bash-tool items. Grouped because they all rewrite the same execution path and only make sense read together. Depends on #1 in this stack (same files).

## What changed

**`cwd`, `env` and `user` on the request** (#3). The working directory was fixed per server and the environment cleaned, so every caller synthesized context into the script: `cd -- … || exit 1`, one `export` per variable, a `runuser` wrapper. That is error-prone shell each client reimplements, it puts secrets in the command text, and it spends the script's size budget.

**The script runs from a temp file** (#4). It travelled as one argument to `bash -c`, so `MAX_ARG_STRLEN` (128 KiB) was a hard ceiling and an oversized script failed with a bare `E2BIG`. A file, not bash's stdin, on purpose: a script read from stdin is consumed incrementally, so any command in it that reads stdin swallows the remainder.

**The init prefix no longer rewrites the script** (#5). It was `source <init> && <command>`, so only the *first* statement was conditional on the init and the rest ran regardless — `a; b; c` did not mean what the caller wrote. Now joined with `;`, on the same line so bash still reports the caller's own line numbers.

```mermaid
flowchart TD
  req["BashCommandRequest (+ cwd, env, user)"] --> resolve["resolve_working_directory (new)"]
  resolve --> join["'source init ; cmd' (was: '&&')"]
  join --> write["_write_script: temp file (was: bash -c arg, 128 KiB cap)"]
  write --> argv["bash file, or runuser -u user (new)"]
  argv --> spawn["create_subprocess_exec(cwd, env=cleanenv() | env)"]
  spawn --> cleanup["finally: reap + _remove_script (new)"]
```

## How to verify

```
uv run pytest -m unit unit-tests/test_bash_executor.py
uv run pytest integration-tests/docker_tests/test_bash_executor.py integration-tests/test_tool_service.py
```

Integration proves the parts unit tests cannot: a **512 KiB script runs** (4× the old ceiling), a script whose first command reads stdin still runs its second, `a; b; c` all execute while the caller's own `&&` still short-circuits, and an `env` value never reaches the logged command.

An empty script is now a no-op exiting 0 rather than a syntax error — same change seen from the other side.

Full suite: **1232 passed, 2 skipped**; docs site builds.

Resolves: JBRes-10676 (partially — #3, #4, #5)
