### PR TITLE
[JBRes-10676] Per-server labels and annotations (stack 7/8)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,7 +214,9 @@ Then ask: does the new field change what a *reused* or *restored* server looks l
 it belongs in `_HASH_FIELDS`
 (`orchestrator/src/idegym/orchestrator/snapshot_pipeline.py`); if it is purely runtime, it
 deliberately stays out. Getting this wrong means either a snapshot that is silently reused
-with the wrong configuration, or one that never matches and is rebuilt every time.
+with the wrong configuration, or one that never matches and is rebuilt every time. Metadata
+that describes *who asked* rather than *what is in* the environment — `labels`, `annotations` —
+stays out: a per-job value in the hash makes every snapshot a miss.
 
 A frozen payload string in `unit-tests/test_orchestrator_mcp.py` serialises a whole request
 model, so adding a field to `BashCommandRequest` or `StartServerRequest` fails that test until
@@ -274,6 +276,15 @@ Plugins are discovered through entry points, not imports. See
   read via `plugin_asset()`, never a path relative to `__file__`.
 - The keys returned by `get_context_files()` must match the `COPY` paths in the plugin's
   Dockerfile template; a unit test enforces this.
+
+### Kubernetes object metadata on a server
+
+`StartServerRequest.labels` and `.annotations` are merged *underneath* the labels IdeGYM sets
+itself, so a managed key always wins, and the request model rejects any attempt to set one
+(`MANAGED_LABEL_KEYS` / `MANAGED_LABEL_PREFIXES` in `api/src/idegym/api/orchestrator/servers.py`).
+Adding a new managed label means adding it there too — otherwise a caller can take over a key
+the Service selector, the PodDisruptionBudget, or the watcher's pod queries match on, and detach
+their own sandbox from the machinery that manages it.
 
 ### Anything that changes a built image
 

--- a/api/src/idegym/api/orchestrator/servers.py
+++ b/api/src/idegym/api/orchestrator/servers.py
@@ -9,8 +9,19 @@ from idegym.api.pod_spec import (
     KubernetesVolumeMount,
 )
 from idegym.api.resources import KubernetesResources
-from idegym.api.type import KubernetesNodeSelector, KubernetesObjectName, OCIImageName
-from pydantic import BaseModel, Field
+from idegym.api.type import (
+    KubernetesAnnotations,
+    KubernetesLabels,
+    KubernetesNodeSelector,
+    KubernetesObjectName,
+    OCIImageName,
+)
+from pydantic import BaseModel, Field, field_validator
+
+# Labels IdeGYM sets itself: the Service selector, the PodDisruptionBudget and the watcher's
+# pod queries all match on these, so a caller must not be able to take them over.
+MANAGED_LABEL_KEYS = frozenset({"app"})
+MANAGED_LABEL_PREFIXES = ("app.kubernetes.io/", "idegym.jetbrains.com/")
 
 
 class ServerReuseStrategy(StrEnum):
@@ -94,6 +105,25 @@ class StartServerRequest(BaseModel):
         description="Kubernetes node selector labels for scheduling the server pod",
         examples=[{"kubernetes.io/os": "linux"}],
     )
+    labels: KubernetesLabels = Field(
+        default_factory=dict,
+        description=(
+            "Extra labels applied to the server's Deployment, Pod, Service and PodDisruptionBudget, "
+            "so a sandbox can be found with 'kubectl get pods -l ...' and grouped for cost "
+            "attribution. Keys IdeGYM manages ('app', 'app.kubernetes.io/*', 'idegym.jetbrains.com/*') "
+            "are rejected rather than silently ignored, since overwriting them would break the "
+            "selectors that address the pod."
+        ),
+        examples=[{"team": "research", "job": "swe-bench-run-42"}],
+    )
+    annotations: KubernetesAnnotations = Field(
+        default_factory=dict,
+        description=(
+            "Extra annotations applied to the server pod. Use for metadata too long or too "
+            "unstructured to be a label, such as a task URL or a serialized request id."
+        ),
+        examples=[{"idegym.example.com/task-url": "https://tracker.example.com/TASK-1"}],
+    )
     volumes: list[KubernetesVolume] = Field(
         default_factory=list,
         description="Pod-level volumes (native Kubernetes shape), mounted into the server container via 'volume_mounts'",
@@ -169,6 +199,20 @@ class StartServerRequest(BaseModel):
         ),
         examples=[0, 3],
     )
+
+    @field_validator("labels")
+    @classmethod
+    def _reject_managed_label_keys(cls, labels: KubernetesLabels) -> KubernetesLabels:
+        """Refuse to accept a label IdeGYM owns rather than accepting and then overwriting it.
+
+        The managed labels are what the Service selector, the PodDisruptionBudget and the
+        watcher's pod queries match on, so a caller who overwrote one would detach their own
+        sandbox from the machinery that manages it.
+        """
+        reserved = sorted(key for key in labels if key in MANAGED_LABEL_KEYS or key.startswith(MANAGED_LABEL_PREFIXES))
+        if reserved:
+            raise ValueError(f"labels may not set IdeGYM-managed keys: {', '.join(reserved)}")
+        return labels
 
 
 class ServerScopedRequest(BaseModel):

--- a/api/src/idegym/api/type.py
+++ b/api/src/idegym/api/type.py
@@ -59,7 +59,12 @@ KubernetesLabelValue = Annotated[
 ]
 
 
+# An annotation key follows the label-key syntax; the value is arbitrary and may be long.
+KubernetesAnnotationKey: TypeAlias = KubernetesLabelKey
+
 KubernetesNodeSelector: TypeAlias = dict[KubernetesLabelKey, KubernetesLabelValue]
+KubernetesLabels: TypeAlias = dict[KubernetesLabelKey, KubernetesLabelValue]
+KubernetesAnnotations: TypeAlias = dict[KubernetesAnnotationKey, str]
 AuthType: TypeAlias = Literal["Basic", "Bearer", "Token"]
 Duration: TypeAlias = timedelta
 LogLevel: TypeAlias = int

--- a/backend-utils/src/idegym/backend/utils/kubernetes_client.py
+++ b/backend-utils/src/idegym/backend/utils/kubernetes_client.py
@@ -269,6 +269,8 @@ async def deploy_server(
     server_kind: ServerKind = ServerKind.IDEGYM,
     snapshot_id: Optional[str] = None,
     snapshot_tag: Optional[str] = None,
+    extra_labels: Optional[dict[str, str]] = None,
+    extra_annotations: Optional[dict[str, str]] = None,
 ):
     """
     Create a Kubernetes Deployment, Service, and PodDisruptionBudget for a server.
@@ -327,7 +329,10 @@ async def deploy_server(
     )
 
     image_pull_secret = V1LocalObjectReference(name="regcred")
+    # Caller metadata goes on first so a managed key always wins: the selectors that address the
+    # pod are built from the managed labels, and prometheus scraping from the managed annotations.
     annotations = {
+        **(extra_annotations or {}),
         "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
         **prometheus_annotations,
     }
@@ -341,6 +346,7 @@ async def deploy_server(
         "app.kubernetes.io/part-of": "idegym",
     }
     labels = {
+        **(extra_labels or {}),
         **match_labels,
         "app.kubernetes.io/version": __version__,
         "idegym.jetbrains.com/snapshot-id": snapshot_id or server_name,

--- a/client/src/idegym/client/client.py
+++ b/client/src/idegym/client/client.py
@@ -37,7 +37,13 @@ from idegym.api.pod_spec import (
     KubernetesVolumeMount,
 )
 from idegym.api.resources import KubernetesResources
-from idegym.api.type import KubernetesNodeSelector, KubernetesObjectName, OCIImageName
+from idegym.api.type import (
+    KubernetesAnnotations,
+    KubernetesLabels,
+    KubernetesNodeSelector,
+    KubernetesObjectName,
+    OCIImageName,
+)
 from idegym.client.exceptions import http_error
 from idegym.client.operations.clients import ClientOperations
 from idegym.client.operations.forwarding import ForwardingOperations
@@ -306,6 +312,8 @@ class IdeGYMClient:
         server_kind: ServerKind = ServerKind.IDEGYM,
         snapshot: Optional[SnapshotRef] = None,
         max_restarts: int = 0,
+        labels: Optional[KubernetesLabels] = None,
+        annotations: Optional[KubernetesAnnotations] = None,
     ):
         """
         Async context manager that starts a server and yields an :class:`IdeGYMServer` handle.
@@ -336,6 +344,8 @@ class IdeGYMClient:
             server_kind=server_kind,
             snapshot=snapshot,
             max_restarts=max_restarts,
+            labels=labels,
+            annotations=annotations,
         )
 
         try:
@@ -398,6 +408,8 @@ class IdeGYMClient:
         server_kind: ServerKind = ServerKind.IDEGYM,
         snapshot: Optional[SnapshotRef] = None,
         max_restarts: int = 0,
+        labels: Optional[KubernetesLabels] = None,
+        annotations: Optional[KubernetesAnnotations] = None,
     ) -> IdeGYMServer:
         """
         Start an IdeGYM server and return an :class:`IdeGYMServer` handle.
@@ -430,6 +442,8 @@ class IdeGYMClient:
             server_kind=server_kind,
             snapshot=snapshot,
             max_restarts=max_restarts,
+            labels=labels,
+            annotations=annotations,
         )
 
         if isinstance(server_response, ErrorResponse):

--- a/client/src/idegym/client/operations/servers.py
+++ b/client/src/idegym/client/operations/servers.py
@@ -38,7 +38,13 @@ from idegym.api.pod_spec import (
 )
 from idegym.api.resources import KubernetesResources
 from idegym.api.status import Status
-from idegym.api.type import KubernetesNodeSelector, KubernetesObjectName, OCIImageName
+from idegym.api.type import (
+    KubernetesAnnotations,
+    KubernetesLabels,
+    KubernetesNodeSelector,
+    KubernetesObjectName,
+    OCIImageName,
+)
 from idegym.client.exceptions import raise_for_error_response
 from idegym.client.operations.project import ProjectOperations
 from idegym.client.operations.utils import HTTPUtils, PollingConfig
@@ -76,6 +82,8 @@ class ServerOperations:
         server_kind: ServerKind = ServerKind.IDEGYM,
         snapshot: Optional[SnapshotRef] = None,
         max_restarts: int = 0,
+        labels: Optional[KubernetesLabels] = None,
+        annotations: Optional[KubernetesAnnotations] = None,
     ) -> StartServerResponse | ErrorResponse:
         client_id = self._utils.validate_client_id(client_id)
         namespace = self._utils.validate_namespace(namespace)
@@ -111,6 +119,8 @@ class ServerOperations:
                 server_kind=server_kind,
                 snapshot=snapshot,
                 max_restarts=max_restarts,
+                labels=labels or {},
+                annotations=annotations or {},
             )
             response_raw = await self._utils.make_request(
                 "POST", "/api/idegym-servers", request, request_timeout=remaining_time

--- a/e2e-tests/test_pod_spec_overrides.py
+++ b/e2e-tests/test_pod_spec_overrides.py
@@ -105,3 +105,42 @@ async def test_pod_overrides_host_aliases(test_image, test_id):
         assert result.exit_code == 0, result.stderr
         assert "10.123.45.67" in result.stdout
         assert "agent.internal.test" in result.stdout
+
+
+@pytest.mark.asyncio
+async def test_labels_and_annotations_reach_the_pod(test_id, test_image):
+    """A sandbox can be tagged with the job that created it and found by label selector."""
+    job_label = f"e2e-job-{test_id}"
+    async with (
+        create_http_client(name=f"labels-{test_id}", nodes_count=0) as client,
+        client.with_server(
+            image_tag=test_image,
+            server_name=f"labels-{test_id}",
+            runtime_class_name="gvisor",
+            server_start_wait_timeout_in_seconds=DEFAULT_SERVER_START_TIMEOUT,
+            labels={"idegym-e2e-job": job_label, "team": "research"},
+            annotations={"idegym.example.com/task-url": "https://tracker.example.test/TASK-1"},
+        ),
+    ):
+        # The whole point of a label: finding the sandbox without knowing its generated name.
+        pods = k8s_client.list_pods(namespace=DEFAULT_NAMESPACE, label_selector=f"idegym-e2e-job={job_label}")
+        assert len(pods) == 1
+
+        pod = pods[0]
+        assert pod.metadata.labels["team"] == "research"
+        assert pod.metadata.annotations["idegym.example.com/task-url"] == "https://tracker.example.test/TASK-1"
+        # Managed labels are untouched, so the platform still addresses the pod.
+        assert pod.metadata.labels["app.kubernetes.io/part-of"] == "idegym"
+
+
+@pytest.mark.asyncio
+async def test_a_managed_label_is_rejected_before_anything_is_created(test_id, test_image):
+    async with create_http_client(name=f"labels-reject-{test_id}", nodes_count=0) as client:
+        with pytest.raises(Exception, match="IdeGYM-managed keys"):
+            await client.start_server(
+                image_tag=test_image,
+                server_name=f"labels-reject-{test_id}",
+                runtime_class_name="gvisor",
+                server_start_wait_timeout_in_seconds=DEFAULT_SERVER_START_TIMEOUT,
+                labels={"app": "hijacked"},
+            )

--- a/orchestrator/src/idegym/orchestrator/router/server.py
+++ b/orchestrator/src/idegym/orchestrator/router/server.py
@@ -484,6 +484,8 @@ async def _task_start_server(
                 server_kind=request.server_kind,
                 snapshot_id=request.snapshot.id if request.snapshot else None,
                 snapshot_tag=request.snapshot.tag if request.snapshot else None,
+                extra_labels=request.labels,
+                extra_annotations=request.annotations,
             )
 
             await wait_for_pods_ready(

--- a/unit-tests/test_server_labels.py
+++ b/unit-tests/test_server_labels.py
@@ -1,0 +1,175 @@
+"""Caller-supplied labels and annotations on a server.
+
+Two things have to hold: the metadata actually lands on every object an operator would query,
+and it can never displace the managed keys the platform addresses the pod by.
+"""
+
+from uuid import uuid4
+
+import pytest
+from idegym.api.orchestrator.servers import StartServerRequest
+from idegym.backend.utils import kubernetes_client as kc
+from kubernetes_asyncio.client import ApiClient
+from pydantic import ValidationError
+
+
+@pytest.fixture
+async def api_client():
+    client = ApiClient()
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+def _patch_clients(mocker, api_client):
+    deployment_result = mocker.MagicMock()
+    deployment_result.api_version = "apps/v1"
+    deployment_result.kind = "Deployment"
+    deployment_result.metadata.name = "srv"
+    deployment_result.metadata.uid = "uid-123"
+
+    apps = mocker.MagicMock()
+    apps.api_client = api_client
+    apps.create_namespaced_deployment = mocker.AsyncMock(return_value=deployment_result)
+    core = mocker.MagicMock()
+    core.create_namespaced_service = mocker.AsyncMock()
+    policy = mocker.MagicMock()
+    policy.create_namespaced_pod_disruption_budget = mocker.AsyncMock()
+
+    clients = (apps, mocker.MagicMock(), core, policy, mocker.MagicMock())
+    mocker.patch.object(kc, "create_clients", mocker.AsyncMock(return_value=clients))
+    return apps, core, policy
+
+
+async def _deploy(mocker, api_client, **kwargs):
+    apps, core, policy = _patch_clients(mocker, api_client)
+    await kc.deploy_server(image_tag="img:latest", server_name="srv", namespace="ns", **kwargs)
+    return {
+        "deployment": apps.create_namespaced_deployment.call_args.kwargs["body"],
+        "service": core.create_namespaced_service.call_args.kwargs["body"],
+        "pdb": policy.create_namespaced_pod_disruption_budget.call_args.kwargs["body"],
+    }
+
+
+# --------------------------------------------------------------------------------------
+# What lands in the cluster
+# --------------------------------------------------------------------------------------
+
+
+async def test_extra_labels_land_on_every_object_an_operator_queries(mocker, api_client) -> None:
+    objects = await _deploy(mocker, api_client, extra_labels={"team": "research", "job": "run-42"})
+
+    for name in ("deployment", "service", "pdb"):
+        labels = objects[name].metadata.labels
+        assert labels["team"] == "research", name
+        assert labels["job"] == "run-42", name
+    assert objects["deployment"].spec.template.metadata.labels["team"] == "research"
+
+
+async def test_extra_annotations_land_on_the_pod(mocker, api_client) -> None:
+    objects = await _deploy(mocker, api_client, extra_annotations={"example.com/task": "TASK-1"})
+
+    annotations = objects["deployment"].spec.template.metadata.annotations
+    assert annotations["example.com/task"] == "TASK-1"
+
+
+async def test_managed_labels_survive_a_collision(mocker, api_client) -> None:
+    """The API rejects these, but the deploy layer must not depend on that to stay correct."""
+    objects = await _deploy(
+        mocker,
+        api_client,
+        extra_labels={"app": "hijacked", "app.kubernetes.io/part-of": "somebody-else"},
+    )
+
+    labels = objects["deployment"].metadata.labels
+    assert labels["app"] == "srv"
+    assert labels["app.kubernetes.io/part-of"] == "idegym"
+
+
+async def test_managed_annotations_survive_a_collision(mocker, api_client) -> None:
+    objects = await _deploy(
+        mocker,
+        api_client,
+        extra_annotations={"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
+    )
+
+    annotations = objects["deployment"].spec.template.metadata.annotations
+    assert annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"] == "false"
+
+
+async def test_the_selector_never_picks_up_caller_labels(mocker, api_client) -> None:
+    """A selector that grew a caller label would stop matching pods started without it."""
+    objects = await _deploy(mocker, api_client, extra_labels={"team": "research"})
+
+    assert "team" not in objects["deployment"].spec.selector.match_labels
+    assert "team" not in objects["service"].spec.selector
+    assert "team" not in objects["pdb"].spec.selector.match_labels
+
+
+async def test_no_extra_metadata_leaves_the_objects_as_before(mocker, api_client) -> None:
+    objects = await _deploy(mocker, api_client)
+
+    assert set(objects["deployment"].metadata.labels) == {
+        "app",
+        "app.kubernetes.io/component",
+        "app.kubernetes.io/name",
+        "app.kubernetes.io/part-of",
+        "app.kubernetes.io/version",
+        "idegym.jetbrains.com/snapshot-id",
+    }
+
+
+# --------------------------------------------------------------------------------------
+# What the request model accepts
+# --------------------------------------------------------------------------------------
+
+
+def _request(**kwargs) -> StartServerRequest:
+    return StartServerRequest(client_id=uuid4(), image_tag="registry.test/env:latest", **kwargs)
+
+
+def test_labels_and_annotations_default_to_empty() -> None:
+    request = _request()
+
+    assert (request.labels, request.annotations) == ({}, {})
+
+
+@pytest.mark.parametrize(
+    "reserved",
+    ["app", "app.kubernetes.io/name", "app.kubernetes.io/anything", "idegym.jetbrains.com/snapshot-id"],
+)
+def test_a_managed_label_key_is_rejected(reserved) -> None:
+    with pytest.raises(ValidationError, match="IdeGYM-managed keys"):
+        _request(labels={reserved: "mine"})
+
+
+def test_the_error_names_every_offending_key() -> None:
+    with pytest.raises(ValidationError) as caught:
+        _request(labels={"app": "a", "app.kubernetes.io/name": "b", "team": "research"})
+
+    assert "labels may not set IdeGYM-managed keys: app, app.kubernetes.io/name" in str(caught.value)
+
+
+@pytest.mark.parametrize("key", ["appliance", "team", "example.com/job", "idegym.example.com/task"])
+def test_a_key_that_merely_resembles_a_managed_one_is_accepted(key) -> None:
+    assert _request(labels={key: "value"}).labels == {key: "value"}
+
+
+def test_an_annotation_may_use_a_managed_looking_key() -> None:
+    """Annotations carry no selector weight, so the label reservation does not apply to them."""
+    assert _request(annotations={"app.kubernetes.io/notes": "long text"}).annotations
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [{"": "value"}, {"Not A Key": "value"}, {"team": "x" * 64}],
+)
+def test_labels_are_held_to_the_kubernetes_syntax(labels) -> None:
+    with pytest.raises(ValidationError):
+        _request(labels=labels)
+
+
+def test_annotation_values_are_not_length_limited_like_labels() -> None:
+    """An annotation is where metadata too long to be a label goes."""
+    assert _request(annotations={"example.com/notes": "x" * 5000}).annotations

--- a/website/docs/reference/client.md
+++ b/website/docs/reference/client.md
@@ -125,6 +125,8 @@ async with client.with_server(
     run_as_root=False,
     resources=None,  # KubernetesResources
     node_selector=None,
+    labels={"team": "research", "job": "swe-bench-run-42"},
+    annotations={"idegym.example.com/task-url": "https://tracker.example.com/TASK-1"},
     server_start_wait_timeout_in_seconds=60,
     reuse_strategy=ServerReuseStrategy.RESET,
     close_action=ServerCloseAction.FINISH,  # FINISH or STOP
@@ -140,9 +142,36 @@ async with client.with_server(
 | `run_as_root` | Run the container as root (default: `False`) |
 | `resources` | Kubernetes resource requests/limits |
 | `node_selector` | Node affinity labels |
+| `labels` | Extra labels for the server's Deployment, Pod, Service and PodDisruptionBudget |
+| `annotations` | Extra annotations for the server pod |
 | `server_start_wait_timeout_in_seconds` | How long to wait for the server pod to become ready |
 | `reuse_strategy` | Whether to take over an existing server: `NONE` (always create from scratch), `RESTART` (reuse and restart the pod), `RESET` (reuse and reset project state) — see [Server reuse](#server-reuse) |
 | `close_action` | `FINISH` — release the server but leave it running for the next client; `STOP` — stop and delete the server |
+
+#### Tagging a sandbox
+
+`labels` and `annotations` are how a sandbox gets attributed to the job, team or task that
+created it, which makes the usual operator workflows apply:
+
+```sh
+kubectl get pods -n idegym -l job=swe-bench-run-42
+```
+
+They land on the Deployment, Pod, Service and PodDisruptionBudget. Use a label for anything you
+want to select or group by, and an annotation for metadata that is too long or too unstructured
+to be one — a Kubernetes label value is capped at 63 characters.
+
+Keys IdeGYM manages are **rejected**, not silently overwritten: `app`, anything under
+`app.kubernetes.io/`, and anything under `idegym.jetbrains.com/`. Those are what the Service
+selector, the PodDisruptionBudget and the watcher's pod queries match on, so taking one over
+would detach the sandbox from the machinery that manages it. Annotations carry no selector
+weight and are not restricted.
+
+Two things they deliberately do not affect. They are not part of the snapshot hash — they
+describe who asked for a sandbox, not what is in it, and a per-job label would otherwise make
+every snapshot a miss. And they are not part of reuse matching: a server reused through
+`RESTART` or `RESET` keeps the labels it was started with, so do not rely on them to tell one
+episode from the next on a reused server.
 
 ### `start_server(...)` / `stop_server(...)` / `finish_server(...)`
 


### PR DESCRIPTION
**Stack 7/8** — #289 ← #290 ← #291 ← #292 ← #293 ← #294 ← **#295** ← #296 (merge in order, oldest first).
Base: `…-06-…`. Branch: `vladimir.poliakov/jbres-10676-07-…`.

Improvement #17 of JBRes-10676, which the ticket calls the highest ratio of operator value to effort on the list. Its own PR because it is self-contained and touches all five plumbing layers; it sits here only to avoid conflicting with the client signatures the SDK PRs below change.

## What changed

`pod_overrides` is a partial `V1PodSpec`, which cannot set object metadata, and there was no labels field — so a sandbox could not be tagged with the job, team or task that created it, and none of `kubectl get pods -l …`, cost attribution or dashboard grouping applied. The workaround was folding metadata into the server *name*, against a 63-character RFC-1035 budget.

`StartServerRequest.labels` and `.annotations` are now applied to the Deployment, Pod, Service and PodDisruptionBudget.

Two design points worth review attention:

- **Caller metadata merges underneath the managed keys**, so a managed key always wins, *and* the request model rejects any attempt to set one (`app`, `app.kubernetes.io/*`, `idegym.jetbrains.com/*`) rather than silently overwriting. Those are what the Service selector, the PDB and the watcher's pod queries match on — taking one over would detach the sandbox from the machinery that manages it. The deploy layer enforces this independently of the validator, so the platform stays correct even if a request reaches it another way.
- **Neither field enters the snapshot hash.** They describe who asked for a sandbox, not what is in it, and a per-job label would otherwise make every snapshot a miss. They are likewise not part of reuse matching, so a reused server keeps the labels it was started with — documented, not fixed.

## How to verify

```
uv run pytest -m unit unit-tests/test_server_labels.py
```

- Deploy-layer tests assert the collision behaviour and that **no caller label ever leaks into a selector** — a selector that grew one would stop matching pods started without it.
- Request-model tests separate keys IdeGYM owns from keys that merely resemble them (`appliance`, `idegym.example.com/task`).
- `e2e-tests/test_pod_spec_overrides.py` does the thing labels exist for: finds the sandbox by selector without knowing its generated name. Collected only, no cluster here.

Full suite: **1318 passed, 2 skipped**; docs site builds.

Resolves: JBRes-10676 (partially — #17)
