### PR TITLE
[JBRes-10676] Server lifecycle: status, keepalive, listing, reuse reporting (stack 5/8)

### DIFF
--- a/api/src/idegym/api/orchestrator/servers.py
+++ b/api/src/idegym/api/orchestrator/servers.py
@@ -177,6 +177,27 @@ class FinishServerRequest(ServerScopedRequest):
     pass
 
 
+class KeepaliveServerRequest(ServerScopedRequest):
+    """Hold a server against the inactivity reaper for a bounded window."""
+
+    minutes: float = Field(
+        default=15.0,
+        gt=0,
+        le=24 * 60,
+        description=(
+            "How long from now to hold the server, in minutes. Calling again extends the window; "
+            "it is never shortened, so two holders cannot cut each other short."
+        ),
+        examples=[15, 60],
+    )
+
+
+class KeepaliveServerResponse(BaseModel):
+    server_id: int
+    keepalive_until: int = Field(description="Epoch milliseconds until which the server is held", ge=0)
+    minutes: float = Field(description="Minutes from now that 'keepalive_until' corresponds to", ge=0)
+
+
 class RestartServerRequest(ServerScopedRequest):
     server_start_wait_timeout_in_seconds: int = Field(
         default=60, description="Seconds to wait for server readiness after restart", ge=0
@@ -237,6 +258,13 @@ class ServerStatusResponse(BaseModel):
         ge=0,
     )
     idle_seconds: float = Field(description="Seconds since 'last_activity_at'", ge=0)
+    keepalive_until: Optional[int] = Field(
+        default=None,
+        description=(
+            "Epoch milliseconds until which an explicit keepalive holds this server against the "
+            "inactivity reaper, or null when none is in effect"
+        ),
+    )
     pod_phase: Optional[str] = Field(
         default=None, description="Kubernetes phase of the server pod, or null when no pod matches"
     )

--- a/api/src/idegym/api/orchestrator/servers.py
+++ b/api/src/idegym/api/orchestrator/servers.py
@@ -53,7 +53,10 @@ class StartServerRequest(BaseModel):
     )
     server_name: KubernetesObjectName = Field(
         default="default-idegym-server",
-        description="Logical server name used as the Kubernetes resource name prefix and for matching reusable servers",
+        description=(
+            "Logical server name, used as the Kubernetes resource name prefix. It is one of the "
+            "seven fields reuse matches on, not the key: see 'reuse_strategy' for the full set."
+        ),
         examples=["my-server", "echo-env-server"],
     )
     runtime_class_name: Optional[str] = Field(
@@ -135,8 +138,13 @@ class StartServerRequest(BaseModel):
     reuse_strategy: ServerReuseStrategy = Field(
         default=ServerReuseStrategy.RESET,
         description=(
-            "What to do if a server with this name already exists: NONE recreates from scratch, "
-            "RESTART restarts it, RESET resets project state."
+            "Whether to take over an existing server instead of creating one: NONE always creates "
+            "from scratch, RESTART reuses one and restarts its pod, RESET reuses one and resets "
+            "the project state. Reuse runs only for RESTART and RESET, and a candidate must match "
+            "on all seven of: client name, image_tag, runtime_class_name, run_as_root, server_kind, "
+            "server_name (when set), and an availability of FINISHED. A server is FINISHED only "
+            "after finish_server; a client that always calls stop_server leaves its servers STOPPED, "
+            "so reuse never hits. StartServerResponse.reused reports what actually happened."
         ),
     )
     server_kind: ServerKind = Field(
@@ -213,6 +221,14 @@ class StartServerResponse(BaseModel):
     generated_name: Optional[str] = Field(default=None, description="Generated Kubernetes resource name")
     service_name: Optional[str] = Field(default=None, description="Kubernetes Service name for the server")
     image_tag: Optional[str] = Field(default=None)
+    reused: bool = Field(
+        default=False,
+        description=(
+            "True when an existing FINISHED server was taken over rather than a new one created. "
+            "Reuse depends on seven fields matching, so it is easy to configure a request that "
+            "silently never reuses; this reports what happened instead of leaving it to be inferred."
+        ),
+    )
     need_to_reset: bool = Field(default=False, description="True if the reused server requires a project reset")
 
 

--- a/api/src/idegym/api/orchestrator/servers.py
+++ b/api/src/idegym/api/orchestrator/servers.py
@@ -239,6 +239,33 @@ class ServerRequestResponse(BaseModel):
     status: str
 
 
+class ServerSummary(BaseModel):
+    """One row of the server list: what the orchestrator knows without asking Kubernetes.
+
+    Deliberately has no pod fields — listing them would mean one API call per server. Use the
+    status endpoint for the pod view of a single server.
+    """
+
+    server_id: int = Field(description="Numeric IdeGYM server ID")
+    server_name: Optional[str] = Field(default=None, description="Logical server name from the start request")
+    generated_name: str = Field(description="Kubernetes resource name for the server")
+    namespace: str
+    availability: str = Field(description="Availability status recorded by the orchestrator")
+    usable: bool = Field(description="True when the server is in a state that accepts requests")
+    image_tag: Optional[str] = Field(default=None)
+    created_at: int = Field(description="Epoch milliseconds", ge=0)
+    last_activity_at: int = Field(description="Epoch milliseconds", ge=0)
+    keepalive_until: Optional[int] = Field(
+        default=None, description="Epoch milliseconds until which an explicit keepalive holds the server"
+    )
+    details: Optional[str] = Field(default=None, description="Failure reason recorded on a terminal status")
+
+
+class ListServersResponse(BaseModel):
+    client_id: UUID
+    servers: list[ServerSummary] = Field(default_factory=list)
+
+
 class ServerStatusResponse(BaseModel):
     """Everything needed to answer 'is this server usable right now', in one call.
 

--- a/api/src/idegym/api/orchestrator/servers.py
+++ b/api/src/idegym/api/orchestrator/servers.py
@@ -218,6 +218,32 @@ class ServerRequestResponse(BaseModel):
     status: str
 
 
+class ServerStatusResponse(BaseModel):
+    """Everything needed to answer 'is this server usable right now', in one call.
+
+    Reading it does not count as activity, so polling it cannot keep a server alive by accident.
+    """
+
+    server_id: int = Field(description="Numeric IdeGYM server ID")
+    server_name: Optional[str] = Field(default=None, description="Logical server name from the start request")
+    generated_name: str = Field(description="Kubernetes resource name for the server")
+    namespace: str
+    availability: str = Field(description="Availability status recorded by the orchestrator, e.g. ALIVE or CRASHED")
+    usable: bool = Field(description="True when the server is in a state that accepts requests (ALIVE or REUSED)")
+    image_tag: Optional[str] = Field(default=None)
+    created_at: int = Field(description="Epoch milliseconds", ge=0)
+    last_activity_at: int = Field(
+        description="Epoch milliseconds of the last activity the orchestrator recorded for this server",
+        ge=0,
+    )
+    idle_seconds: float = Field(description="Seconds since 'last_activity_at'", ge=0)
+    pod_phase: Optional[str] = Field(
+        default=None, description="Kubernetes phase of the server pod, or null when no pod matches"
+    )
+    pod_ready: bool = Field(default=False, description="True when the pod is Running with all containers ready")
+    details: Optional[str] = Field(default=None, description="Failure reason recorded on a terminal status")
+
+
 class AliveServerInfo(BaseModel):
     id: int = Field(description="Numeric IdeGYM server ID")
     generated_name: str = Field(description="Kubernetes resource name for the server")

--- a/backend-utils/src/idegym/backend/utils/kubernetes_client.py
+++ b/backend-utils/src/idegym/backend/utils/kubernetes_client.py
@@ -721,6 +721,22 @@ async def list_pods(label_selector: str, namespace: str) -> list[V1Pod]:
         return (await core.list_namespaced_pod(namespace=namespace, label_selector=label_selector)).items
 
 
+async def pod_phase_and_readiness(label_selector: str, namespace: str) -> tuple[Optional[str], bool]:
+    """Return the phase of the server's pod and whether every container in it is ready.
+
+    Terminating pods are skipped, so a restart in progress reports the incoming pod rather than
+    the one on its way out. The phase is ``None`` when no pod matches the selector at all.
+    """
+    pods = [pod for pod in await list_pods(label_selector, namespace) if pod.metadata.deletion_timestamp is None]
+    if not pods:
+        return None, False
+
+    pod = pods[0]
+    container_statuses = pod.status.container_statuses or []
+    ready = pod.status.phase == "Running" and bool(container_statuses) and all(c.ready for c in container_statuses)
+    return pod.status.phase, ready
+
+
 async def are_any_pods_alive(label_selector: str, namespace: str) -> bool:
     """Return True if at least one non-terminating Running pod matches the selector."""
 

--- a/charts/idegym/values.yaml
+++ b/charts/idegym/values.yaml
@@ -103,7 +103,7 @@ database:
   # migration must bump it too. The orchestrator refuses to start on a mismatch, and
   # `scripts/rollback.py` reads it back from the target release to pick the downgrade
   # target. See website/docs/reference/database_rollback.md.
-  schemaRevision: "003"
+  schemaRevision: "004"
 
 service:
   type: ClusterIP

--- a/client/src/idegym/client/client.py
+++ b/client/src/idegym/client/client.py
@@ -26,6 +26,7 @@ from idegym.api.orchestrator.servers import (
     ServerActionResponse,
     ServerKind,
     ServerReuseStrategy,
+    ServerSummary,
     SnapshotRef,
     StartServerResponse,
 )
@@ -413,6 +414,16 @@ class IdeGYMClient:
             )
         else:
             raise RuntimeError(f"Unexpected response from server start: {server_response.model_dump()}")
+
+    async def list_servers(self, include_terminal: bool = False) -> list[ServerSummary]:
+        """List the servers this client owns, newest first.
+
+        Scoped to this client's registration, so it answers "what am I holding" — which is what
+        makes cleaning up after a crash possible without cluster access. Terminal servers are
+        excluded unless ``include_terminal`` asks for them.
+        """
+        response = await self.server.list_servers(client_id=self.client_id, include_terminal=include_terminal)
+        return response.servers
 
     async def build_and_push_images(
         self,

--- a/client/src/idegym/client/client.py
+++ b/client/src/idegym/client/client.py
@@ -411,6 +411,7 @@ class IdeGYMClient:
                 namespace=namespace,
                 polling_config=polling_config,
                 server_kind=server_kind,
+                reused=server_response.reused,
             )
         else:
             raise RuntimeError(f"Unexpected response from server start: {server_response.model_dump()}")

--- a/client/src/idegym/client/operations/servers.py
+++ b/client/src/idegym/client/operations/servers.py
@@ -10,6 +10,7 @@ from idegym.api.orchestrator.servers import (
     FinishServerRequest,
     KeepaliveServerRequest,
     KeepaliveServerResponse,
+    ListServersResponse,
     RestartServerRequest,
     ServerActionResponse,
     ServerKind,
@@ -230,6 +231,18 @@ class ServerOperations:
             f"/api/idegym-servers/{server_id}/capabilities?client_id={client_id}",
         )
         return CapabilitiesResponse.model_validate(response_raw)
+
+    async def list_servers(
+        self, client_id: Optional[UUID] = None, include_terminal: bool = False
+    ) -> ListServersResponse:
+        """List the servers this client owns, newest first."""
+        client_id = self._utils.validate_client_id(client_id)
+        response_raw = await self._utils.make_request(
+            "GET",
+            "/api/idegym-servers",
+            params={"client_id": str(client_id), "include_terminal": include_terminal},
+        )
+        return ListServersResponse.model_validate(response_raw)
 
     async def keepalive_server(
         self,

--- a/client/src/idegym/client/operations/servers.py
+++ b/client/src/idegym/client/operations/servers.py
@@ -12,6 +12,7 @@ from idegym.api.orchestrator.servers import (
     ServerActionResponse,
     ServerKind,
     ServerReuseStrategy,
+    ServerStatusResponse,
     SnapshotRef,
     StartServerRequest,
     StartServerResponse,
@@ -227,6 +228,16 @@ class ServerOperations:
             f"/api/idegym-servers/{server_id}/capabilities?client_id={client_id}",
         )
         return CapabilitiesResponse.model_validate(response_raw)
+
+    async def get_server_status(self, server_id: int, client_id: Optional[UUID] = None) -> ServerStatusResponse:
+        """Report the server's availability, pod phase and idle time without touching it."""
+        client_id = self._utils.validate_client_id(client_id)
+        response_raw = await self._utils.make_request(
+            "GET",
+            f"/api/idegym-servers/{server_id}/status",
+            params={"client_id": str(client_id)},
+        )
+        return ServerStatusResponse.model_validate(response_raw)
 
     async def snapshot_server(
         self,

--- a/client/src/idegym/client/operations/servers.py
+++ b/client/src/idegym/client/operations/servers.py
@@ -8,6 +8,8 @@ from idegym.api.capabilities import CapabilitiesResponse
 from idegym.api.orchestrator.servers import (
     ErrorResponse,
     FinishServerRequest,
+    KeepaliveServerRequest,
+    KeepaliveServerResponse,
     RestartServerRequest,
     ServerActionResponse,
     ServerKind,
@@ -228,6 +230,20 @@ class ServerOperations:
             f"/api/idegym-servers/{server_id}/capabilities?client_id={client_id}",
         )
         return CapabilitiesResponse.model_validate(response_raw)
+
+    async def keepalive_server(
+        self,
+        server_id: int,
+        minutes: float = 15.0,
+        client_id: Optional[UUID] = None,
+        namespace: Optional[str] = None,
+    ) -> KeepaliveServerResponse:
+        """Hold the server against the inactivity reaper for the next ``minutes``."""
+        client_id = self._utils.validate_client_id(client_id)
+        namespace = self._utils.validate_namespace(namespace)
+        request = KeepaliveServerRequest(client_id=client_id, namespace=namespace, server_id=server_id, minutes=minutes)
+        response_raw = await self._utils.make_request("POST", "/api/idegym-servers/keepalive", request)
+        return KeepaliveServerResponse.model_validate(response_raw)
 
     async def get_server_status(self, server_id: int, client_id: Optional[UUID] = None) -> ServerStatusResponse:
         """Report the server's availability, pod phase and idle time without touching it."""

--- a/client/src/idegym/client/server.py
+++ b/client/src/idegym/client/server.py
@@ -39,12 +39,16 @@ class IdeGYMServer:
         namespace: Optional[str] = None,
         polling_config: PollingConfig = PollingConfig(),
         server_kind: ServerKind = ServerKind.IDEGYM,
+        reused: bool = False,
     ):
         self.server_id = server_id
         self.client_id = client_id
         self.namespace = namespace
         self.polling_config = polling_config
         self.server_kind = server_kind
+        #: True when the orchestrator took over an existing FINISHED server instead of creating
+        #: one. Reuse turns on seven fields matching, so it is worth checking rather than assuming.
+        self.reused = reused
 
         self._http_utils = http_utils
         self._forwarding: ForwardingOperations = ForwardingOperations(utils=http_utils)

--- a/client/src/idegym/client/server.py
+++ b/client/src/idegym/client/server.py
@@ -7,6 +7,7 @@ from idegym.api.orchestrator.servers import (
     ErrorResponse,
     ServerActionResponse,
     ServerKind,
+    ServerStatusResponse,
 )
 from idegym.api.orchestrator.snapshots import CreateSnapshotResponse
 from idegym.api.project.reset import ResetResult
@@ -135,6 +136,14 @@ class IdeGYMServer:
     async def list_capabilities(self) -> CapabilitiesResponse:
         """Return the list of server plugins loaded in the running container."""
         return await self.server.list_capabilities(server_id=self.server_id, client_id=self.client_id)
+
+    async def status(self) -> ServerStatusResponse:
+        """Report whether this server is usable, and why not when it is not.
+
+        Reading the status does not count as activity, so a poll loop cannot keep the server
+        from being reaped.
+        """
+        return await self.server.get_server_status(server_id=self.server_id, client_id=self.client_id)
 
     async def restart_server(
         self,

--- a/client/src/idegym/client/server.py
+++ b/client/src/idegym/client/server.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from idegym.api.capabilities import CapabilitiesResponse
 from idegym.api.orchestrator.servers import (
     ErrorResponse,
+    KeepaliveServerResponse,
     ServerActionResponse,
     ServerKind,
     ServerStatusResponse,
@@ -136,6 +137,23 @@ class IdeGYMServer:
     async def list_capabilities(self) -> CapabilitiesResponse:
         """Return the list of server plugins loaded in the running container."""
         return await self.server.list_capabilities(server_id=self.server_id, client_id=self.client_id)
+
+    async def keepalive(self, minutes: float = 15.0) -> KeepaliveServerResponse:
+        """Hold this server against the inactivity reaper for the next ``minutes``.
+
+        The watcher reaps on time since the last completed request, which is only a proxy for
+        "somebody is using this" — a sandbox is equally quiet while an agent thinks, a build
+        runs, or a human reads a stack trace. Call this while you still hold the server.
+
+        Calling again extends the window; it is never shortened, so two holders of the same
+        server cannot cut each other short.
+        """
+        return await self.server.keepalive_server(
+            server_id=self.server_id,
+            minutes=minutes,
+            client_id=self.client_id,
+            namespace=self.namespace,
+        )
 
     async def status(self) -> ServerStatusResponse:
         """Report whether this server is usable, and why not when it is not.

--- a/e2e-tests/test_server_lifecycle.py
+++ b/e2e-tests/test_server_lifecycle.py
@@ -97,3 +97,48 @@ async def test_server_lifecycle_with_reuse(test_image, test_id):
 
             result = await new_server.setup_reward(setup_check_script="python --version")
             assert result.status == "success"
+
+
+@pytest.mark.asyncio
+async def test_server_status_reports_a_live_server_and_survives_stopping_it(test_image, test_id):
+    """Status has to answer for a stopped server too — that is the point of a liveness probe."""
+    async with create_http_client(name=f"status-{test_id}", nodes_count=0) as client:
+        server = await client.start_server(
+            image_tag=test_image,
+            server_name=f"status-{test_id}",
+            runtime_class_name="gvisor",
+            run_as_root=True,
+            server_start_wait_timeout_in_seconds=DEFAULT_SERVER_START_TIMEOUT,
+        )
+
+        alive = await server.status()
+        assert alive.usable is True
+        assert alive.availability == "ALIVE"
+        assert alive.pod_phase == "Running"
+        assert alive.pod_ready is True
+        assert alive.server_id == server.server_id
+
+        await client.stop_server(server)
+
+        stopped = await server.status()
+        assert stopped.usable is False
+        assert stopped.availability == "STOPPED"
+
+
+@pytest.mark.asyncio
+async def test_reading_status_does_not_count_as_activity(test_image, test_id):
+    async with (
+        create_http_client(name=f"status-idle-{test_id}", nodes_count=0) as client,
+        client.with_server(
+            image_tag=test_image,
+            server_name=f"status-idle-{test_id}",
+            runtime_class_name="gvisor",
+            run_as_root=True,
+            server_start_wait_timeout_in_seconds=DEFAULT_SERVER_START_TIMEOUT,
+        ) as server,
+    ):
+        first = await server.status()
+        second = await server.status()
+
+        assert second.last_activity_at == first.last_activity_at
+        assert second.idle_seconds >= first.idle_seconds

--- a/e2e-tests/test_server_lifecycle.py
+++ b/e2e-tests/test_server_lifecycle.py
@@ -142,3 +142,34 @@ async def test_reading_status_does_not_count_as_activity(test_image, test_id):
 
         assert second.last_activity_at == first.last_activity_at
         assert second.idle_seconds >= first.idle_seconds
+
+
+@pytest.mark.asyncio
+async def test_client_can_list_the_servers_it_owns(test_image, test_id):
+    """Recovering from a crash means asking the orchestrator what is still ours, without kubectl."""
+    async with (
+        create_http_client(name=f"list-a-{test_id}", nodes_count=0) as client_a,
+        create_http_client(name=f"list-b-{test_id}", nodes_count=0) as client_b,
+    ):
+        assert await client_a.list_servers() == []
+
+        server = await client_a.start_server(
+            image_tag=test_image,
+            server_name=f"list-{test_id}",
+            runtime_class_name="gvisor",
+            run_as_root=True,
+            server_start_wait_timeout_in_seconds=DEFAULT_SERVER_START_TIMEOUT,
+        )
+
+        owned = await client_a.list_servers()
+        assert [s.server_id for s in owned] == [server.server_id]
+        assert owned[0].usable is True
+
+        # Another registration must not see it.
+        assert await client_b.list_servers() == []
+
+        await client_a.stop_server(server)
+
+        assert await client_a.list_servers() == []
+        stopped = await client_a.list_servers(include_terminal=True)
+        assert [(s.server_id, s.availability) for s in stopped] == [(server.server_id, "STOPPED")]

--- a/e2e-tests/test_server_strategies.py
+++ b/e2e-tests/test_server_strategies.py
@@ -234,3 +234,44 @@ async def test_reward_operations(test_image, test_id):
 
         result = await server.test_reward(test_script="python -c 'assert 1+1==2'")
         assert result.status == "success"
+
+
+@pytest.mark.asyncio
+async def test_start_reports_whether_the_server_was_reused(test_image, test_id):
+    """`reused` has to distinguish the three outcomes: fresh, taken over, and never-matching."""
+    async with create_http_client(name=f"reused-{test_id}", nodes_count=0) as client:
+        first = await client.start_server(
+            image_tag=test_image,
+            server_name=f"reused-{test_id}",
+            runtime_class_name="gvisor",
+            server_start_wait_timeout_in_seconds=DEFAULT_SERVER_START_TIMEOUT,
+            reuse_strategy=ServerReuseStrategy.RESET,
+        )
+        assert first.reused is False
+        await client.finish_server(first)
+
+        second = await client.start_server(
+            image_tag=test_image,
+            server_name=f"reused-{test_id}",
+            runtime_class_name="gvisor",
+            server_start_wait_timeout_in_seconds=DEFAULT_SERVER_START_TIMEOUT,
+            reuse_strategy=ServerReuseStrategy.RESET,
+        )
+        assert second.reused is True
+        assert second.server_id == first.server_id
+
+        # A server left STOPPED is never FINISHED, so a request that looks identical cannot reuse
+        # it — the configuration mistake `reused` exists to make visible.
+        await client.stop_server(second)
+        third = await client.start_server(
+            image_tag=test_image,
+            server_name=f"reused-{test_id}",
+            runtime_class_name="gvisor",
+            server_start_wait_timeout_in_seconds=DEFAULT_SERVER_START_TIMEOUT,
+            reuse_strategy=ServerReuseStrategy.RESET,
+        )
+        try:
+            assert third.reused is False
+            assert third.server_id != second.server_id
+        finally:
+            await client.stop_server(third)

--- a/e2e-tests/test_watcher.py
+++ b/e2e-tests/test_watcher.py
@@ -76,3 +76,38 @@ def test_watcher_cleans_up_stale_server(test_id):
         time.sleep(3)
 
     pytest.fail(f"Watcher did not transition stale server to KILLED in time (last status: {status!r})")
+
+
+@pytest.mark.e2e
+def test_watcher_leaves_a_server_held_by_keepalive(test_id):
+    """A stale row that would be reaped survives while its keepalive window is open.
+
+    Uses the same always-stale row as the test above, so the only difference between the two
+    outcomes is `keepalive_until`.
+    """
+    assert wait_for_pod_ready(WATCHER_APP_LABEL, timeout=120), "Watcher pod did not become ready"
+
+    generated_name = f"watcher-keepalive-{test_id}"
+    now_ms = int(time.time() * 1000)
+    held_until_ms = now_ms + 30 * 60 * 1000
+
+    insert_sql = (
+        "WITH c AS ("
+        "  INSERT INTO clients (id, name, namespace, created_at, last_heartbeat_time, availability, nodes_count)"
+        f"  VALUES (gen_random_uuid(), 'watcher-keepalive', '{DEFAULT_NAMESPACE}', {now_ms}, {now_ms}, 'ALIVE', 0)"
+        "  RETURNING id"
+        ") "
+        "INSERT INTO servers (client_id, client_name, server_name, generated_name, namespace, created_at,"
+        " last_heartbeat_time, keepalive_until, availability, cpu, ram, run_as_root, server_kind, service_port) "
+        f"SELECT id, 'watcher-keepalive', 'srv', '{generated_name}', '{DEFAULT_NAMESPACE}', {now_ms}, 0,"
+        f" {held_until_ms}, 'ALIVE', 0, 0, false, 'idegym', 80 FROM c;"
+    )
+    _exec_psql(insert_sql)
+    logger.info(f"Inserted held server {generated_name}")
+
+    # Long enough for several cleanup passes; the unheld test above proves one lands well inside this.
+    deadline = time.time() + 90
+    while time.time() < deadline:
+        status = _exec_psql(f"SELECT availability FROM servers WHERE generated_name = '{generated_name}';").strip()
+        assert status == "ALIVE", f"Watcher reaped a server held by keepalive (status: {status!r})"
+        time.sleep(5)

--- a/integration-tests/database/test_migration_roundtrip.py
+++ b/integration-tests/database/test_migration_roundtrip.py
@@ -134,7 +134,16 @@ async def seed_revision_003(engine: AsyncEngine) -> None:
     await execute(engine, "UPDATE snapshots SET pod_snapshot_name = 'pod-snapshot-1'")
 
 
-SEEDS = {"001": seed_revision_001, "002": seed_revision_002, "003": seed_revision_003}
+async def seed_revision_004(engine: AsyncEngine) -> None:
+    await execute(engine, "UPDATE servers SET keepalive_until = 1")
+
+
+SEEDS = {
+    "001": seed_revision_001,
+    "002": seed_revision_002,
+    "003": seed_revision_003,
+    "004": seed_revision_004,
+}
 
 
 async def test_round_trip_through_every_revision(manager: MigrationManager):

--- a/integration-tests/database/test_migration_roundtrip.py
+++ b/integration-tests/database/test_migration_roundtrip.py
@@ -23,6 +23,10 @@ from idegym.orchestrator.migration_manager import (
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
+# Stands in for a database migrated by a newer image than the one running. Must never collide
+# with a real revision id, hence the shape rather than a plausible next number.
+UNKNOWN_NEWER_REVISION = "9x9-from-the-future"
+
 CLIENT_ID = "11111111-1111-1111-1111-111111111111"
 PREPARE_REQUEST_ID = "22222222-2222-2222-2222-222222222222"
 
@@ -31,12 +35,18 @@ TABLES_BY_REVISION = {
     "001": {"clients", "servers", "resource_limit_rules", "job_statuses", "async_operations"},
     "002": {"snapshot_prepare_requests", "snapshots", "snapshot_jobs"},
     "003": set(),
+    "004": set(),
 }
 
 # Columns revision 003 adds, and whose data its downgrade deliberately discards.
 COLUMNS_ADDED_BY_003 = {
     "servers": {"details", "max_restarts", "snapshot_id"},
     "snapshots": {"pod_snapshot_name"},
+}
+
+# Same for 004, which adds the keepalive hold.
+COLUMNS_ADDED_BY_004 = {
+    "servers": {"keepalive_until"},
 }
 
 
@@ -154,7 +164,7 @@ async def test_round_trip_through_every_revision(manager: MigrationManager):
     """
     engine = manager.engine
     chain = manager.revision_chain()
-    assert chain == ["001", "002", "003"], "update this test's per-revision expectations"
+    assert chain == ["001", "002", "003", "004"], "update this test's per-revision expectations"
 
     expected_tables: set[str] = set()
     for revision in chain:
@@ -166,8 +176,9 @@ async def test_round_trip_through_every_revision(manager: MigrationManager):
         assert expected_tables <= await table_names(engine)
         await SEEDS[revision](engine)
 
-    for table, columns in COLUMNS_ADDED_BY_003.items():
-        assert columns <= await column_names(engine, table)
+    for added in (COLUMNS_ADDED_BY_003, COLUMNS_ADDED_BY_004):
+        for table, columns in added.items():
+            assert columns <= await column_names(engine, table)
 
     for revision, previous in zip(reversed(chain), [*reversed(chain[:-1]), BASE_REVISION], strict=True):
         plan = await manager.migrate_to(previous, allow_downgrade=True)
@@ -186,7 +197,7 @@ async def test_round_trip_through_every_revision(manager: MigrationManager):
 
 
 async def test_downgrading_only_the_last_revision_preserves_rows(manager: MigrationManager):
-    """003 -> 002 -> 003 keeps every row, and empties exactly the columns 003 added."""
+    """head -> 002 -> 003 keeps every row, and empties exactly the columns 003 added."""
     engine = manager.engine
     await manager.migrate_to("heads")
     await seed_revision_001(engine)
@@ -243,8 +254,9 @@ async def test_downgrade_needs_explicit_approval(manager: MigrationManager):
     with pytest.raises(MigrationError, match="downgrade"):
         await manager.migrate_to("002")
 
-    assert await manager.get_current_revision() == "003"
-    assert COLUMNS_ADDED_BY_003["servers"] <= await column_names(manager.engine, "servers")
+    assert await manager.get_current_revision() == manager.revision_chain()[-1]
+    expected = COLUMNS_ADDED_BY_003["servers"] | COLUMNS_ADDED_BY_004["servers"]
+    assert expected <= await column_names(manager.engine, "servers")
 
 
 async def test_unknown_target_is_rejected_before_touching_the_schema(manager: MigrationManager):
@@ -253,7 +265,7 @@ async def test_unknown_target_is_rejected_before_touching_the_schema(manager: Mi
     with pytest.raises(MigrationError, match="not one of the migrations in this image"):
         await manager.migrate_to("999", allow_downgrade=True)
 
-    assert await manager.get_current_revision() == "003"
+    assert await manager.get_current_revision() == manager.revision_chain()[-1]
 
 
 async def test_revision_this_image_does_not_contain_is_rejected(manager: MigrationManager):
@@ -263,10 +275,13 @@ async def test_revision_this_image_does_not_contain_is_rejected(manager: Migrati
     rather than surface as a missing-revision KeyError.
     """
     await manager.migrate_to("heads")
-    await execute(manager.engine, "UPDATE alembic_version SET version_num = '004'")
+    head = manager.revision_chain()[-1]
+    # Deliberately not head + 1: that becomes a real revision the next time someone adds one,
+    # and this test would then quietly stop testing anything.
+    await execute(manager.engine, f"UPDATE alembic_version SET version_num = '{UNKNOWN_NEWER_REVISION}'")
 
     with pytest.raises(MigrationError, match="use the image that introduced it"):
-        await manager.migrate_to("003", allow_downgrade=True)
+        await manager.migrate_to(head, allow_downgrade=True)
 
 
 async def test_a_lock_held_elsewhere_stops_the_migration(manager: MigrationManager, migration_db_url: str):

--- a/integration-tests/database/test_watcher_cleanup.py
+++ b/integration-tests/database/test_watcher_cleanup.py
@@ -14,6 +14,7 @@ from idegym.api.orchestrator.clients import AvailabilityStatus
 from idegym.api.orchestrator.operations import AsyncOperationStatus, AsyncOperationType
 from idegym.api.status import Status
 from idegym.api.type import Duration
+from idegym.orchestrator.database.database import extend_idegym_server_keepalive
 from idegym.orchestrator.database.models import AsyncOperation, Client, IdeGYMServer, JobStatusRecord
 from idegym.watcher.cleanup import (
     check_orphaned_kaniko_jobs,
@@ -94,6 +95,83 @@ async def test_cleanup_servers_marks_inactive_server_killed(db: AsyncSession, mo
     reloaded = await _reload(db, IdeGYMServer, server_id)
     assert reloaded.availability == AvailabilityStatus.KILLED
     mock_k8s["clean_up_server"].assert_awaited_once()
+
+
+async def test_cleanup_servers_leaves_a_server_held_by_keepalive(db: AsyncSession, mock_k8s):
+    """The keepalive window is the client saying it still holds the server, idle or not."""
+    now = int(time.time() * 1000)
+    client = await _make_client(db, last_heartbeat_time=now)
+    server = IdeGYMServer(
+        client_id=client.id,
+        client_name=client.name,
+        server_name="srv",
+        generated_name=f"srv-{uuid4().hex[:8]}",
+        namespace="idegym",
+        last_heartbeat_time=now - 30 * 60 * 1000,
+        keepalive_until=now + 10 * 60 * 1000,
+        availability=AvailabilityStatus.ALIVE,
+    )
+    db.add(server)
+    await db.commit()
+    server_id = server.id
+
+    await cleanup_servers(
+        db,
+        current_time=now,
+        inactive_timeout=Duration(minutes=10),
+        finished_timeout=Duration(minutes=5),
+    )
+
+    reloaded = await _reload(db, IdeGYMServer, server_id)
+    assert reloaded.availability == AvailabilityStatus.ALIVE
+    mock_k8s["clean_up_server"].assert_not_awaited()
+
+
+async def test_extend_keepalive_only_ever_lengthens_the_window(db: AsyncSession):
+    """Two holders of one server must not be able to cut each other short."""
+    now = int(time.time() * 1000)
+    client = await _make_client(db, last_heartbeat_time=now)
+    server = IdeGYMServer(
+        client_id=client.id,
+        client_name=client.name,
+        server_name="srv",
+        generated_name=f"srv-{uuid4().hex[:8]}",
+        namespace="idegym",
+        last_heartbeat_time=now,
+        availability=AvailabilityStatus.ALIVE,
+    )
+    db.add(server)
+    await db.commit()
+
+    long_hold = await extend_idegym_server_keepalive(db, server.id, now + 60 * 60 * 1000)
+    short_hold = await extend_idegym_server_keepalive(db, server.id, now + 60 * 1000)
+
+    assert long_hold.keepalive_until == now + 60 * 60 * 1000
+    assert short_hold.keepalive_until == now + 60 * 60 * 1000
+
+
+async def test_extend_keepalive_does_not_revive_a_terminal_server(db: AsyncSession):
+    now = int(time.time() * 1000)
+    client = await _make_client(db, last_heartbeat_time=now)
+    server = IdeGYMServer(
+        client_id=client.id,
+        client_name=client.name,
+        server_name="srv",
+        generated_name=f"srv-{uuid4().hex[:8]}",
+        namespace="idegym",
+        last_heartbeat_time=now,
+        availability=AvailabilityStatus.KILLED,
+    )
+    db.add(server)
+    await db.commit()
+
+    result = await extend_idegym_server_keepalive(db, server.id, now + 60 * 60 * 1000)
+
+    assert result.keepalive_until is None
+
+
+async def test_extend_keepalive_reports_a_missing_server(db: AsyncSession):
+    assert await extend_idegym_server_keepalive(db, 999_999, 1) is None
 
 
 async def test_cleanup_clients_marks_inactive_client_killed(db: AsyncSession, mock_k8s):

--- a/orchestrator/src/idegym/orchestrator/database/database.py
+++ b/orchestrator/src/idegym/orchestrator/database/database.py
@@ -471,6 +471,26 @@ async def save_idegym_server(
     return server
 
 
+async def extend_idegym_server_keepalive(db: AsyncSession, server_id: int, until: int) -> Optional[IdeGYMServer]:
+    """Hold a server against the inactivity reaper until ``until`` epoch millis.
+
+    The window is only ever extended, never shortened, so two callers holding the same server
+    cannot cut each other's hold short. A terminal server is returned untouched: reviving one
+    by keepalive would contradict whatever put it in that state.
+    """
+    server = await get_idegym_server(db, server_id)
+    if not server:
+        return None
+
+    if AvailabilityStatus(server.availability).is_terminal:
+        return server
+
+    server.keepalive_until = max(server.keepalive_until or 0, until)
+    await db.commit()
+    await db.refresh(server)
+    return server
+
+
 async def update_idegym_server_heartbeat(
     db: AsyncSession,
     server_id: int,

--- a/orchestrator/src/idegym/orchestrator/database/helpers.py
+++ b/orchestrator/src/idegym/orchestrator/database/helpers.py
@@ -88,6 +88,36 @@ async def update_client_status(db: AsyncSession, client_id: UUID, availability_s
 
 
 @with_db_session
+async def get_owned_server(db: AsyncSession, client_id: UUID, server_id: int):
+    """Look up a server and check the client owns it, whatever state the server is in.
+
+    Unlike ``validate_server`` this accepts a finished, stopped or crashed server: an endpoint
+    that reports status has to be able to report exactly those.
+    """
+    return await _load_owned_server(db=db, client_id=client_id, server_id=server_id)
+
+
+async def _load_owned_server(db: AsyncSession, client_id: UUID, server_id: int):
+    client = await get_client(db, client_id)
+    if not client:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Client with ID {client_id} not found")
+
+    server = await get_idegym_server(db=db, server_id=server_id)
+    if not server:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"IdeGYM server with ID {server_id} not found"
+        )
+
+    if server.client_id != client_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"IdeGYM server with ID {server_id} is not associated with client ID {client_id}",
+        )
+
+    return server
+
+
+@with_db_session
 async def validate_server(db: AsyncSession, client_id: UUID, server_id: int):
     """Validate that the client owns the server and that it is in a usable state (ALIVE or REUSED)."""
     client = await get_client(db, client_id)

--- a/orchestrator/src/idegym/orchestrator/database/helpers.py
+++ b/orchestrator/src/idegym/orchestrator/database/helpers.py
@@ -9,6 +9,7 @@ from idegym.api.orchestrator.servers import AliveServerInfo, ErrorResponse, Star
 from idegym.orchestrator.database.database import (
     check_resources_and_save_server,
     create_client,
+    extend_idegym_server_keepalive,
     find_matching_finished_server,
     find_snapshot_by_request_hash,
     get_async_operation,
@@ -85,6 +86,18 @@ async def update_client_status(db: AsyncSession, client_id: UUID, availability_s
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Client with ID {client_id} not found")
     logger.debug(f"Updated client with ID {client_id} status to {availability_status}")
     return client
+
+
+@with_db_session
+async def extend_server_keepalive(db: AsyncSession, client_id: UUID, server_id: int, until: int):
+    """Hold a client's own server against the inactivity reaper until ``until`` epoch millis."""
+    await _load_owned_server(db=db, client_id=client_id, server_id=server_id)
+    server = await extend_idegym_server_keepalive(db=db, server_id=server_id, until=until)
+    if not server:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"IdeGYM server with ID {server_id} not found"
+        )
+    return server
 
 
 @with_db_session

--- a/orchestrator/src/idegym/orchestrator/database/helpers.py
+++ b/orchestrator/src/idegym/orchestrator/database/helpers.py
@@ -235,6 +235,15 @@ async def find_matching_finished_server_in_db(
 
 
 @with_db_session
+async def list_client_servers(db: AsyncSession, client_id: UUID, include_terminal: bool):
+    """Return every server owned by a client, newest first, optionally including dead ones."""
+    servers = await get_idegym_servers_by_client_id(db, client_id)
+    if not include_terminal:
+        servers = [server for server in servers if not AvailabilityStatus(server.availability).is_terminal]
+    return sorted(servers, key=lambda server: server.created_at or 0, reverse=True)
+
+
+@with_db_session
 async def find_alive_servers(db: AsyncSession, client_id: UUID) -> list[AliveServerInfo]:
     servers_info = []
     servers = await get_idegym_servers_by_client_id(db, client_id)

--- a/orchestrator/src/idegym/orchestrator/database/models.py
+++ b/orchestrator/src/idegym/orchestrator/database/models.py
@@ -59,6 +59,11 @@ class IdeGYMServer(Base):
     # for servers started from a snapshot, otherwise the server's own generated_name.
     snapshot_id = Column(String, index=True, nullable=True)
 
+    # Epoch millis until which an explicit keepalive holds this server against the inactivity reaper.
+    # Distinct from last_heartbeat_time, which only ever means "a request finished at this point":
+    # a sandbox can be legitimately in use and quiet, and only the client knows that.
+    keepalive_until = Column(BigInteger, nullable=True)
+
     # Restarts tolerated before the watcher marks the server CRASHED and tears it down (0 = fail on first crash).
     max_restarts = Column(Integer, default=0, nullable=False)
     # Human-readable reason populated on terminal failures (e.g. the crash/OOM/eviction cause).

--- a/orchestrator/src/idegym/orchestrator/migrations/versions/004_down.sql
+++ b/orchestrator/src/idegym/orchestrator/migrations/versions/004_down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE servers DROP COLUMN IF EXISTS keepalive_until;

--- a/orchestrator/src/idegym/orchestrator/migrations/versions/004_server_keepalive.py
+++ b/orchestrator/src/idegym/orchestrator/migrations/versions/004_server_keepalive.py
@@ -1,0 +1,51 @@
+"""Add keepalive_until to servers
+
+Holds a server against the watcher's inactivity reaper for an explicit window, so that a
+sandbox nobody is sending requests to — an agent thinking, a long local build, a human
+debugging — is not mistaken for a sandbox nobody is holding.
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-08-31
+
+"""
+
+from pathlib import Path
+
+from alembic import op
+
+revision = "004"
+down_revision = "003"
+branch_labels = None
+depends_on = None
+
+
+def execute_sql_file(sql_file_path: Path) -> None:
+    with open(sql_file_path, "r") as f:
+        sql_content = f.read()
+
+    if not sql_content.strip():
+        return
+
+    lines = []
+    for line in sql_content.split("\n"):
+        line = line.strip()
+        if line and not line.startswith("--"):
+            lines.append(line)
+
+    clean_sql = " ".join(lines)
+    statements = [stmt.strip() for stmt in clean_sql.split(";") if stmt.strip()]
+
+    for statement in statements:
+        if statement:
+            op.execute(statement)
+
+
+def upgrade() -> None:
+    migration_dir = Path(__file__).parent
+    execute_sql_file(migration_dir / "004_up.sql")
+
+
+def downgrade() -> None:
+    migration_dir = Path(__file__).parent
+    execute_sql_file(migration_dir / "004_down.sql")

--- a/orchestrator/src/idegym/orchestrator/migrations/versions/004_up.sql
+++ b/orchestrator/src/idegym/orchestrator/migrations/versions/004_up.sql
@@ -1,0 +1,2 @@
+-- Epoch milliseconds until which an explicit keepalive holds the server against the inactivity reaper
+ALTER TABLE servers ADD COLUMN IF NOT EXISTS keepalive_until BIGINT;

--- a/orchestrator/src/idegym/orchestrator/router/server.py
+++ b/orchestrator/src/idegym/orchestrator/router/server.py
@@ -12,11 +12,13 @@ from idegym.api.orchestrator.servers import (
     FinishServerRequest,
     KeepaliveServerRequest,
     KeepaliveServerResponse,
+    ListServersResponse,
     RestartServerRequest,
     ServerActionResponse,
     ServerKind,
     ServerReuseStrategy,
     ServerStatusResponse,
+    ServerSummary,
     StartServerRequest,
     StartServerResponse,
     StopServerRequest,
@@ -34,6 +36,7 @@ from idegym.orchestrator.database.helpers import (
     extend_server_keepalive,
     find_matching_finished_server_in_db,
     get_owned_server,
+    list_client_servers,
     update_operation_status,
     update_operation_with_error,
     update_server_owner,
@@ -182,6 +185,39 @@ async def get_server_capabilities(server_id: int, client_id: UUID, low_level_req
     if response.status_code >= 400:
         raise HTTPException(status_code=response.status_code, detail=response.text)
     return CapabilitiesResponse.model_validate_json(response.text)
+
+
+@router.get("/api/idegym-servers")
+@handle_server_exceptions("listing IdeGYM servers")
+async def list_servers(client_id: UUID, include_terminal: bool = False) -> ListServersResponse:
+    """List the servers a client owns.
+
+    Without this a client cannot ask what it is holding, so finding a leaked pod after a crash
+    meant reaching for kubectl — which a client running outside the cluster generally cannot do.
+    Terminal servers are excluded unless asked for, since the common question is "what is still
+    mine and running".
+    """
+    await validate_client(client_id)
+    servers = await list_client_servers(client_id=client_id, include_terminal=include_terminal)
+    return ListServersResponse(
+        client_id=client_id,
+        servers=[
+            ServerSummary(
+                server_id=server.id,
+                server_name=server.server_name,
+                generated_name=server.generated_name,
+                namespace=server.namespace,
+                availability=server.availability,
+                usable=server.availability in {AvailabilityStatus.ALIVE, AvailabilityStatus.REUSED},
+                image_tag=server.image_tag,
+                created_at=server.created_at,
+                last_activity_at=server.last_heartbeat_time,
+                keepalive_until=server.keepalive_until,
+                details=server.details,
+            )
+            for server in servers
+        ],
+    )
 
 
 @router.post("/api/idegym-servers/keepalive")

--- a/orchestrator/src/idegym/orchestrator/router/server.py
+++ b/orchestrator/src/idegym/orchestrator/router/server.py
@@ -495,11 +495,17 @@ async def _task_start_server(
                 server_id=server_id,
                 server_name=server_server_name,
                 image_tag=server_image_tag,
+                reused=existing_server is not None,
                 need_to_reset=used_reset_reuse,
             ),
         )
 
-        logger.info(f"Started IdeGYM server {server_generated_name} with ID {server_id}")
+        logger.info(
+            "Started IdeGYM server",
+            server=server_generated_name,
+            server_id=server_id,
+            reused=existing_server is not None,
+        )
 
     except CancelledError:
         logger.warning(

--- a/orchestrator/src/idegym/orchestrator/router/server.py
+++ b/orchestrator/src/idegym/orchestrator/router/server.py
@@ -10,6 +10,8 @@ from idegym.api.orchestrator.clients import AvailabilityStatus
 from idegym.api.orchestrator.operations import AsyncOperationStatus, AsyncOperationType
 from idegym.api.orchestrator.servers import (
     FinishServerRequest,
+    KeepaliveServerRequest,
+    KeepaliveServerResponse,
     RestartServerRequest,
     ServerActionResponse,
     ServerKind,
@@ -29,6 +31,7 @@ from idegym.backend.utils.kubernetes_client import (
 from idegym.orchestrator.database.helpers import (
     check_resources_and_save_server_in_db,
     create_async_operation,
+    extend_server_keepalive,
     find_matching_finished_server_in_db,
     get_owned_server,
     update_operation_status,
@@ -181,6 +184,30 @@ async def get_server_capabilities(server_id: int, client_id: UUID, low_level_req
     return CapabilitiesResponse.model_validate_json(response.text)
 
 
+@router.post("/api/idegym-servers/keepalive")
+@handle_server_exceptions("keeping an IdeGYM server alive")
+async def keepalive_server(request: KeepaliveServerRequest) -> KeepaliveServerResponse:
+    """Hold a server against the watcher's inactivity reaper for the requested window.
+
+    The reaper works off the last time a request finished, which is a poor proxy for "somebody
+    is using this": a sandbox can be legitimately idle while an agent thinks or a build runs.
+    Only the holder knows, so this is how it says so.
+    """
+    until = current_time_millis() + int(request.minutes * 60_000)
+    server = await extend_server_keepalive(client_id=request.client_id, server_id=request.server_id, until=until)
+    logger.info(
+        "Extended server keepalive",
+        server_id=server.id,
+        keepalive_until=server.keepalive_until,
+        minutes=request.minutes,
+    )
+    return KeepaliveServerResponse(
+        server_id=server.id,
+        keepalive_until=server.keepalive_until,
+        minutes=max(server.keepalive_until - current_time_millis(), 0) / 60_000,
+    )
+
+
 @router.get("/api/idegym-servers/{server_id}/status")
 @handle_server_exceptions("fetching server status")
 async def get_server_status(server_id: int, client_id: UUID) -> ServerStatusResponse:
@@ -205,6 +232,7 @@ async def get_server_status(server_id: int, client_id: UUID) -> ServerStatusResp
         created_at=server.created_at,
         last_activity_at=server.last_heartbeat_time,
         idle_seconds=max(now - server.last_heartbeat_time, 0) / 1000,
+        keepalive_until=server.keepalive_until,
         pod_phase=pod_phase,
         pod_ready=pod_ready,
         details=server.details,

--- a/orchestrator/src/idegym/orchestrator/router/server.py
+++ b/orchestrator/src/idegym/orchestrator/router/server.py
@@ -231,6 +231,16 @@ async def keepalive_server(request: KeepaliveServerRequest) -> KeepaliveServerRe
     """
     until = current_time_millis() + int(request.minutes * 60_000)
     server = await extend_server_keepalive(client_id=request.client_id, server_id=request.server_id, until=until)
+    # A terminal server is returned untouched, so the hold was refused. Keying on availability
+    # rather than on a null `keepalive_until` matters: a server that held a lease before it died
+    # still carries the old timestamp, and reporting that back would claim a hold we do not have.
+    # This is the race the endpoint exists to lose gracefully — a keepalive loop overtaken by the
+    # reaper — so it says the sandbox is gone instead of 500-ing on None arithmetic.
+    if AvailabilityStatus(server.availability).is_terminal:
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail=f"IdeGYM server with ID {server.id} is {server.availability} and cannot be held alive",
+        )
     logger.info(
         "Extended server keepalive",
         server_id=server.id,

--- a/orchestrator/src/idegym/orchestrator/router/server.py
+++ b/orchestrator/src/idegym/orchestrator/router/server.py
@@ -14,6 +14,7 @@ from idegym.api.orchestrator.servers import (
     ServerActionResponse,
     ServerKind,
     ServerReuseStrategy,
+    ServerStatusResponse,
     StartServerRequest,
     StartServerResponse,
     StopServerRequest,
@@ -21,6 +22,7 @@ from idegym.api.orchestrator.servers import (
 from idegym.backend.utils.kubernetes_client import (
     clean_up_server,
     deploy_server,
+    pod_phase_and_readiness,
     restart_pods,
     wait_for_pods_ready,
 )
@@ -28,6 +30,7 @@ from idegym.orchestrator.database.helpers import (
     check_resources_and_save_server_in_db,
     create_async_operation,
     find_matching_finished_server_in_db,
+    get_owned_server,
     update_operation_status,
     update_operation_with_error,
     update_server_owner,
@@ -35,6 +38,7 @@ from idegym.orchestrator.database.helpers import (
     validate_client,
     validate_server,
 )
+from idegym.orchestrator.database.models import current_time_millis
 from idegym.orchestrator.router.forwarding import build_server_host
 from idegym.orchestrator.util.decorators import handle_async_task_exceptions, handle_server_exceptions
 from idegym.orchestrator.util.errors import format_error
@@ -175,6 +179,36 @@ async def get_server_capabilities(server_id: int, client_id: UUID, low_level_req
     if response.status_code >= 400:
         raise HTTPException(status_code=response.status_code, detail=response.text)
     return CapabilitiesResponse.model_validate_json(response.text)
+
+
+@router.get("/api/idegym-servers/{server_id}/status")
+@handle_server_exceptions("fetching server status")
+async def get_server_status(server_id: int, client_id: UUID) -> ServerStatusResponse:
+    """Report whether a server is usable, without touching it.
+
+    Before this existed the cheapest liveness probe was an unrelated endpoint such as
+    ``/capabilities``, which happens to touch both the database record and the pod. This reads
+    the record and the pod phase directly, and deliberately does not update the server's
+    activity timestamp, so polling it cannot keep a server from being reaped.
+    """
+    server = await get_owned_server(client_id=client_id, server_id=server_id)
+    pod_phase, pod_ready = await pod_phase_and_readiness(f"app={server.generated_name}", server.namespace)
+    now = current_time_millis()
+    return ServerStatusResponse(
+        server_id=server.id,
+        server_name=server.server_name,
+        generated_name=server.generated_name,
+        namespace=server.namespace,
+        availability=server.availability,
+        usable=server.availability in {AvailabilityStatus.ALIVE, AvailabilityStatus.REUSED},
+        image_tag=server.image_tag,
+        created_at=server.created_at,
+        last_activity_at=server.last_heartbeat_time,
+        idle_seconds=max(now - server.last_heartbeat_time, 0) / 1000,
+        pod_phase=pod_phase,
+        pod_ready=pod_ready,
+        details=server.details,
+    )
 
 
 @executes_operation_in_background

--- a/unit-tests/test_server_keepalive.py
+++ b/unit-tests/test_server_keepalive.py
@@ -1,0 +1,156 @@
+"""The explicit keepalive: the endpoint, the watcher's respect for it, and the client call.
+
+The behaviour that matters is negative — a held server must survive a cleanup pass it would
+otherwise have failed — so most of these drive ``cleanup_servers`` directly.
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from idegym.api.orchestrator.clients import AvailabilityStatus
+from idegym.api.orchestrator.servers import KeepaliveServerRequest
+from idegym.api.type import Duration
+from idegym.orchestrator.router import server as server_router
+from idegym.watcher import cleanup as watcher_cleanup
+from pydantic import ValidationError
+
+NOW = 10_000_000
+INACTIVE_TIMEOUT = Duration(minutes=10)
+FINISHED_TIMEOUT = Duration(minutes=5)
+
+
+def _stale_server(**overrides) -> SimpleNamespace:
+    """A server whose last request finished an hour ago — well past every timeout."""
+    record = {
+        "id": 7,
+        "generated_name": "srv-abc123",
+        "namespace": "idegym",
+        "availability": AvailabilityStatus.ALIVE,
+        "last_heartbeat_time": NOW - 60 * 60 * 1000,
+        "keepalive_until": None,
+    }
+    record.update(overrides)
+    return SimpleNamespace(**record)
+
+
+@pytest.fixture
+def cleanup_pass(mocker):
+    """Run one ``cleanup_servers`` pass over the given servers and report what was deleted."""
+
+    async def run(*servers):
+        mocker.patch.object(watcher_cleanup, "get_idegym_servers_by_status", mocker.AsyncMock(return_value=servers))
+        deleted = mocker.patch.object(watcher_cleanup, "clean_up_server", mocker.AsyncMock())
+        mocker.patch.object(watcher_cleanup, "update_idegym_server_heartbeat", mocker.AsyncMock())
+
+        await watcher_cleanup.cleanup_servers(
+            db=mocker.MagicMock(),
+            current_time=NOW,
+            inactive_timeout=INACTIVE_TIMEOUT,
+            finished_timeout=FINISHED_TIMEOUT,
+        )
+        return [call.kwargs["name"] for call in deleted.await_args_list]
+
+    return run
+
+
+# --------------------------------------------------------------------------------------
+# The watcher
+# --------------------------------------------------------------------------------------
+
+
+async def test_an_idle_server_without_a_hold_is_still_reaped(cleanup_pass) -> None:
+    assert await cleanup_pass(_stale_server()) == ["srv-abc123"]
+
+
+async def test_a_held_server_survives_the_reaper(cleanup_pass) -> None:
+    assert await cleanup_pass(_stale_server(keepalive_until=NOW + 60_000)) == []
+
+
+async def test_an_expired_hold_stops_protecting_the_server(cleanup_pass) -> None:
+    assert await cleanup_pass(_stale_server(keepalive_until=NOW - 1)) == ["srv-abc123"]
+
+
+async def test_a_hold_protects_a_finished_server_too(cleanup_pass) -> None:
+    held = _stale_server(availability=AvailabilityStatus.FINISHED, keepalive_until=NOW + 60_000)
+
+    assert await cleanup_pass(held) == []
+
+
+async def test_a_hold_on_one_server_does_not_protect_another(cleanup_pass) -> None:
+    held = _stale_server(id=1, generated_name="held", keepalive_until=NOW + 60_000)
+    unheld = _stale_server(id=2, generated_name="unheld")
+
+    assert await cleanup_pass(held, unheld) == ["unheld"]
+
+
+# --------------------------------------------------------------------------------------
+# The endpoint
+# --------------------------------------------------------------------------------------
+
+
+async def test_keepalive_extends_the_window_by_the_requested_minutes(mocker) -> None:
+    mocker.patch.object(server_router, "current_time_millis", return_value=NOW)
+    extend = mocker.patch.object(
+        server_router,
+        "extend_server_keepalive",
+        mocker.AsyncMock(return_value=SimpleNamespace(id=7, keepalive_until=NOW + 30 * 60_000)),
+    )
+    client_id = uuid4()
+
+    response = await server_router.keepalive_server(
+        KeepaliveServerRequest(client_id=client_id, server_id=7, minutes=30)
+    )
+
+    extend.assert_awaited_once_with(client_id=client_id, server_id=7, until=NOW + 30 * 60_000)
+    assert response.keepalive_until == NOW + 30 * 60_000
+    assert response.minutes == 30
+
+
+async def test_keepalive_reports_the_window_actually_in_effect(mocker) -> None:
+    """A longer hold already in place wins, and the response says so rather than echoing the ask."""
+    mocker.patch.object(server_router, "current_time_millis", return_value=NOW)
+    mocker.patch.object(
+        server_router,
+        "extend_server_keepalive",
+        mocker.AsyncMock(return_value=SimpleNamespace(id=7, keepalive_until=NOW + 60 * 60_000)),
+    )
+
+    response = await server_router.keepalive_server(KeepaliveServerRequest(client_id=uuid4(), server_id=7, minutes=5))
+
+    assert response.minutes == 60
+
+
+@pytest.mark.parametrize("minutes", [0, -1, 24 * 60 + 1])
+def test_keepalive_request_rejects_a_window_outside_the_allowed_range(minutes) -> None:
+    with pytest.raises(ValidationError):
+        KeepaliveServerRequest(client_id=uuid4(), server_id=7, minutes=minutes)
+
+
+def test_keepalive_request_defaults_to_a_bounded_window() -> None:
+    assert KeepaliveServerRequest(client_id=uuid4(), server_id=7).minutes == 15.0
+
+
+# --------------------------------------------------------------------------------------
+# The client
+# --------------------------------------------------------------------------------------
+
+
+async def test_client_sends_the_requested_window(mocker) -> None:
+    from idegym.client.operations.servers import ServerOperations
+
+    utils = mocker.MagicMock()
+    utils.validate_client_id.side_effect = lambda client_id: client_id
+    utils.validate_namespace.side_effect = lambda namespace: namespace or "idegym"
+    utils.make_request = mocker.AsyncMock(return_value={"server_id": 7, "keepalive_until": NOW, "minutes": 45.0})
+    operations = ServerOperations(utils=utils, project=mocker.MagicMock())
+
+    response = await operations.keepalive_server(server_id=7, minutes=45, client_id=uuid4())
+
+    sent = utils.make_request.await_args.args[2]
+    assert (utils.make_request.await_args.args[1], sent.minutes, sent.server_id) == (
+        "/api/idegym-servers/keepalive",
+        45,
+        7,
+    )
+    assert response.minutes == 45.0

--- a/unit-tests/test_server_keepalive.py
+++ b/unit-tests/test_server_keepalive.py
@@ -94,7 +94,9 @@ async def test_keepalive_extends_the_window_by_the_requested_minutes(mocker) -> 
     extend = mocker.patch.object(
         server_router,
         "extend_server_keepalive",
-        mocker.AsyncMock(return_value=SimpleNamespace(id=7, keepalive_until=NOW + 30 * 60_000)),
+        mocker.AsyncMock(
+            return_value=SimpleNamespace(id=7, availability=AvailabilityStatus.ALIVE, keepalive_until=NOW + 30 * 60_000)
+        ),
     )
     client_id = uuid4()
 
@@ -113,12 +115,45 @@ async def test_keepalive_reports_the_window_actually_in_effect(mocker) -> None:
     mocker.patch.object(
         server_router,
         "extend_server_keepalive",
-        mocker.AsyncMock(return_value=SimpleNamespace(id=7, keepalive_until=NOW + 60 * 60_000)),
+        mocker.AsyncMock(
+            return_value=SimpleNamespace(id=7, availability=AvailabilityStatus.ALIVE, keepalive_until=NOW + 60 * 60_000)
+        ),
     )
 
     response = await server_router.keepalive_server(KeepaliveServerRequest(client_id=uuid4(), server_id=7, minutes=5))
 
     assert response.minutes == 60
+
+
+@pytest.mark.parametrize(
+    ("availability", "keepalive_until"),
+    [
+        # No prior hold, and one left over from before the server died: both must be refused.
+        (AvailabilityStatus.KILLED, None),
+        (AvailabilityStatus.CRASHED, NOW + 60_000),
+        (AvailabilityStatus.STOPPED, None),
+    ],
+)
+async def test_keepalive_on_a_terminal_server_reports_gone_not_a_server_error(
+    mocker, availability, keepalive_until
+) -> None:
+    """The reaper can overtake a keepalive loop; that must not surface as an opaque 500."""
+    from fastapi import HTTPException
+
+    mocker.patch.object(server_router, "current_time_millis", return_value=NOW)
+    mocker.patch.object(
+        server_router,
+        "extend_server_keepalive",
+        mocker.AsyncMock(
+            return_value=SimpleNamespace(id=7, availability=availability, keepalive_until=keepalive_until)
+        ),
+    )
+
+    with pytest.raises(HTTPException) as caught:
+        await server_router.keepalive_server(KeepaliveServerRequest(client_id=uuid4(), server_id=7))
+
+    assert caught.value.status_code == 410
+    assert availability in caught.value.detail
 
 
 @pytest.mark.parametrize("minutes", [0, -1, 24 * 60 + 1])

--- a/unit-tests/test_server_listing.py
+++ b/unit-tests/test_server_listing.py
@@ -1,0 +1,156 @@
+"""Listing the servers a client owns.
+
+The point of the endpoint is recovery after a crash, so the cases that matter are the ones a
+crashed client would hit: terminal rows, ordering, and scoping to one registration.
+"""
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from idegym.api.orchestrator.clients import AvailabilityStatus
+from idegym.orchestrator.database import helpers
+from idegym.orchestrator.router import server as server_router
+
+
+def _row(server_id, availability=AvailabilityStatus.ALIVE, created_at=0, **overrides):
+    record = {
+        "id": server_id,
+        "server_name": f"srv-{server_id}",
+        "generated_name": f"srv-{server_id}-abc",
+        "namespace": "idegym",
+        "availability": availability,
+        "image_tag": "registry.test/env:latest",
+        "created_at": created_at,
+        "last_heartbeat_time": created_at,
+        "keepalive_until": None,
+        "details": None,
+    }
+    record.update(overrides)
+    return SimpleNamespace(**record)
+
+
+@pytest.fixture
+def listed(mocker):
+    def configure(*rows):
+        mocker.patch.object(server_router, "validate_client", mocker.AsyncMock())
+        return mocker.patch.object(server_router, "list_client_servers", mocker.AsyncMock(return_value=list(rows)))
+
+    return configure
+
+
+async def test_listing_maps_every_row_and_marks_usability(listed) -> None:
+    client_id = uuid4()
+    query = listed(_row(1), _row(2, availability=AvailabilityStatus.FINISHED))
+
+    response = await server_router.list_servers(client_id=client_id)
+
+    query.assert_awaited_once_with(client_id=client_id, include_terminal=False)
+    assert response.client_id == client_id
+    assert [(s.server_id, s.usable) for s in response.servers] == [(1, True), (2, False)]
+
+
+async def test_listing_reports_a_terminal_servers_reason(listed) -> None:
+    listed(_row(1, availability=AvailabilityStatus.CRASHED, details="OOMKilled"))
+
+    response = await server_router.list_servers(client_id=uuid4(), include_terminal=True)
+
+    assert response.servers[0].details == "OOMKilled"
+    assert response.servers[0].usable is False
+
+
+async def test_include_terminal_is_passed_through(listed) -> None:
+    query = listed()
+
+    await server_router.list_servers(client_id=uuid4(), include_terminal=True)
+
+    assert query.await_args.kwargs["include_terminal"] is True
+
+
+async def test_an_unknown_client_is_rejected_before_listing(mocker) -> None:
+    from fastapi import HTTPException
+
+    mocker.patch.object(server_router, "validate_client", mocker.AsyncMock(side_effect=HTTPException(status_code=404)))
+    query = mocker.patch.object(server_router, "list_client_servers", mocker.AsyncMock())
+
+    with pytest.raises(HTTPException):
+        await server_router.list_servers(client_id=uuid4())
+
+    query.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------------------
+# The database helper
+# --------------------------------------------------------------------------------------
+
+
+@pytest.fixture
+def owned_rows(mocker):
+    """Feed rows to the helper, standing in for the session ``@with_db_session`` would open."""
+
+    @asynccontextmanager
+    async def session():
+        yield mocker.MagicMock()
+
+    def configure(*rows):
+        mocker.patch.object(helpers, "get_db_session", session)
+        mocker.patch.object(helpers, "get_idegym_servers_by_client_id", mocker.AsyncMock(return_value=list(rows)))
+
+    return configure
+
+
+async def test_helper_hides_terminal_servers_by_default(owned_rows) -> None:
+    owned_rows(_row(1), _row(2, availability=AvailabilityStatus.KILLED))
+
+    servers = await helpers.list_client_servers(client_id=uuid4(), include_terminal=False)
+
+    assert [server.id for server in servers] == [1]
+
+
+async def test_helper_returns_terminal_servers_when_asked(owned_rows) -> None:
+    owned_rows(_row(1), _row(2, availability=AvailabilityStatus.KILLED))
+
+    servers = await helpers.list_client_servers(client_id=uuid4(), include_terminal=True)
+
+    assert {server.id for server in servers} == {1, 2}
+
+
+async def test_helper_returns_newest_first(owned_rows) -> None:
+    owned_rows(_row(1, created_at=100), _row(2, created_at=300), _row(3, created_at=200))
+
+    servers = await helpers.list_client_servers(client_id=uuid4(), include_terminal=True)
+
+    assert [server.id for server in servers] == [2, 3, 1]
+
+
+async def test_client_wrapper_returns_the_rows_and_sends_the_filter(mocker) -> None:
+    from idegym.client.operations.servers import ServerOperations
+
+    utils = mocker.MagicMock()
+    utils.validate_client_id.side_effect = lambda client_id: client_id
+    client_id = uuid4()
+    utils.make_request = mocker.AsyncMock(
+        return_value={
+            "client_id": str(client_id),
+            "servers": [
+                {
+                    "server_id": 1,
+                    "generated_name": "srv-1-abc",
+                    "namespace": "idegym",
+                    "availability": "ALIVE",
+                    "usable": True,
+                    "created_at": 1,
+                    "last_activity_at": 1,
+                }
+            ],
+        }
+    )
+    operations = ServerOperations(utils=utils, project=mocker.MagicMock())
+
+    response = await operations.list_servers(client_id=client_id, include_terminal=True)
+
+    utils.make_request.assert_awaited_once_with(
+        "GET", "/api/idegym-servers", params={"client_id": str(client_id), "include_terminal": True}
+    )
+    assert [server.server_id for server in response.servers] == [1]

--- a/unit-tests/test_server_reuse_reporting.py
+++ b/unit-tests/test_server_reuse_reporting.py
@@ -1,0 +1,110 @@
+"""Reporting whether a start actually reused a server.
+
+Reuse turns on seven fields matching, and the common way to get it wrong — always calling
+``stop_server``, so nothing is ever FINISHED — is invisible. These pin that the answer is
+reported rather than left to be inferred.
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from idegym.api.orchestrator.operations import AsyncOperationStatus
+from idegym.api.orchestrator.servers import (
+    ServerReuseStrategy,
+    StartServerRequest,
+    StartServerResponse,
+)
+from idegym.orchestrator.router import server as server_router
+
+
+def _request(**overrides) -> StartServerRequest:
+    fields = {
+        "client_id": uuid4(),
+        "image_tag": "registry.test/env:latest",
+        "server_name": "srv",
+        "reuse_strategy": ServerReuseStrategy.RESET,
+    }
+    fields.update(overrides)
+    return StartServerRequest(**fields)
+
+
+@pytest.fixture
+def started(mocker):
+    """Run `_task_start_server` with everything it touches stubbed; return the recorded result."""
+
+    async def run(request, existing=None):
+        mocker.patch.object(server_router, "extract_resources_request", return_value=(1.0, 1.0))
+        mocker.patch.object(
+            server_router,
+            "find_matching_finished_server_in_db",
+            mocker.AsyncMock(return_value=(existing, "client-name")),
+        )
+        mocker.patch.object(server_router, "validate_client", mocker.AsyncMock(return_value=SimpleNamespace(name="c")))
+        mocker.patch.object(
+            server_router,
+            "check_resources_and_save_server_in_db",
+            mocker.AsyncMock(
+                return_value=SimpleNamespace(id=1, generated_name="srv-new", server_name="srv", image_tag="tag")
+            ),
+        )
+        for name in ("deploy_server", "wait_for_pods_ready", "restart_pods", "update_server_owner"):
+            mocker.patch.object(server_router, name, mocker.AsyncMock())
+        mocker.patch.object(server_router, "update_server_status", mocker.AsyncMock())
+        update = mocker.patch.object(server_router, "update_operation_status", mocker.AsyncMock())
+
+        await server_router._task_start_server(config=mocker.MagicMock(), request=request, async_operation_id=1)
+
+        succeeded = [
+            call
+            for call in update.await_args_list
+            if call.kwargs.get("async_operation_status") == AsyncOperationStatus.SUCCEEDED
+        ]
+        assert succeeded, "the start task did not report success"
+        return succeeded[-1].kwargs["result"]
+
+    return run
+
+
+def _existing_server():
+    return SimpleNamespace(id=9, generated_name="srv-old", server_name="srv", image_tag="tag")
+
+
+async def test_a_fresh_start_reports_no_reuse(started) -> None:
+    result = await started(_request())
+
+    assert result.reused is False
+
+
+async def test_taking_over_a_finished_server_reports_reuse(started) -> None:
+    result = await started(_request(), existing=_existing_server())
+
+    assert result.reused is True
+    assert result.server_id == 9
+
+
+async def test_a_restart_reuse_is_reported_without_asking_for_a_reset(started) -> None:
+    result = await started(_request(reuse_strategy=ServerReuseStrategy.RESTART), existing=_existing_server())
+
+    assert (result.reused, result.need_to_reset) == (True, False)
+
+
+async def test_reuse_is_not_attempted_at_all_for_strategy_none(started, mocker) -> None:
+    result = await started(_request(reuse_strategy=ServerReuseStrategy.NONE), existing=_existing_server())
+
+    assert result.reused is False
+    server_router.find_matching_finished_server_in_db.assert_not_awaited()
+
+
+def test_the_response_defaults_to_not_reused() -> None:
+    response = StartServerResponse(namespace="idegym", client_id=uuid4())
+
+    assert response.reused is False
+
+
+def test_the_match_key_is_written_down_on_reuse_strategy() -> None:
+    """The field description is the only place a caller can learn what reuse matches on."""
+    description = StartServerRequest.model_fields["reuse_strategy"].description
+
+    for field in ("image_tag", "runtime_class_name", "run_as_root", "server_kind", "server_name", "FINISHED"):
+        assert field in description, field

--- a/unit-tests/test_server_status.py
+++ b/unit-tests/test_server_status.py
@@ -22,6 +22,7 @@ def _record(**overrides) -> SimpleNamespace:
         "image_tag": "registry.test/env:latest",
         "created_at": 1_000_000,
         "last_heartbeat_time": 1_060_000,
+        "keepalive_until": None,
         "details": None,
     }
     record.update(overrides)
@@ -55,6 +56,15 @@ async def test_status_reports_the_record_the_pod_and_the_idle_time(stub_orchestr
     assert status.pod_ready is True
     assert status.last_activity_at == 1_060_000
     assert status.idle_seconds == 60.0
+    assert status.keepalive_until is None
+
+
+async def test_status_reports_an_active_keepalive_hold(stub_orchestrator) -> None:
+    stub_orchestrator(_record(keepalive_until=1_900_000))
+
+    status = await server_router.get_server_status(server_id=7, client_id=uuid4())
+
+    assert status.keepalive_until == 1_900_000
 
 
 @pytest.mark.parametrize(

--- a/unit-tests/test_server_status.py
+++ b/unit-tests/test_server_status.py
@@ -1,0 +1,178 @@
+"""The per-server status endpoint and its client wrapper.
+
+The properties worth pinning are the ones that make it usable as a liveness probe: it answers
+for a dead server instead of raising, and it does not count as activity.
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from idegym.api.orchestrator.clients import AvailabilityStatus
+from idegym.orchestrator.router import server as server_router
+
+
+def _record(**overrides) -> SimpleNamespace:
+    record = {
+        "id": 7,
+        "server_name": "my-server",
+        "generated_name": "my-server-abc123",
+        "namespace": "idegym",
+        "availability": AvailabilityStatus.ALIVE,
+        "image_tag": "registry.test/env:latest",
+        "created_at": 1_000_000,
+        "last_heartbeat_time": 1_060_000,
+        "details": None,
+    }
+    record.update(overrides)
+    return SimpleNamespace(**record)
+
+
+@pytest.fixture
+def stub_orchestrator(mocker):
+    """Patch the two things the handler reaches out to, and freeze the clock."""
+
+    def configure(record, pod=("Running", True)):
+        owned = mocker.patch.object(server_router, "get_owned_server", mocker.AsyncMock(return_value=record))
+        pods = mocker.patch.object(server_router, "pod_phase_and_readiness", mocker.AsyncMock(return_value=pod))
+        mocker.patch.object(server_router, "current_time_millis", return_value=1_120_000)
+        return owned, pods
+
+    return configure
+
+
+async def test_status_reports_the_record_the_pod_and_the_idle_time(stub_orchestrator) -> None:
+    client_id = uuid4()
+    owned, pods = stub_orchestrator(_record())
+
+    status = await server_router.get_server_status(server_id=7, client_id=client_id)
+
+    owned.assert_awaited_once_with(client_id=client_id, server_id=7)
+    pods.assert_awaited_once_with("app=my-server-abc123", "idegym")
+    assert status.availability == AvailabilityStatus.ALIVE
+    assert status.usable is True
+    assert status.pod_phase == "Running"
+    assert status.pod_ready is True
+    assert status.last_activity_at == 1_060_000
+    assert status.idle_seconds == 60.0
+
+
+@pytest.mark.parametrize(
+    ("availability", "usable"),
+    [
+        (AvailabilityStatus.ALIVE, True),
+        (AvailabilityStatus.REUSED, True),
+        (AvailabilityStatus.FINISHED, False),
+        (AvailabilityStatus.CRASHED, False),
+        (AvailabilityStatus.KILLED, False),
+    ],
+)
+async def test_usable_tracks_the_states_that_accept_requests(stub_orchestrator, availability, usable) -> None:
+    stub_orchestrator(_record(availability=availability))
+
+    status = await server_router.get_server_status(server_id=7, client_id=uuid4())
+
+    assert status.usable is usable
+
+
+async def test_a_crashed_server_reports_its_reason_instead_of_raising(stub_orchestrator) -> None:
+    """`validate_server` would 410 here; a status endpoint has to answer."""
+    stub_orchestrator(_record(availability=AvailabilityStatus.CRASHED, details="OOMKilled"), pod=(None, False))
+
+    status = await server_router.get_server_status(server_id=7, client_id=uuid4())
+
+    assert status.availability == AvailabilityStatus.CRASHED
+    assert status.details == "OOMKilled"
+    assert status.pod_phase is None
+    assert status.pod_ready is False
+
+
+async def test_reading_status_does_not_record_activity(stub_orchestrator, mocker) -> None:
+    stub_orchestrator(_record())
+    update = mocker.patch.object(server_router, "update_server_status", mocker.AsyncMock())
+
+    await server_router.get_server_status(server_id=7, client_id=uuid4())
+
+    update.assert_not_awaited()
+
+
+async def test_idle_seconds_never_goes_negative_on_clock_skew(stub_orchestrator) -> None:
+    stub_orchestrator(_record(last_heartbeat_time=9_000_000))
+
+    status = await server_router.get_server_status(server_id=7, client_id=uuid4())
+
+    assert status.idle_seconds == 0
+
+
+async def test_client_wrapper_passes_the_client_id_and_parses_the_response(mocker) -> None:
+    from idegym.client.operations.servers import ServerOperations
+
+    utils = mocker.MagicMock()
+    utils.validate_client_id.side_effect = lambda client_id: client_id
+    utils.make_request = mocker.AsyncMock(
+        return_value={
+            "server_id": 7,
+            "generated_name": "my-server-abc123",
+            "namespace": "idegym",
+            "availability": "ALIVE",
+            "usable": True,
+            "created_at": 1,
+            "last_activity_at": 2,
+            "idle_seconds": 0.5,
+            "pod_ready": True,
+        }
+    )
+    operations = ServerOperations(utils=utils, project=mocker.MagicMock())
+    client_id = uuid4()
+
+    status = await operations.get_server_status(server_id=7, client_id=client_id)
+
+    utils.make_request.assert_awaited_once_with(
+        "GET", "/api/idegym-servers/7/status", params={"client_id": str(client_id)}
+    )
+    assert status.usable is True
+
+
+# --------------------------------------------------------------------------------------
+# Pod phase lookup
+# --------------------------------------------------------------------------------------
+
+
+def _pod(phase, *, ready=True, terminating=False, containers=1):
+    return SimpleNamespace(
+        metadata=SimpleNamespace(name="pod", deletion_timestamp=object() if terminating else None),
+        status=SimpleNamespace(
+            phase=phase,
+            container_statuses=[SimpleNamespace(ready=ready) for _ in range(containers)],
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("pods", "expected"),
+    [
+        ([], (None, False)),
+        ([_pod("Running")], ("Running", True)),
+        ([_pod("Running", ready=False)], ("Running", False)),
+        ([_pod("Pending")], ("Pending", False)),
+        ([_pod("Running", containers=0)], ("Running", False)),
+    ],
+)
+async def test_pod_phase_and_readiness_summarises_one_pod(mocker, pods, expected) -> None:
+    from idegym.backend.utils import kubernetes_client
+
+    mocker.patch.object(kubernetes_client, "list_pods", mocker.AsyncMock(return_value=pods))
+
+    assert await kubernetes_client.pod_phase_and_readiness("app=x", "idegym") == expected
+
+
+async def test_pod_phase_and_readiness_ignores_a_pod_on_its_way_out(mocker) -> None:
+    from idegym.backend.utils import kubernetes_client
+
+    mocker.patch.object(
+        kubernetes_client,
+        "list_pods",
+        mocker.AsyncMock(return_value=[_pod("Running", terminating=True), _pod("Pending")]),
+    )
+
+    assert await kubernetes_client.pod_phase_and_readiness("app=x", "idegym") == ("Pending", False)

--- a/watcher/src/idegym/watcher/cleanup.py
+++ b/watcher/src/idegym/watcher/cleanup.py
@@ -70,6 +70,15 @@ async def cleanup_servers(db: AsyncSession, current_time: int, inactive_timeout:
             f"(active: {time_since_last_heartbeat / 1000 / 60:.2f} minutes ago)"
         )
 
+        # An explicit keepalive is the client saying it still holds this server. Request activity
+        # is only a proxy for that, and a bad one while an agent thinks or a build runs.
+        if server.keepalive_until and server.keepalive_until > current_time:
+            logger.debug(
+                f"Skipping IdeGYM server {server.generated_name}: held by keepalive for another "
+                f"{(server.keepalive_until - current_time) / 1000 / 60:.2f} minutes"
+            )
+            continue
+
         if time_since_last_heartbeat > timeout:
             logger.info(
                 f"Removing IdeGYM server {server.generated_name} with status {server.availability}"

--- a/website/docs/architecture/orchestrator.md
+++ b/website/docs/architecture/orchestrator.md
@@ -57,7 +57,12 @@ flowchart TB
 - **Client lifecycle** — register a client (with optional node pre-provisioning), track
   heartbeats, and on stop/finish tear down or release its servers.
 - **Server lifecycle** — start (or **reuse** a matching finished server), stop, finish
-  (release for reuse), and restart environment pods, waiting for readiness.
+  (release for reuse), and restart environment pods, waiting for readiness. Reuse matches on
+  seven fields, one of which is that the candidate is `FINISHED` — so a client that only ever
+  stops its servers never reuses one. The start response reports `reused` either way; see
+  [Server reuse](/reference/client#server-reuse).
+- **Server status and keepalive** — report a server's availability, pod phase and idle time,
+  and hold an idle-but-in-use server against the watcher's inactivity reaper on request.
 - **Image builds** — accept image-builder YAML, compile each `Image` to a spec, and submit
   it through a **pluggable build backend** (Kaniko by default, or GKE Cloud Build) driven by
   a shared `ImageBuildService` (see [image builder](/architecture/image-builder#build-backends)).

--- a/website/docs/architecture/watcher.md
+++ b/website/docs/architecture/watcher.md
@@ -53,6 +53,21 @@ Under a Postgres **advisory lock** (so only one reconciler runs at a time), the 
 3. **Cleans up the rest.** It reconciles the database against live cluster state — evicting
    servers whose clients are gone and reclaiming orphaned resources — and frees quota.
 
+## Inactivity and the keepalive hold
+
+A server is reaped once `inactive_timeout` (or `finished_timeout`, for a `FINISHED` one) has
+passed since its `last_heartbeat_time` — which advances only when a request against it
+completes. That timestamp answers "when did work last finish here", not "is anybody holding
+this", and the two diverge whenever a sandbox is legitimately quiet: an agent thinking, a long
+local build, a human reading a stack trace.
+
+A client that knows it still holds a server says so with
+`POST /api/idegym-servers/keepalive`, which writes an expiry into the server's
+`keepalive_until` column. The watcher skips any server whose hold has not expired, before it
+looks at the timeout at all. The hold is stored separately from `last_heartbeat_time` on
+purpose: pushing the heartbeat into the future would keep the server alive but make "last
+active" a lie, and would extend the hold by a further `inactive_timeout`.
+
 ## Restart budget
 
 The crash policy is **per-server**: `StartServerRequest.max_restarts` (default `0` = fail

--- a/website/docs/reference/client.md
+++ b/website/docs/reference/client.md
@@ -115,7 +115,7 @@ async with client.with_server(
 | `resources` | Kubernetes resource requests/limits |
 | `node_selector` | Node affinity labels |
 | `server_start_wait_timeout_in_seconds` | How long to wait for the server pod to become ready |
-| `reuse_strategy` | What to do if a server with this name already exists: `NONE` (recreate the server from scratch), `RESTART` (restart the server), `RESET` (reset project state) |
+| `reuse_strategy` | Whether to take over an existing server: `NONE` (always create from scratch), `RESTART` (reuse and restart the pod), `RESET` (reuse and reset project state) — see [Server reuse](#server-reuse) |
 | `close_action` | `FINISH` — release the server but leave it running for the next client; `STOP` — stop and delete the server |
 
 ### `start_server(...)` / `stop_server(...)` / `finish_server(...)`
@@ -130,6 +130,37 @@ server = await client.start_server(image_tag=..., server_name=..., ...)
 await client.finish_server(server)  # release without stopping
 # or
 await client.stop_server(server)    # stop and delete
+```
+
+#### Server reuse
+
+Reuse is attempted only for `RESTART` and `RESET`. A candidate is taken over only if **all** of
+these match:
+
+| Field | Comes from |
+|-------|-----------|
+| client name | the `name` this client registered with |
+| `image_tag` | the start request |
+| `runtime_class_name` | the start request |
+| `run_as_root` | the start request |
+| `server_kind` | the start request |
+| `server_name` | the start request, when set |
+| availability is `FINISHED` | how the previous holder released it |
+
+`server_name` is one of seven filters, not the key — two requests with the same name but
+different images will not share a server.
+
+The last row is the one that catches people. A server becomes `FINISHED` only through
+`finish_server` (or `close_action=FINISH`, which `with_server` uses by default). A client that
+always calls `stop_server` leaves its servers `STOPPED`, and **reuse can then never hit** — the
+requests look identical and a new server is created every time.
+
+Because that is invisible from the outside, the start response says what happened:
+
+```python
+server = await client.start_server(..., reuse_strategy=ServerReuseStrategy.RESET)
+if not server.reused:
+    ...  # a fresh server; the project is already in its initial state
 ```
 
 ### `list_servers(include_terminal=False)` — what am I holding?

--- a/website/docs/reference/client.md
+++ b/website/docs/reference/client.md
@@ -347,9 +347,10 @@ cannot cut each other short — which also means `keepalive(minutes=1)` after
 `keepalive(minutes=60)` leaves the longer hold in place, and the response reports the window
 actually in effect rather than the one you asked for. The maximum window is 24 hours.
 
-A hold on a server that has already reached a terminal state does nothing; keepalive is for
-keeping a live server alive, not for reviving a dead one. `status()` reports the hold as
-`keepalive_until`.
+A hold on a server that has already reached a terminal state is refused with `410 Gone`, which
+the client raises as `IdeGYMNotFoundError`: keepalive keeps a live server alive, it does not
+revive a dead one. Catch it as "the sandbox is gone, start a new one". `status()` reports the
+hold as `keepalive_until`.
 
 ### `status()` — is this server usable?
 

--- a/website/docs/reference/client.md
+++ b/website/docs/reference/client.md
@@ -132,6 +132,23 @@ await client.finish_server(server)  # release without stopping
 await client.stop_server(server)    # stop and delete
 ```
 
+### `list_servers(include_terminal=False)` — what am I holding?
+
+```python
+for server in await client.list_servers():
+    print(server.server_id, server.availability, server.image_tag)
+```
+
+Scoped to this client's registration, newest first. Terminal servers (`STOPPED`, `KILLED`,
+`CRASHED`, …) are excluded unless `include_terminal=True`, so the default answers "what is
+still mine and running" — which is what makes cleaning up after a crashed run possible without
+cluster access.
+
+Each row carries `server_id`, `server_name`, `generated_name`, `namespace`, `availability`,
+`usable`, `image_tag`, `created_at`, `last_activity_at`, `keepalive_until` and `details`. There
+are no pod fields: listing them would mean one Kubernetes call per server. Use
+[`status()`](#status--is-this-server-usable) for the pod view of one server.
+
 ### `build_and_push_images(path, timeout, poll_interval)` — image builds
 
 Submit a YAML image definition for Kaniko build and wait for completion:

--- a/website/docs/reference/client.md
+++ b/website/docs/reference/client.md
@@ -283,6 +283,33 @@ file with a stale tail. Downloading a path that does not exist fails with a 404.
 Prefer these over base64 through the bash tool: they are not bounded by the size of a single
 shell script, and the payload never reaches the command log.
 
+### `status()` — is this server usable?
+
+```python
+status = await server.status()
+
+if not status.usable:
+    print(status.availability, status.details)  # e.g. "CRASHED", "OOMKilled"
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `server_id` | `int` | Numeric server ID |
+| `server_name` / `generated_name` | `str` | Logical name from the start request, and the Kubernetes resource name |
+| `namespace` | `str` | Namespace the server runs in |
+| `availability` | `str` | Orchestrator status: `ALIVE`, `REUSED`, `FINISHED`, `STOPPED`, `CRASHED`, … |
+| `usable` | `bool` | True when the server accepts requests (`ALIVE` or `REUSED`) |
+| `image_tag` | `str \| None` | Image the server runs |
+| `created_at` / `last_activity_at` | `int` | Epoch milliseconds |
+| `idle_seconds` | `float` | Seconds since the last recorded activity |
+| `pod_phase` | `str \| None` | Kubernetes phase, or `None` when no pod matches |
+| `pod_ready` | `bool` | True when the pod is `Running` with all containers ready |
+| `details` | `str \| None` | Failure reason recorded on a terminal status |
+
+Use this rather than an unrelated call such as `list_capabilities` as a liveness probe. It
+answers for a finished, stopped or crashed server instead of raising, and reading it does not
+count as activity — so a polling loop will not keep a server from being reaped.
+
 ### `restart_server(...)`
 
 Restart the server pod (preserves the same image and configuration):

--- a/website/docs/reference/client.md
+++ b/website/docs/reference/client.md
@@ -283,6 +283,26 @@ file with a stale tail. Downloading a path that does not exist fails with a 404.
 Prefer these over base64 through the bash tool: they are not bounded by the size of a single
 shell script, and the payload never reaches the command log.
 
+### `keepalive(minutes=15.0)` — hold a server that is idle on purpose
+
+The watcher reaps servers on time since the last completed request. That is only a proxy for
+"somebody is using this", and a poor one: a sandbox is equally quiet while an agent thinks, a
+build runs, or a human reads a stack trace. Call `keepalive` while you still hold the server.
+
+```python
+hold = await server.keepalive(minutes=30)
+print(hold.keepalive_until)  # epoch milliseconds
+```
+
+Calling again extends the window and never shortens it, so two holders of the same server
+cannot cut each other short — which also means `keepalive(minutes=1)` after
+`keepalive(minutes=60)` leaves the longer hold in place, and the response reports the window
+actually in effect rather than the one you asked for. The maximum window is 24 hours.
+
+A hold on a server that has already reached a terminal state does nothing; keepalive is for
+keeping a live server alive, not for reviving a dead one. `status()` reports the hold as
+`keepalive_until`.
+
 ### `status()` — is this server usable?
 
 ```python
@@ -302,6 +322,7 @@ if not status.usable:
 | `image_tag` | `str \| None` | Image the server runs |
 | `created_at` / `last_activity_at` | `int` | Epoch milliseconds |
 | `idle_seconds` | `float` | Seconds since the last recorded activity |
+| `keepalive_until` | `int \| None` | Epoch milliseconds until which an explicit keepalive holds the server |
 | `pod_phase` | `str \| None` | Kubernetes phase, or `None` when no pod matches |
 | `pod_ready` | `bool` | True when the pod is `Running` with all containers ready |
 | `details` | `str \| None` | Failure reason recorded on a terminal status |

--- a/website/docs/reference/http_error_codes.md
+++ b/website/docs/reference/http_error_codes.md
@@ -158,6 +158,22 @@ Mark a server as finished (not stopped — pod remains running, available for re
 | Server not active | `410 Gone` | `detail: "IdeGYM server with ID {id} is not available (status: ...)"` |
 | Internal error | `500 Internal Server Error` | JSON `detail` |
 
+### Servers — `POST /api/idegym-servers/keepalive`
+
+Hold a server against the watcher's inactivity reaper for `minutes` from now. Synchronous.
+
+| Scenario | HTTP Status | Details |
+|----------|-------------|---------|
+| Success | `200 OK` | `KeepaliveServerResponse` with the window actually in effect |
+| `minutes` out of range (0 < minutes ≤ 1440) | `422 Unprocessable Entity` | Pydantic validation error |
+| Client not found | `404 Not Found` | `detail: "Client with ID {id} not found"` |
+| Server not found or owned by another client | `404 Not Found` | |
+| Internal error | `500 Internal Server Error` | JSON `detail` |
+
+A hold on a server already in a terminal state succeeds and does nothing: the response reports
+no window. The window only ever extends, so a shorter request against a longer existing hold
+returns the longer one.
+
 ### Servers — `GET /api/idegym-servers/{server_id}/status`
 
 Report a server's availability, pod phase and idle time. Synchronous, and read-only: it does

--- a/website/docs/reference/http_error_codes.md
+++ b/website/docs/reference/http_error_codes.md
@@ -158,6 +158,22 @@ Mark a server as finished (not stopped — pod remains running, available for re
 | Server not active | `410 Gone` | `detail: "IdeGYM server with ID {id} is not available (status: ...)"` |
 | Internal error | `500 Internal Server Error` | JSON `detail` |
 
+### Servers — `GET /api/idegym-servers/{server_id}/status`
+
+Report a server's availability, pod phase and idle time. Synchronous, and read-only: it does
+**not** update the server's activity timestamp, so polling it will not keep a server alive.
+
+| Scenario | HTTP Status | Details |
+|----------|-------------|---------|
+| Success | `200 OK` | `ServerStatusResponse` — including for a finished, stopped or crashed server |
+| Client not found | `404 Not Found` | `detail: "Client with ID {id} not found"` |
+| Server not found | `404 Not Found` | `detail: "IdeGYM server with ID {id} not found"` |
+| Server owned by another client | `404 Not Found` | `detail: "... is not associated with client ID {id}"` |
+| Internal error | `500 Internal Server Error` | JSON `detail` |
+
+Unlike the other server endpoints this one does not return `410 Gone` for an inactive server —
+reporting that state is the reason it exists.
+
 ### Servers — `POST /api/idegym-servers/restart`
 
 Restart an IdeGYM server's pods. Always async.

--- a/website/docs/reference/http_error_codes.md
+++ b/website/docs/reference/http_error_codes.md
@@ -180,11 +180,14 @@ Hold a server against the watcher's inactivity reaper for `minutes` from now. Sy
 | `minutes` out of range (0 < minutes ≤ 1440) | `422 Unprocessable Entity` | Pydantic validation error |
 | Client not found | `404 Not Found` | `detail: "Client with ID {id} not found"` |
 | Server not found or owned by another client | `404 Not Found` | |
+| Server already in a terminal state | `410 Gone` | `detail: "... is KILLED and cannot be held alive"` |
 | Internal error | `500 Internal Server Error` | JSON `detail` |
 
-A hold on a server already in a terminal state succeeds and does nothing: the response reports
-no window. The window only ever extends, so a shorter request against a longer existing hold
-returns the longer one.
+A server that has already reached a terminal state cannot be held: the hold is refused with
+`410 Gone`. That is the race the endpoint exists to lose gracefully — a keepalive loop can be
+overtaken by the reaper — so treat a 410 here as "the sandbox is gone, start a new one" rather
+than as an error to retry. The window only ever extends, so a shorter request against a longer
+existing hold returns the longer one.
 
 ### Servers — `GET /api/idegym-servers/{server_id}/status`
 

--- a/website/docs/reference/http_error_codes.md
+++ b/website/docs/reference/http_error_codes.md
@@ -158,6 +158,18 @@ Mark a server as finished (not stopped — pod remains running, available for re
 | Server not active | `410 Gone` | `detail: "IdeGYM server with ID {id} is not available (status: ...)"` |
 | Internal error | `500 Internal Server Error` | JSON `detail` |
 
+### Servers — `GET /api/idegym-servers`
+
+List the servers a client owns. Synchronous.
+
+| Scenario | HTTP Status | Details |
+|----------|-------------|---------|
+| Success | `200 OK` | `ListServersResponse`; an empty list when the client owns nothing |
+| Client not found | `404 Not Found` | `detail: "Client with ID {id} not found"` |
+| Internal error | `500 Internal Server Error` | JSON `detail` |
+
+Query parameters: `client_id` (required) and `include_terminal` (default `false`).
+
 ### Servers — `POST /api/idegym-servers/keepalive`
 
 Hold a server against the watcher's inactivity reaper for `minutes` from now. Synchronous.


### PR DESCRIPTION
**Stack 5/8** — #289 ← #290 ← #291 ← #292 ← **#293** ← #294 ← #295 ← #296 (merge in order, oldest first).
Base: `…-04-bash-execution`. Branch: `vladimir.poliakov/jbres-10676-05-…`.

Improvements #7, #8, #9, #10 of JBRes-10676 — knowing and controlling a server's lifecycle. Grouped because they touch the same four files. **Contains migration 004.**

## What changed

**`GET /api/idegym-servers/{id}/status`** (#7) — there was no "is this server healthy" call, so callers used `list_capabilities` as a probe. It uses an ownership-only lookup rather than `validate_server`, since a status endpoint must *report* a crashed server instead of 410-ing on it, and it records no activity.

**An explicit keepalive** (#8) — the reaper works off `last_heartbeat_time`, which only advances when a request finishes, so a sandbox that is legitimately idle (an agent thinking, a long build) ages toward being reaped while in use. Held in a new column rather than by pushing the heartbeat into the future, so "when was this last used" stays truthful.

**`client.list_servers()`** (#9) — the SDK could not ask what it owned, so finding a leaked pod meant `kubectl`.

**`StartServerResponse.reused`** (#10) — plus the seven-field reuse match key written down. A client that always calls `stop_server` leaves servers `STOPPED`, so reuse can never hit; that was invisible.

```mermaid
flowchart LR
  ka["server.keepalive(minutes) (new)"] --> ep["POST .../keepalive (new)"]
  ep --> col[("servers.keepalive_until (new, migration 004)")]
  hb[("last_heartbeat_time (unchanged)")] --> reaper["watcher cleanup_servers"]
  col --> reaper
  reaper -->|"hold active: skip (new)"| kept["server kept"]
  reaper -->|"no hold, idle past timeout"| kill["clean_up_server, KILLED"]
```

Migration **004** adds nullable `servers.keepalive_until`; chart `schemaRevision` → `004`; single head verified.

## How to verify

```
uv run pytest -m unit unit-tests/test_server_status.py unit-tests/test_server_keepalive.py \
  unit-tests/test_server_listing.py unit-tests/test_server_reuse_reporting.py
```

Keepalive is driven through `cleanup_servers` directly: the behaviour is negative, so a held server must survive a pass that reaps the identical unheld one.

**Not run here (needs Docker):** `integration-tests/database/{test_migration_roundtrip,test_watcher_cleanup}.py`. E2E collected only. Manual recipe in a comment below.

Full suite: **1275 passed, 2 skipped**; docs builds.

Resolves: JBRes-10676 (partially — #7, #8, #9, #10)
