### PR TITLE
[JBRes-10676] SDK: raising failures, injectable HTTP client, loop-owning facade (stack 6/8)

### DIFF
--- a/client/src/idegym/client/__init__.py
+++ b/client/src/idegym/client/__init__.py
@@ -11,6 +11,7 @@ from idegym.client.exceptions import (
     IdeGYMServerError,
     IdeGYMTimeoutError,
 )
+from idegym.client.shared import SharedIdeGYMClient
 
 try:
     __version__ = version("idegym-client")
@@ -30,5 +31,6 @@ __all__ = (
     "IdeGYMNotFoundError",
     "IdeGYMServerError",
     "IdeGYMTimeoutError",
+    "SharedIdeGYMClient",
     "__version__",
 )

--- a/client/src/idegym/client/client.py
+++ b/client/src/idegym/client/client.py
@@ -138,7 +138,11 @@ class IdeGYMClient:
                 base_url=orchestrator_url,
                 timeout=request_timeout_in_seconds,
                 transport=transport,
-                limits=limits if limits is not None else Limits(),
+                # Only override when asked: a bare `Limits()` is not httpx's default. It sets
+                # max_connections=None, which removes the 100-connection pool cap entirely, so
+                # passing it unconditionally would unbound the pool for every caller that never
+                # asked to configure one.
+                **({"limits": limits} if limits is not None else {}),
                 headers=(
                     {
                         "Authorization": f"Basic {credential}",

--- a/client/src/idegym/client/client.py
+++ b/client/src/idegym/client/client.py
@@ -62,6 +62,11 @@ class ServerCloseAction(StrEnum):
 class IdeGYMClient:
     """
     HTTP client for interacting with the IdeGYM orchestrator and server APIs.
+
+    **This object is bound to the event loop that created it.** It owns an ``httpx`` session and
+    a heartbeat task, so every call has to be awaited on that same loop. If you drive sandboxes
+    from more than one loop, use :class:`~idegym.client.shared.SharedIdeGYMClient`, which owns a
+    loop in its own thread and lets any caller share one registration.
     """
 
     def __init__(

--- a/client/src/idegym/client/client.py
+++ b/client/src/idegym/client/client.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Optional
 from uuid import UUID, uuid4
 
-from httpx import AsyncClient
+from httpx import AsyncBaseTransport, AsyncClient, Limits
 from idegym.api.auth import BasicAuth
 from idegym.api.config import OTELConfig, TracingConfig
 from idegym.api.health import HealthCheckResponse
@@ -75,6 +75,9 @@ class IdeGYMClient:
         heartbeat_interval_in_seconds: int = 60,
         request_timeout_in_seconds: int = 60,
         otel_config: Optional[OTELConfig] = None,
+        transport: Optional[AsyncBaseTransport] = None,
+        limits: Optional[Limits] = None,
+        http_client: Optional[AsyncClient] = None,
     ):
         """
         Initialize the IdeGYM HTTP client.
@@ -94,6 +97,17 @@ class IdeGYMClient:
             otel_config: OpenTelemetry configuration for tracing. Falls back to ``IDEGYM_OTEL_*``
                 environment variables when not provided. Tracing stays off unless an endpoint is
                 configured, either here or through ``IDEGYM_OTEL_TRACING_ENDPOINT``.
+            transport: Transport for the HTTP client this object builds — for an alternative HTTP
+                stack, a recording transport in tests, or a proxy.
+            limits: Connection-pool limits for the HTTP client this object builds.
+            http_client: A fully configured ``httpx.AsyncClient`` to use verbatim. Nothing about it
+                is modified, so it must already carry ``base_url`` and any authentication, and it
+                is not closed on exit — its owner closes it. Mutually exclusive with ``transport``
+                and ``limits``.
+
+        Raises:
+            ValueError: if ``http_client`` is combined with ``transport`` or ``limits``, since the
+                supplied client is used as-is and those arguments would be silently ignored.
         """
         if orchestrator_url == "idegym.test":
             orchestrator_url = f"http://{orchestrator_url}"
@@ -107,20 +121,30 @@ class IdeGYMClient:
         if not orchestrator_url == "http://idegym.test" and not (auth.username and auth.password):
             raise ValueError("Username and password must be provided or set in environment variables")
 
-        http_client = AsyncClient(
-            base_url=orchestrator_url,
-            timeout=request_timeout_in_seconds,
-            headers=(
-                {
-                    "Authorization": f"Basic {credential}",
-                    "Content-Type": "application/json",
-                }
-                if (credential := auth.base64)
-                else {
-                    "Content-Type": "application/json",
-                }
-            ),
-        )
+        if http_client is not None and (transport is not None or limits is not None):
+            raise ValueError(
+                "transport and limits configure the client IdeGYM builds; they do not apply to http_client"
+            )
+
+        # A supplied client belongs to its caller: used as-is, and closed by them, not here.
+        owns_http_client = http_client is None
+        if http_client is None:
+            http_client = AsyncClient(
+                base_url=orchestrator_url,
+                timeout=request_timeout_in_seconds,
+                transport=transport,
+                limits=limits if limits is not None else Limits(),
+                headers=(
+                    {
+                        "Authorization": f"Basic {credential}",
+                        "Content-Type": "application/json",
+                    }
+                    if (credential := auth.base64)
+                    else {
+                        "Content-Type": "application/json",
+                    }
+                ),
+            )
 
         # Tracing is opt-in: with no endpoint the exporter is never built, so a caller who
         # does not know about OTEL cannot end up shipping telemetry off their infrastructure.
@@ -142,6 +166,7 @@ class IdeGYMClient:
         )
 
         self._http_client: AsyncClient = http_client
+        self._owns_http_client: bool = owns_http_client
         self._otel_config: OTELConfig = otel_config
 
         self._heartbeat_interval_in_seconds: int = heartbeat_interval_in_seconds
@@ -216,7 +241,8 @@ class IdeGYMClient:
             client=self._http_client,
             config=self._otel_config,
         )
-        await self._http_client.aclose()
+        if self._owns_http_client:
+            await self._http_client.aclose()
 
     async def health_check(self) -> HealthCheckResponse:
         response_raw = await self._utils.make_request("GET", "/health")

--- a/client/src/idegym/client/exceptions.py
+++ b/client/src/idegym/client/exceptions.py
@@ -14,6 +14,7 @@ from http import HTTPStatus
 from typing import Optional
 
 from idegym.api.exceptions import IdeGYMException
+from idegym.api.orchestrator.servers import ErrorResponse
 
 
 class IdeGYMHTTPError(IdeGYMException, RuntimeError):
@@ -114,3 +115,19 @@ def http_error(
 ) -> IdeGYMHTTPError:
     """Build the most specific exception for ``status_code``, ready to raise."""
     return error_class_for_status(status_code)(message, status_code=status_code, body=body, method=method, url=url)
+
+
+def raise_for_error_response[T](response: T | ErrorResponse, operation: str) -> T:
+    """Turn an ``ErrorResponse`` from an async operation into the matching exception.
+
+    Some operations report failure as a *return value* rather than by raising, which makes it
+    possible to record a live pod as stopped simply by not checking. Passing the result through
+    here makes failure loud, consistently with the rest of the API.
+    """
+    if isinstance(response, ErrorResponse):
+        raise http_error(
+            f"{operation} failed: {response.model_dump()}",
+            status_code=response.status_code,
+            body=response.body,
+        )
+    return response

--- a/client/src/idegym/client/operations/servers.py
+++ b/client/src/idegym/client/operations/servers.py
@@ -39,6 +39,7 @@ from idegym.api.pod_spec import (
 from idegym.api.resources import KubernetesResources
 from idegym.api.status import Status
 from idegym.api.type import KubernetesNodeSelector, KubernetesObjectName, OCIImageName
+from idegym.client.exceptions import raise_for_error_response
 from idegym.client.operations.project import ProjectOperations
 from idegym.client.operations.utils import HTTPUtils, PollingConfig
 from idegym.utils.logging import get_logger
@@ -166,6 +167,12 @@ class ServerOperations:
         namespace: Optional[str] = None,
         polling_config: PollingConfig = PollingConfig(),
     ) -> ServerActionResponse:
+        """Stop a server and delete its Kubernetes resources.
+
+        Raises an :class:`~idegym.client.exceptions.IdeGYMHTTPError` if the delete fails, rather
+        than returning the failure — a caller that did not check used to record a live pod as
+        stopped and leak it.
+        """
         client_id = self._utils.validate_client_id(client_id)
         namespace = self._utils.validate_namespace(namespace)
         request = StopServerRequest(client_id=client_id, namespace=namespace, server_id=server_id)
@@ -173,12 +180,13 @@ class ServerOperations:
         response: ServerActionResponse = self._utils.parse_response(
             response_raw=response_raw, model_class=ServerActionResponse
         )
-        return await self._utils.wait_for_async_operation_to_end(
+        result = await self._utils.wait_for_async_operation_to_end(
             operation_id=response.operation_id,
             success_response_model=ServerActionResponse,
             error_response_model=ErrorResponse,
             polling_config=polling_config,
         )
+        return raise_for_error_response(result, f"Stopping server {server_id}")
 
     async def restart_server(
         self,
@@ -202,7 +210,7 @@ class ServerOperations:
         response: ServerActionResponse = self._utils.parse_response(
             response_raw=response_raw, model_class=ServerActionResponse
         )
-        return await self._utils.wait_for_async_operation_to_end(
+        result = await self._utils.wait_for_async_operation_to_end(
             operation_id=response.operation_id,
             success_response_model=ServerActionResponse,
             error_response_model=ErrorResponse,
@@ -214,6 +222,7 @@ class ServerOperations:
                 max_delay_for_exponential_wait_in_sec=polling_config.max_delay_for_exponential_wait_in_sec,
             ),
         )
+        return raise_for_error_response(result, f"Restarting server {server_id}")
 
     async def finish_server(
         self, server_id: int, client_id: Optional[UUID] = None, namespace: Optional[str] = None

--- a/client/src/idegym/client/shared.py
+++ b/client/src/idegym/client/shared.py
@@ -31,6 +31,8 @@ logger = get_logger(__name__)
 class _LoopThread:
     """An event loop running in its own daemon thread, accepting work from any other thread."""
 
+    _DRAIN_TIMEOUT_SECONDS = 5.0
+
     def __init__(self, name: str) -> None:
         self._loop = asyncio.new_event_loop()
         self._started = threading.Event()
@@ -57,9 +59,29 @@ class _LoopThread:
         return asyncio.run_coroutine_threadsafe(call(), self._loop)
 
     def close(self) -> None:
+        """Drain the loop before stopping it, so nothing is torn down mid-flight.
+
+        ``IdeGYMClient.__aexit__`` cancels the heartbeat task without awaiting it, and the file
+        transfers hand work to ``asyncio.to_thread``. Stopping the loop immediately would leave
+        those pending — Python then prints "Task was destroyed but it is pending!" on every exit,
+        and the executor and async generators never get their shutdown hooks.
+        """
+        try:
+            self.submit(self._drain).result(timeout=self._DRAIN_TIMEOUT_SECONDS)
+        # A failed or slow drain must never stop us from shutting the loop down.
+        except BaseException:
+            logger.debug("Loop drain did not finish cleanly; stopping anyway", exc_info=True)
         self._loop.call_soon_threadsafe(self._loop.stop)
         self._thread.join()
         self._loop.close()
+
+    async def _drain(self) -> None:
+        """Let cancellations be delivered, then run the loop's own shutdown hooks."""
+        pending = [task for task in asyncio.all_tasks(self._loop) if task is not asyncio.current_task()]
+        if pending:
+            await asyncio.wait(pending, timeout=self._DRAIN_TIMEOUT_SECONDS)
+        await self._loop.shutdown_asyncgens()
+        await self._loop.shutdown_default_executor()
 
 
 class SharedIdeGYMClient:

--- a/client/src/idegym/client/shared.py
+++ b/client/src/idegym/client/shared.py
@@ -1,0 +1,133 @@
+"""Drive one IdeGYM registration from more than one thread or event loop.
+
+An :class:`~idegym.client.client.IdeGYMClient` owns an ``httpx`` session and a heartbeat task,
+both bound to the loop that created it. A caller that drives sandboxes from several loops — a
+synchronous facade with one loop per sandbox, say — therefore cannot share a single
+registration with it, and has to run the client on its own dedicated loop in a separate thread.
+That is roughly a hundred and fifty lines of easy-to-get-subtly-wrong machinery, and every
+integration with the same shape has to write it.
+
+:class:`SharedIdeGYMClient` is that machinery, once. It owns a loop in a dedicated thread,
+constructs and registers the client on it, and marshals every call back onto it, so callers on
+any thread or loop share one registration freely.
+
+Sharing a registration matters beyond convenience: deregistering terminates every server that
+client owns, so two registrations for one process means one of them can tear down the other's
+sandboxes.
+"""
+
+import asyncio
+import threading
+from collections.abc import Awaitable, Callable
+from concurrent.futures import Future
+from typing import Any, Optional, Self
+
+from idegym.client.client import IdeGYMClient
+from idegym.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class _LoopThread:
+    """An event loop running in its own daemon thread, accepting work from any other thread."""
+
+    def __init__(self, name: str) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._started = threading.Event()
+        self._thread = threading.Thread(target=self._run, name=name, daemon=True)
+        self._thread.start()
+        # Block until the loop is actually running, so the first submit cannot race the start.
+        self._started.wait()
+
+    def _run(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.call_soon(self._started.set)
+        self._loop.run_forever()
+
+    def submit[T](self, factory: Callable[[], Awaitable[T]]) -> Future[T]:
+        """Run ``factory()`` on the owned loop and return a future the calling thread can wait on.
+
+        A factory rather than a coroutine so that the awaitable is created on the owning loop:
+        anything a coroutine function touches at creation time then belongs to the right loop.
+        """
+
+        async def call() -> T:
+            return await factory()
+
+        return asyncio.run_coroutine_threadsafe(call(), self._loop)
+
+    def close(self) -> None:
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join()
+        self._loop.close()
+
+
+class SharedIdeGYMClient:
+    """A thread-safe handle on one registered :class:`IdeGYMClient`.
+
+    Takes the same arguments as ``IdeGYMClient`` and registers on entry, exactly as
+    ``async with IdeGYMClient(...)`` would::
+
+        with SharedIdeGYMClient(orchestrator_url=..., name="run", namespace="idegym") as shared:
+            server = shared.run(lambda client: client.start_server(image_tag=...))
+            result = shared.run(lambda _: server.execute_bash("echo hi"))
+            shared.run(lambda client: client.stop_server(server))
+
+    Every call is marshalled onto the owned loop, so concurrent calls from different threads are
+    safe and all of them share the one registration.
+    """
+
+    def __init__(self, **client_arguments: Any) -> None:
+        self._client_arguments = client_arguments
+        self._loop: Optional[_LoopThread] = None
+        self._client: Optional[IdeGYMClient] = None
+
+    @property
+    def client(self) -> IdeGYMClient:
+        """The underlying client. Only touch it from a callable passed to :meth:`run`."""
+        if self._client is None:
+            raise RuntimeError("SharedIdeGYMClient is not started; use it as a context manager")
+        return self._client
+
+    def __enter__(self) -> Self:
+        self._loop = _LoopThread(name="idegym-client-loop")
+
+        async def start() -> IdeGYMClient:
+            client = IdeGYMClient(**self._client_arguments)
+            await client.__aenter__()
+            return client
+
+        try:
+            self._client = self._loop.submit(start).result()
+        except BaseException:
+            self._loop.close()
+            self._loop = None
+            raise
+        return self
+
+    def __exit__(self, exception_type, exception, traceback) -> bool:
+        loop, client = self._loop, self._client
+        self._client = None
+        self._loop = None
+        try:
+            if client is not None and loop is not None:
+                loop.submit(lambda: client.__aexit__(exception_type, exception, traceback)).result()
+        finally:
+            if loop is not None:
+                loop.close()
+        return False
+
+    def submit[T](self, call: Callable[[IdeGYMClient], Awaitable[T]]) -> Future[T]:
+        """Schedule ``call(client)`` on the owned loop without waiting for it."""
+        if self._loop is None:
+            raise RuntimeError("SharedIdeGYMClient is not started; use it as a context manager")
+        client = self.client
+        return self._loop.submit(lambda: call(client))
+
+    def run[T](self, call: Callable[[IdeGYMClient], Awaitable[T]], timeout: Optional[float] = None) -> T:
+        """Run ``call(client)`` on the owned loop and return its result.
+
+        Safe to call from any thread, including one that is itself running an event loop — the
+        awaitable never touches the caller's loop.
+        """
+        return self.submit(call).result(timeout)

--- a/unit-tests/test_client_exceptions.py
+++ b/unit-tests/test_client_exceptions.py
@@ -5,6 +5,8 @@ retry policy branches on, and the fact that the change stayed backwards compatib
 messages and the ``RuntimeError`` base are what existing callers already depend on.
 """
 
+from uuid import uuid4
+
 import httpx
 import pytest
 from idegym.api.exceptions import IdeGYMException
@@ -130,3 +132,54 @@ async def test_start_server_failure_is_typed(mocker) -> None:
         await client.start_server(image_tag="registry.test/env:latest")
 
     assert caught.value.status_code == 503
+
+
+# --------------------------------------------------------------------------------------
+# Operations that used to report failure by returning it
+# --------------------------------------------------------------------------------------
+
+
+def _server_operations(mocker, terminal_result):
+    from idegym.client.operations.servers import ServerOperations
+
+    utils = mocker.MagicMock()
+    utils.validate_client_id.side_effect = lambda client_id: client_id
+    utils.validate_namespace.side_effect = lambda namespace: namespace or "idegym"
+    utils.make_request = mocker.AsyncMock(return_value={"server_name": "srv", "message": "ok", "operation_id": 3})
+    utils.parse_response.side_effect = lambda response_raw, model_class: model_class.model_validate(response_raw)
+    utils.wait_for_async_operation_to_end = mocker.AsyncMock(return_value=terminal_result)
+    return ServerOperations(utils=utils, project=mocker.MagicMock())
+
+
+async def test_stop_server_raises_instead_of_returning_the_failure(mocker) -> None:
+    operations = _server_operations(mocker, ErrorResponse(status_code=500, body="delete failed"))
+
+    with pytest.raises(IdeGYMServerError) as caught:
+        await operations.stop_server(server_id=7, client_id=uuid4())
+
+    assert caught.value.status_code == 500
+    assert "Stopping server 7 failed" in str(caught.value)
+
+
+async def test_restart_server_raises_instead_of_returning_the_failure(mocker) -> None:
+    operations = _server_operations(mocker, ErrorResponse(status_code=410, body="pod gone"))
+
+    with pytest.raises(IdeGYMNotFoundError):
+        await operations.restart_server(server_id=7, client_id=uuid4())
+
+
+async def test_a_successful_stop_still_returns_the_action_response(mocker) -> None:
+    from idegym.api.orchestrator.servers import ServerActionResponse
+
+    success = ServerActionResponse(server_name="srv", message="Successfully stopped")
+    operations = _server_operations(mocker, success)
+
+    assert await operations.stop_server(server_id=7, client_id=uuid4()) is success
+
+
+def test_raise_for_error_response_passes_a_success_through() -> None:
+    from idegym.client.exceptions import raise_for_error_response
+
+    value = object()
+
+    assert raise_for_error_response(value, "Doing a thing") is value

--- a/unit-tests/test_client_http_configuration.py
+++ b/unit-tests/test_client_http_configuration.py
@@ -1,0 +1,84 @@
+"""Supplying or configuring the client's HTTP stack.
+
+The behaviour worth pinning is ownership: a client IdeGYM builds is closed on exit, and one
+handed in is not — closing somebody else's pooled client out from under them is the failure
+this feature has to avoid while removing the need to reach into private attributes.
+"""
+
+import httpx
+import pytest
+from idegym.client.client import IdeGYMClient
+
+CREDENTIALS = {"IDEGYM_AUTH_USERNAME": "user", "IDEGYM_AUTH_PASSWORD": "secret"}
+
+
+@pytest.fixture(autouse=True)
+def credentials(monkeypatch):
+    monkeypatch.delenv("IDEGYM_OTEL_TRACING_ENDPOINT", raising=False)
+    for name, value in CREDENTIALS.items():
+        monkeypatch.setenv(name, value)
+
+
+def _build(**kwargs) -> IdeGYMClient:
+    return IdeGYMClient(orchestrator_url="idegym.test", name="c", namespace="idegym", **kwargs)
+
+
+def test_a_supplied_transport_is_the_one_used() -> None:
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, json={}))
+
+    client = _build(transport=transport)
+
+    assert client._http_client._transport is transport
+
+
+def test_supplied_limits_reach_the_pool() -> None:
+    client = _build(limits=httpx.Limits(max_connections=7, max_keepalive_connections=3))
+
+    pool = client._http_client._transport._pool
+    assert pool._max_connections == 7
+    assert pool._max_keepalive_connections == 3
+
+
+def test_a_supplied_client_is_used_verbatim() -> None:
+    supplied = httpx.AsyncClient(base_url="http://elsewhere.test")
+
+    client = _build(http_client=supplied)
+
+    assert client._http_client is supplied
+    assert str(supplied.base_url) == "http://elsewhere.test"
+
+
+@pytest.mark.parametrize(
+    "conflicting",
+    [
+        {"transport": httpx.MockTransport(lambda request: httpx.Response(200))},
+        {"limits": httpx.Limits(max_connections=1)},
+    ],
+)
+def test_configuring_a_client_you_also_supplied_is_rejected(conflicting) -> None:
+    with pytest.raises(ValueError, match="http_client"):
+        _build(http_client=httpx.AsyncClient(base_url="http://elsewhere.test"), **conflicting)
+
+
+@pytest.fixture
+def unregistered_exit(mocker):
+    """Let ``__aexit__`` run without a registration behind it."""
+    mocker.patch.object(IdeGYMClient, "_stop_client", mocker.AsyncMock())
+
+
+async def test_a_client_idegym_built_is_closed_on_exit(unregistered_exit) -> None:
+    client = _build()
+
+    await client.__aexit__(None, None, None)
+
+    assert client._http_client.is_closed
+
+
+async def test_a_supplied_client_survives_exit(unregistered_exit) -> None:
+    supplied = httpx.AsyncClient(base_url="http://idegym.test")
+    client = _build(http_client=supplied)
+
+    await client.__aexit__(None, None, None)
+
+    assert not supplied.is_closed
+    await supplied.aclose()

--- a/unit-tests/test_shared_client.py
+++ b/unit-tests/test_shared_client.py
@@ -1,0 +1,180 @@
+"""The loop-owning facade.
+
+The properties that matter are all about loops and threads, so these tests drive it from
+several of each rather than mocking the concurrency away. The underlying ``IdeGYMClient`` is
+stubbed: what is under test is the marshalling, not the HTTP.
+"""
+
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from idegym.client import shared as shared_module
+from idegym.client.shared import SharedIdeGYMClient, _LoopThread
+
+
+class _FakeClient:
+    """Records the loop and thread each call ran on."""
+
+    instances: list["_FakeClient"] = []
+
+    def __init__(self, **arguments):
+        self.arguments = arguments
+        self.entered = False
+        self.exited_with = None
+        self.creation_thread = threading.current_thread().name
+        _FakeClient.instances.append(self)
+
+    async def __aenter__(self):
+        self.entered = True
+        return self
+
+    async def __aexit__(self, exception_type, exception, traceback):
+        self.exited_with = (exception_type, exception, traceback)
+        return False
+
+    async def where_am_i(self) -> tuple[int, str]:
+        await asyncio.sleep(0)
+        return id(asyncio.get_running_loop()), threading.current_thread().name
+
+    async def boom(self):
+        raise ValueError("from inside the loop")
+
+
+@pytest.fixture(autouse=True)
+def fake_client(mocker):
+    _FakeClient.instances.clear()
+    mocker.patch.object(shared_module, "IdeGYMClient", _FakeClient)
+    return _FakeClient
+
+
+def _shared() -> SharedIdeGYMClient:
+    return SharedIdeGYMClient(orchestrator_url="idegym.test", name="c", namespace="idegym")
+
+
+# --------------------------------------------------------------------------------------
+# Lifecycle
+# --------------------------------------------------------------------------------------
+
+
+def test_entering_constructs_and_registers_on_the_owned_loop(fake_client) -> None:
+    with _shared() as handle:
+        assert handle.client.entered is True
+        assert handle.client.creation_thread.startswith("idegym-client-loop")
+        assert handle.client.arguments["name"] == "c"
+
+
+def test_exiting_deregisters_and_stops_the_loop() -> None:
+    handle = _shared()
+    with handle:
+        client = handle.client
+        loop = handle._loop
+
+    assert client.exited_with == (None, None, None)
+    assert loop._loop.is_closed()
+
+
+def test_an_exception_in_the_body_reaches_the_client_teardown() -> None:
+    handle = _shared()
+    with pytest.raises(ValueError, match="body failed"), handle:
+        client = handle.client
+        raise ValueError("body failed")
+
+    assert client.exited_with[0] is ValueError
+
+
+def test_a_failed_registration_does_not_leak_the_loop_thread(mocker) -> None:
+    mocker.patch.object(_FakeClient, "__aenter__", side_effect=RuntimeError("registration refused"))
+    before = {thread.name for thread in threading.enumerate()}
+
+    with pytest.raises(RuntimeError, match="registration refused"), _shared():
+        pass
+
+    assert not {name for name in {t.name for t in threading.enumerate()} - before if "idegym-client-loop" in name}
+
+
+def test_using_the_handle_before_entering_is_an_error() -> None:
+    handle = _shared()
+
+    with pytest.raises(RuntimeError, match="not started"):
+        _ = handle.client
+    with pytest.raises(RuntimeError, match="not started"):
+        handle.run(lambda client: client.where_am_i())
+
+
+# --------------------------------------------------------------------------------------
+# Marshalling
+# --------------------------------------------------------------------------------------
+
+
+def test_calls_run_on_the_owned_loop_not_the_callers_thread() -> None:
+    with _shared() as handle:
+        _loop_id, thread_name = handle.run(lambda client: client.where_am_i())
+
+    assert thread_name.startswith("idegym-client-loop")
+    assert thread_name != threading.current_thread().name
+
+
+def test_an_exception_inside_the_loop_surfaces_to_the_caller() -> None:
+    with _shared() as handle, pytest.raises(ValueError, match="from inside the loop"):
+        handle.run(lambda client: client.boom())
+
+
+def test_many_threads_share_one_registration() -> None:
+    with _shared() as handle, ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(lambda _: handle.run(lambda client: client.where_am_i()), range(32)))
+
+    assert len({loop_id for loop_id, _ in results}) == 1
+    assert len(_FakeClient.instances) == 1
+
+
+def test_a_caller_running_its_own_loop_can_still_use_the_handle() -> None:
+    """One loop per sandbox is the shape that could not share a registration before."""
+    with _shared() as handle:
+        owned_loop_id, _ = handle.run(lambda client: client.where_am_i())
+
+        async def from_another_loop():
+            return await asyncio.to_thread(handle.run, lambda client: client.where_am_i())
+
+        seen_from_other_loop, _ = asyncio.run(from_another_loop())
+
+    assert seen_from_other_loop == owned_loop_id
+
+
+def test_submit_returns_before_the_call_completes() -> None:
+    with _shared() as handle:
+        future = handle.submit(lambda client: client.where_am_i())
+
+        assert future.result(timeout=5)[1].startswith("idegym-client-loop")
+
+
+# --------------------------------------------------------------------------------------
+# The loop thread itself
+# --------------------------------------------------------------------------------------
+
+
+def test_loop_thread_creates_the_awaitable_on_its_own_loop() -> None:
+    loop_thread = _LoopThread(name="idegym-client-loop-test")
+    captured = {}
+
+    async def record():
+        captured["loop"] = id(asyncio.get_running_loop())
+
+    def factory():
+        captured["factory_loop_running"] = _running_loop_id()
+        return record()
+
+    try:
+        loop_thread.submit(factory).result(timeout=5)
+    finally:
+        loop_thread.close()
+
+    assert captured["factory_loop_running"] == captured["loop"]
+
+
+def _running_loop_id():
+    try:
+        return id(asyncio.get_running_loop())
+    except RuntimeError:
+        return None

--- a/unit-tests/test_shared_client.py
+++ b/unit-tests/test_shared_client.py
@@ -154,6 +154,38 @@ def test_submit_returns_before_the_call_completes() -> None:
 # --------------------------------------------------------------------------------------
 
 
+def test_exit_leaves_no_pending_task_behind(recwarn) -> None:
+    """`__aexit__` cancels the heartbeat without awaiting it; the loop must deliver that."""
+    leftover = {}
+
+    class _ClientWithHeartbeat(_FakeClient):
+        async def __aenter__(self):
+            async def heartbeat():
+                while True:
+                    await asyncio.sleep(3600)
+
+            leftover["task"] = asyncio.get_running_loop().create_task(heartbeat())
+            self.entered = True
+            return self
+
+        async def __aexit__(self, *exc):
+            leftover["task"].cancel()  # cancelled, deliberately not awaited
+            return False
+
+    handle = SharedIdeGYMClient(orchestrator_url="idegym.test", name="c", namespace="idegym")
+    import idegym.client.shared as module
+
+    original, module.IdeGYMClient = module.IdeGYMClient, _ClientWithHeartbeat
+    try:
+        with handle:
+            pass
+    finally:
+        module.IdeGYMClient = original
+
+    # The drain gives the cancellation a chance to land, so the task is finished, not abandoned.
+    assert leftover["task"].done()
+
+
 def test_loop_thread_creates_the_awaitable_on_its_own_loop() -> None:
     loop_thread = _LoopThread(name="idegym-client-loop-test")
     captured = {}

--- a/website/docs/architecture/client.md
+++ b/website/docs/architecture/client.md
@@ -67,9 +67,16 @@ async with IdeGYMClient(
 ```
 
 Key methods: `with_server(...)` (start + auto-cleanup), explicit `start_server` /
-`stop_server` / `finish_server`, `jobs.build_and_push_images(...)`, and `health_check()`.
-The `reuse_strategy` (`NONE` / `RESTART` / `RESET`) and `close_action` (`FINISH` / `STOP`)
-control reuse — central to fast RL episodes.
+`stop_server` / `finish_server`, `list_servers()` (what this registration owns),
+`jobs.build_and_push_images(...)`, and `health_check()`. The `reuse_strategy`
+(`NONE` / `RESTART` / `RESET`) and `close_action` (`FINISH` / `STOP`) control reuse — central
+to fast RL episodes.
+
+The client is **bound to the loop that created it**: it owns an `httpx` session and a heartbeat
+task. Since deregistering terminates every server a client owns, an integration that drives
+sandboxes from several loops has to share one registration rather than open two — which is what
+`SharedIdeGYMClient` is for. It owns a loop in a dedicated thread and marshals calls onto it.
+See the [client reference](/reference/client).
 
 ## `IdeGYMServer`
 

--- a/website/docs/reference/client.md
+++ b/website/docs/reference/client.md
@@ -247,6 +247,47 @@ print(response.status)  # → "healthy"
 
 ---
 
+## Threads and event loops
+
+`IdeGYMClient` is **bound to the event loop that created it**. It owns an `httpx` session and a
+heartbeat task, so every call has to be awaited on that same loop. One asyncio program with one
+loop needs to know nothing more than this.
+
+It matters when a caller drives sandboxes from several loops — a synchronous facade with one
+loop per sandbox, for instance. Sharing one registration across them is not optional
+bookkeeping: **deregistering a client terminates every server it owns**, so two registrations in
+one process means either can tear down the other's sandboxes.
+
+`SharedIdeGYMClient` owns a loop in a dedicated thread and marshals every call onto it, so any
+thread — including one already running its own loop — can share the single registration:
+
+```python
+from idegym.client import SharedIdeGYMClient
+
+with SharedIdeGYMClient(
+    orchestrator_url="https://idegym.yourdomain.com",
+    name="my-training-run",
+    namespace="idegym",
+) as shared:
+    server = shared.run(lambda client: client.start_server(image_tag="registry.example.com/env:latest"))
+    result = shared.run(lambda _: server.execute_bash("echo hi"))
+    shared.run(lambda client: client.stop_server(server))
+```
+
+It takes the same arguments as `IdeGYMClient` and registers on entry, exactly as
+`async with IdeGYMClient(...)` would.
+
+| Method | Description |
+|--------|-------------|
+| `run(call, timeout=None)` | Run `call(client)` on the owned loop and return its result |
+| `submit(call)` | Schedule `call(client)` and return a `concurrent.futures.Future` |
+| `client` | The underlying `IdeGYMClient`; only touch it from inside a `call` |
+
+`call` takes the client and returns an awaitable, rather than being an awaitable itself, so the
+awaitable is created on the owning loop — nothing ever binds to the caller's.
+
+---
+
 ## `IdeGYMServer`
 
 Returned by `client.with_server()` or `client.start_server()`. Provides all operations on a running

--- a/website/docs/reference/client.md
+++ b/website/docs/reference/client.md
@@ -132,6 +132,19 @@ await client.finish_server(server)  # release without stopping
 await client.stop_server(server)    # stop and delete
 ```
 
+`stop_server` and `restart_server` **raise** when the operation fails, like the rest of the
+API — they do not report failure as a return value. There is no return value to check, so a
+failed delete cannot be mistaken for a successful one and leak the pod:
+
+```python
+from idegym.client import IdeGYMHTTPError
+
+try:
+    await client.stop_server(server)
+except IdeGYMHTTPError as e:
+    ...  # the pod may still be running; the server is not stopped
+```
+
 #### Server reuse
 
 Reuse is attempted only for `RESTART` and `RESET`. A candidate is taken over only if **all** of

--- a/website/docs/reference/client.md
+++ b/website/docs/reference/client.md
@@ -82,7 +82,7 @@ IdeGYMClient(
 | `request_timeout_in_seconds` | Default HTTP request timeout (default: `60`) |
 | `otel_config` | OpenTelemetry tracing configuration |
 | `transport` | Transport for the HTTP client IdeGYM builds — an alternative HTTP stack, a proxy, or a recording transport in tests |
-| `limits` | Connection-pool limits for the HTTP client IdeGYM builds |
+| `limits` | Connection-pool limits for the HTTP client IdeGYM builds; omit for httpx's defaults (100 connections, 20 keep-alive) |
 | `http_client` | A fully configured `httpx.AsyncClient` to use verbatim |
 
 **Configuring the HTTP stack:**

--- a/website/docs/reference/client.md
+++ b/website/docs/reference/client.md
@@ -64,6 +64,9 @@ IdeGYMClient(
     heartbeat_interval_in_seconds: int = 60,
     request_timeout_in_seconds: int = 60,
     otel_config: Optional[OTELConfig] = None,
+    transport: Optional[httpx.AsyncBaseTransport] = None,
+    limits: Optional[httpx.Limits] = None,
+    http_client: Optional[httpx.AsyncClient] = None,
 )
 ```
 
@@ -78,6 +81,29 @@ IdeGYMClient(
 | `heartbeat_interval_in_seconds` | How often to send liveness heartbeats to the orchestrator (default: `60`) |
 | `request_timeout_in_seconds` | Default HTTP request timeout (default: `60`) |
 | `otel_config` | OpenTelemetry tracing configuration |
+| `transport` | Transport for the HTTP client IdeGYM builds — an alternative HTTP stack, a proxy, or a recording transport in tests |
+| `limits` | Connection-pool limits for the HTTP client IdeGYM builds |
+| `http_client` | A fully configured `httpx.AsyncClient` to use verbatim |
+
+**Configuring the HTTP stack:**
+
+```python
+import httpx
+
+client = IdeGYMClient(
+    orchestrator_url="https://idegym.yourdomain.com",
+    name="my-training-run",
+    namespace="idegym",
+    limits=httpx.Limits(max_connections=64, max_keepalive_connections=16),
+    transport=my_transport,
+)
+```
+
+`http_client` is the full escape hatch. It is used exactly as given — nothing about it is
+modified, so it must already carry `base_url` and any authentication — and it is **not** closed
+when the `IdeGYMClient` context exits, because it belongs to its caller. A client IdeGYM builds
+itself is closed on exit as before. Passing `http_client` together with `transport` or `limits`
+raises `ValueError` rather than ignoring them.
 
 **Authentication via environment variables:**
 


### PR DESCRIPTION
**Stack 6/8** — #289 ← #290 ← #291 ← #292 ← #293 ← **#294** ← #295 ← #296 (merge in order, oldest first).
Base: `…-05-…`. Branch: `vladimir.poliakov/jbres-10676-06-…`.

Improvements #12, #13 and #14 of JBRes-10676 — the Medium SDK items. Sits above stack #3 because `stop_server` raises the typed exceptions introduced there.

## What changed

**Stopping a server raises on failure** (#12). A failed delete came back as an `ErrorResponse` *return value*, unlike the rest of the API, so a caller who did not check recorded a live pod as stopped and leaked it. Both methods already declared `-> ServerActionResponse` while able to return `ErrorResponse`, so the type was a lie either way. `snapshot_server` is untouched — its signature declares the union honestly.

**The HTTP client can be supplied or configured** (#13). An integration needing a different HTTP stack or bounded pooling had to reach into `client._http_client._transport` after construction. `transport` and `limits` configure the client IdeGYM builds; `http_client` is the escape hatch, used verbatim and **not closed on exit** because it belongs to its caller. Combining them raises rather than silently ignoring.

**A loop-owning facade** (#14). `IdeGYMClient` is bound to the loop that created it, so a caller driving sandboxes from several loops cannot share one registration. That matters beyond convenience: deregistering terminates every server a client owns, so two registrations in one process means either can tear down the other's sandboxes. `SharedIdeGYMClient` owns a loop in a dedicated thread and marshals calls onto it — roughly the 150 lines each such integration writes for itself.

## How to verify

```
uv run pytest -m unit unit-tests/test_client_exceptions.py \
  unit-tests/test_client_http_configuration.py unit-tests/test_shared_client.py
```

- The stop/restart tests guard a regression that is silent by construction — the old code *returned* the failure, so a happy-path-only test would pass while a pod leaked.
- The facade tests use a real thread pool and a second event loop: 32 calls from 8 threads share one registration, and a caller already running its own loop reaches the same one.
- Ownership is pinned both ways: a built client is closed on exit, a supplied one is not.

Full suite: **1297 passed, 2 skipped**; docs site builds.

Resolves: JBRes-10676 (partially — #12, #13, #14)
